### PR TITLE
#define PASTEF773 required by cblas compatiility layer

### DIFF
--- a/config/armv7a/bli_config.h
+++ b/config/armv7a/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/bgq/bli_config.h
+++ b/config/bgq/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -161,6 +161,7 @@
 #define PASTEF770(name)                        name //## _
 #define PASTEF77(ch1,name)       ch1        ## name //## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name //## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -178,4 +179,3 @@
 
 
 #endif
-

--- a/config/bulldozer/bli_config.h
+++ b/config/bulldozer/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/cortex-a15/bli_config.h
+++ b/config/cortex-a15/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/cortex-a9/bli_config.h
+++ b/config/cortex-a9/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/dunnington/bli_config.h
+++ b/config/dunnington/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/emscripten/bli_config.h
+++ b/config/emscripten/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/loongson3a/bli_config.h
+++ b/config/loongson3a/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/mic/bli_config.h
+++ b/config/mic/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -164,6 +164,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -181,4 +182,3 @@
 
 
 #endif
-

--- a/config/piledriver/bli_config.h
+++ b/config/piledriver/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/pnacl/bli_config.h
+++ b/config/pnacl/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/power7/bli_config.h
+++ b/config/power7/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -155,6 +155,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -172,4 +173,3 @@
 
 
 #endif
-

--- a/config/sandybridge/bli_config.h
+++ b/config/sandybridge/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-

--- a/config/template/bli_config.h
+++ b/config/template/bli_config.h
@@ -1,6 +1,6 @@
 /*
 
-   BLIS    
+   BLIS
    An object-based framework for developing high-performance BLAS-like
    libraries.
 
@@ -157,6 +157,7 @@
 #define PASTEF770(name)                        name ## _
 #define PASTEF77(ch1,name)       ch1        ## name ## _
 #define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
 
 
 
@@ -174,4 +175,3 @@
 
 
 #endif
-


### PR DESCRIPTION
I noticed compile time error when I was trying to build blis for piledriver with cblas compatibility layer enabled. It seems PASTEF773 was not defined anywhere but in /config/reference/blis_config.h. So I went ahead and defined it for every other architecture.
