### PR TITLE
Use _aligned_malloc instead of posix_memalign on Windows

### DIFF
--- a/frame/base/bli_malloc.c
+++ b/frame/base/bli_malloc.c
@@ -43,6 +43,9 @@ void* bli_malloc( siz_t size )
 
 #if BLIS_HEAP_ADDR_ALIGN_SIZE == 1
 	p = malloc( ( size_t )size );
+#elif defined(_WIN32)
+	p = _aligned_malloc( ( size_t )size,
+	                     ( size_t )BLIS_HEAP_ADDR_ALIGN_SIZE );
 #else
 	r_val = posix_memalign( &p,
 	                        ( size_t )BLIS_HEAP_ADDR_ALIGN_SIZE,
@@ -58,6 +61,10 @@ void* bli_malloc( siz_t size )
 
 void bli_free( void* p )
 {
+#if BLIS_HEAP_ADDR_ALIGN_SIZE == 1 || !defined(_WIN32)
 	free( p );
+#else
+	_aligned_free( p );
+#endif
 }
 


### PR DESCRIPTION
This allows BLIS with the reference configuration to compile with MinGW (gcc 4.8.1 [from mingw-builds](http://sourceforge.net/projects/mingwbuilds/files/host-windows/releases/4.8.1/64-bit/threads-win32/seh/x64-4.8.1-release-win32-seh-rev5.7z/download), using MSYS2). The testsuite doesn't run successfully, it gets to the gemm tests then stops with an `Error 127`, see https://gist.github.com/tkelman/e1e619c2f1d2ff410068

If I manually change `BLIS_SIMD_ALIGN_SIZE` to 1 in `bli_config.h`, then a MinGW build does pass unit tests. From WinDbg, it looks like there might be an invalid use of `_aligned_free` with the default alignment of 16.
