### PR TITLE
Fix permissions error installing to non-owned directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -642,31 +642,31 @@ install-headers: check-env $(MK_INCL_DIR_INST)
 
 $(MK_INCL_DIR_INST): $(MK_HEADER_FILES) $(CONFIG_MK_FILE)
 ifeq ($(BLIS_ENABLE_VERBOSE_MAKE_OUTPUT),yes)
-	$(INSTALL) -m 0755 -d $(@)
+	$(MKDIR) $(@)
 	$(INSTALL) -m 0644 $(MK_HEADER_FILES) $(@)
 else
-	@$(INSTALL) -m 0755 -d $(@)
+	@$(MKDIR) $(@)
 	@echo "Installing C header files into $(@)/"
 	@$(INSTALL) -m 0644 $(MK_HEADER_FILES) $(@)
 endif
 
 $(INSTALL_PREFIX)/lib/%-$(VERS_CONF).a: $(BASE_LIB_PATH)/%.a $(CONFIG_MK_FILE)
 ifeq ($(BLIS_ENABLE_VERBOSE_MAKE_OUTPUT),yes)
-	$(INSTALL) -m 0755 -d $(@D)
+	$(MKDIR) $(@D)
 	$(INSTALL) -m 0644 $< $@
 else
 	@echo "Installing $(@F) into $(INSTALL_PREFIX)/lib/"
-	@$(INSTALL) -m 0755 -d $(@D)
+	@$(MKDIR) $(@D)
 	@$(INSTALL) -m 0644 $< $@
 endif
 
 $(INSTALL_PREFIX)/lib/%-$(VERS_CONF).so: $(BASE_LIB_PATH)/%.so $(CONFIG_MK_FILE)
 ifeq ($(BLIS_ENABLE_VERBOSE_MAKE_OUTPUT),yes)
-	$(INSTALL) -m 0755 -d $(@D)
+	$(MKDIR) $(@D)
 	$(INSTALL) -m 0644 $< $@
 else
 	@echo "Installing $(@F) into $(INSTALL_PREFIX)/lib/"
-	@$(INSTALL) -m 0755 -d $(@D)
+	@$(MKDIR) $(@D)
 	@$(INSTALL) -m 0644 $< $@
 endif
 


### PR DESCRIPTION
Hi BLIS Team,

Thanks for all of your work on this project, it's very impressive!  I just ran into an error installing BLIS to `/usr/local` on my system and thought it may be a use case that you'd like to support.  To that end, here's a PR to describe/address it:

When installing to a directory which is not owned by the installing user, even when the user has write permission for the directory, the installation can fail with an error similar to the following:

```
Installing libblis-0.1.4-7-sandybridge.a into /usr/local/lib/
install: cannot change permissions of ‘/usr/local/lib’: Operation not permitted
Makefile:658: recipe for target '/usr/local/lib/libblis-0.1.4-7-sandybridge.a' failed
make: *** [/usr/local/lib/libblis-0.1.4-7-sandybridge.a] Error 1
```

In the example case, the error occurred because the user attempted to install to `/usr/local` and `/usr/local/lib` is owned by root with mode 2755 which the Makefile unsuccessfully attempted to change to 0755.

Given that installing to `/usr/local` is likely to be quite common and the ownership/permissions are the default for Debian and Debian-derived Linux distributions (perhaps others as well), this commit attempts to
support that use case by using `mkdir` rather than `install` to create the directory (which is the same approach as Automake).

I hope you find it useful.

Thanks for considering,
Kevin
