### PR TITLE
Adding armv8a configuration and micro-kernels.

### DIFF
--- a/config/armv8a/bli_config.h
+++ b/config/armv8a/bli_config.h
@@ -1,0 +1,177 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name of The University of Texas at Austin nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef BLIS_CONFIG_H
+#define BLIS_CONFIG_H
+
+
+// -- OPERATING SYSTEM ---------------------------------------------------------
+
+
+
+// -- INTEGER PROPERTIES -------------------------------------------------------
+
+// The bit size of the integer type used to track values such as dimensions,
+// strides, diagonal offsets. A value of 32 results in BLIS using 32-bit signed
+// integers while 64 results in 64-bit integers. Any other value results in use
+// of the C99 type "long int". Note that this ONLY affects integers used
+// internally within BLIS as well as those exposed in the native BLAS-like BLIS
+// interface.
+#define BLIS_INT_TYPE_SIZE               64
+
+
+
+// -- FLOATING-POINT PROPERTIES ------------------------------------------------
+
+// Define the number of floating-point types supported, and the size of the
+// largest type.
+#define BLIS_NUM_FP_TYPES                4
+#define BLIS_MAX_TYPE_SIZE               sizeof(dcomplex)
+
+// Enable use of built-in C99 "float complex" and "double complex" types and
+// associated overloaded operations and functions? Disabling results in
+// scomplex and dcomplex being defined in terms of simple structs.
+//#define BLIS_ENABLE_C99_COMPLEX
+
+
+
+// -- MULTITHREADING -----------------------------------------------------------
+
+// The maximum number of BLIS threads that will run concurrently.
+#define BLIS_MAX_NUM_THREADS             1
+
+
+
+// -- MEMORY ALLOCATION --------------------------------------------------------
+
+// -- Contiguous (static) memory allocator --
+
+// The number of MC x KC, KC x NC, and MC x NC blocks to reserve in the
+// contiguous memory pools.
+#define BLIS_NUM_MC_X_KC_BLOCKS          BLIS_MAX_NUM_THREADS
+#define BLIS_NUM_KC_X_NC_BLOCKS          BLIS_MAX_NUM_THREADS
+#define BLIS_NUM_MC_X_NC_BLOCKS          0
+
+// The maximum preload byte offset is used to pad the end of the contiguous
+// memory pools so that the micro-kernel, when computing with the end of the
+// last block, can exceed the bounds of the usable portion of the memory
+// region without causing a segmentation fault.
+#define BLIS_MAX_PRELOAD_BYTE_OFFSET     128
+
+// -- Memory alignment --
+
+// It is sometimes useful to define the various memory alignments in terms
+// of some other characteristics of the system, such as the cache line size
+// and the page size.
+#define BLIS_CACHE_LINE_SIZE             64
+#define BLIS_PAGE_SIZE                   4096
+
+// Alignment size needed by the instruction set for aligned SIMD/vector
+// instructions.
+#define BLIS_SIMD_ALIGN_SIZE             16
+
+// Alignment size used to align local stack buffers within macro-kernel
+// functions.
+#define BLIS_STACK_BUF_ALIGN_SIZE        BLIS_SIMD_ALIGN_SIZE
+
+// Alignment size used when allocating memory dynamically from the operating
+// system (eg: posix_memalign()). To disable heap alignment and just use
+// malloc() instead, set this to 1.
+#define BLIS_HEAP_ADDR_ALIGN_SIZE        BLIS_SIMD_ALIGN_SIZE
+
+// Alignment size used when sizing leading dimensions of dynamically
+// allocated memory.
+#define BLIS_HEAP_STRIDE_ALIGN_SIZE      BLIS_CACHE_LINE_SIZE
+
+// Alignment size used when allocating entire blocks of contiguous memory
+// from the contiguous memory allocator.
+#define BLIS_CONTIG_ADDR_ALIGN_SIZE      BLIS_PAGE_SIZE
+
+
+
+// -- MIXED DATATYPE SUPPORT ---------------------------------------------------
+
+// Basic (homogeneous) datatype support always enabled.
+
+// Enable mixed domain operations?
+//#define BLIS_ENABLE_MIXED_DOMAIN_SUPPORT
+
+// Enable extra mixed precision operations?
+//#define BLIS_ENABLE_MIXED_PRECISION_SUPPORT
+
+
+
+// -- MISCELLANEOUS OPTIONS ----------------------------------------------------
+
+// Stay initialized after auto-initialization, unless and until the user
+// explicitly calls bli_finalize().
+#define BLIS_ENABLE_STAY_AUTO_INITIALIZED
+
+
+
+// -- BLAS COMPATIBILITY LAYER -------------------------------------------------
+
+// Enable the BLAS compatibility layer?
+#define BLIS_ENABLE_BLAS2BLIS
+
+// The bit size of the integer type used to track values such as dimensions and
+// leading dimensions (ie: column strides) within the BLAS compatibility layer.
+// A value of 32 results in the compatibility layer using 32-bit signed integers
+// while 64 results in 64-bit integers. Any other value results in use of the
+// C99 type "long int". Note that this ONLY affects integers used within the
+// BLAS compatibility layer.
+#define BLIS_BLAS2BLIS_INT_TYPE_SIZE     32
+
+// Fortran-77 name-mangling macros.
+#define PASTEF770(name)                        name ## _
+#define PASTEF77(ch1,name)       ch1        ## name ## _
+#define PASTEF772(ch1,ch2,name)  ch1 ## ch2 ## name ## _
+#define PASTEF773(ch1,ch2,ch3,name)  ch1 ## ch2 ## ch3 ## name ## _
+
+
+
+// -- CBLAS COMPATIBILITY LAYER ------------------------------------------------
+
+// Enable the CBLAS compatibility layer?
+// NOTE: Enabling CBLAS will automatically enable the BLAS compatibility layer
+// regardless of whether or not it was explicitly enabled above. Furthermore,
+// the CBLAS compatibility layer will use the integer type size definition
+// specified above when defining the size of its own integers (regardless of
+// whether the BLAS layer was enabled directly or indirectly).
+//#define BLIS_ENABLE_CBLAS
+
+
+
+
+#endif

--- a/config/armv8a/bli_kernel.h
+++ b/config/armv8a/bli_kernel.h
@@ -1,0 +1,210 @@
+/*
+
+   BLIS    
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name of The University of Texas at Austin nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef BLIS_KERNEL_H
+#define BLIS_KERNEL_H
+
+
+// -- LEVEL-3 MICRO-KERNEL CONSTANTS -------------------------------------------
+
+// -- Cache blocksizes --
+
+//
+// Constraints:
+//
+// (1) MC must be a multiple of:
+//     (a) MR (for zero-padding purposes)
+//     (b) NR (for zero-padding purposes when MR and NR are "swapped")
+// (2) NC must be a multiple of
+//     (a) NR (for zero-padding purposes)
+//     (b) MR (for zero-padding purposes when MR and NR are "swapped")
+//
+
+#define BLIS_DEFAULT_MC_S              416 // 1280 //160 // 160 // 160 //2048 //336 
+#define BLIS_DEFAULT_KC_S              704 //1280 //672 //528 // 856 //2048 //528 
+#define BLIS_DEFAULT_NC_S              4096
+
+#define BLIS_DEFAULT_MC_D              80 //176 
+#define BLIS_DEFAULT_KC_D              336 //368 
+#define BLIS_DEFAULT_NC_D              4096
+
+#define BLIS_DEFAULT_MC_C              64
+#define BLIS_DEFAULT_KC_C              128
+#define BLIS_DEFAULT_NC_C              4096
+
+#define BLIS_DEFAULT_MC_Z              64
+#define BLIS_DEFAULT_KC_Z              128
+#define BLIS_DEFAULT_NC_Z              4096
+
+// -- Register blocksizes --
+
+#define BLIS_DEFAULT_MR_S              4
+#define BLIS_DEFAULT_NR_S              4
+
+#define BLIS_DEFAULT_MR_D              4
+#define BLIS_DEFAULT_NR_D              4
+
+#define BLIS_DEFAULT_MR_C              8
+#define BLIS_DEFAULT_NR_C              4
+
+#define BLIS_DEFAULT_MR_Z              8
+#define BLIS_DEFAULT_NR_Z              4
+
+// NOTE: If the micro-kernel, which is typically unrolled to a factor
+// of f, handles leftover edge cases (ie: when k % f > 0) then these
+// register blocksizes in the k dimension can be defined to 1.
+
+//#define BLIS_DEFAULT_KR_S              1
+//#define BLIS_DEFAULT_KR_D              1
+//#define BLIS_DEFAULT_KR_C              1
+//#define BLIS_DEFAULT_KR_Z              1
+
+// -- Maximum cache blocksizes (for optimizing edge cases) --
+
+// NOTE: These cache blocksize "extensions" have the same constraints as
+// the corresponding default blocksizes above. When these values are
+// larger than the default blocksizes, blocksizes used at edge cases are
+// enlarged if such an extension would encompass the remaining portion of
+// the matrix dimension.
+
+//#define BLIS_MAXIMUM_MC_S              (BLIS_DEFAULT_MC_S + BLIS_DEFAULT_MC_S/4)
+//#define BLIS_MAXIMUM_KC_S              (BLIS_DEFAULT_KC_S + BLIS_DEFAULT_KC_S/4)
+//#define BLIS_MAXIMUM_NC_S              (BLIS_DEFAULT_NC_S + BLIS_DEFAULT_NC_S/4)
+
+//#define BLIS_MAXIMUM_MC_D              (BLIS_DEFAULT_MC_D + BLIS_DEFAULT_MC_D/4)
+//#define BLIS_MAXIMUM_KC_D              (BLIS_DEFAULT_KC_D + BLIS_DEFAULT_KC_D/4)
+//#define BLIS_MAXIMUM_NC_D              (BLIS_DEFAULT_NC_D + BLIS_DEFAULT_NC_D/4)
+
+//#define BLIS_MAXIMUM_MC_C              (BLIS_DEFAULT_MC_C + BLIS_DEFAULT_MC_C/4)
+//#define BLIS_MAXIMUM_KC_C              (BLIS_DEFAULT_KC_C + BLIS_DEFAULT_KC_C/4)
+//#define BLIS_MAXIMUM_NC_C              (BLIS_DEFAULT_NC_C + BLIS_DEFAULT_NC_C/4)
+
+//#define BLIS_MAXIMUM_MC_Z              (BLIS_DEFAULT_MC_Z + BLIS_DEFAULT_MC_Z/4)
+//#define BLIS_MAXIMUM_KC_Z              (BLIS_DEFAULT_KC_Z + BLIS_DEFAULT_KC_Z/4)
+//#define BLIS_MAXIMUM_NC_Z              (BLIS_DEFAULT_NC_Z + BLIS_DEFAULT_NC_Z/4)
+
+// -- Packing register blocksize (for packed micro-panels) --
+
+// NOTE: These register blocksize "extensions" determine whether the
+// leading dimensions used within the packed micro-panels are equal to
+// or greater than their corresponding register blocksizes above.
+
+//#define BLIS_PACKDIM_MR_S              (BLIS_DEFAULT_MR_S + ...)
+//#define BLIS_PACKDIM_NR_S              (BLIS_DEFAULT_NR_S + ...)
+
+//#define BLIS_PACKDIM_MR_D              (BLIS_DEFAULT_MR_D + ...)
+//#define BLIS_PACKDIM_NR_D              (BLIS_DEFAULT_NR_D + ...)
+
+//#define BLIS_PACKDIM_MR_C              (BLIS_DEFAULT_MR_C + ...)
+//#define BLIS_PACKDIM_NR_C              (BLIS_DEFAULT_NR_C + ...)
+
+//#define BLIS_PACKDIM_MR_Z              (BLIS_DEFAULT_MR_Z + ...)
+//#define BLIS_PACKDIM_NR_Z              (BLIS_DEFAULT_NR_Z + ...)
+
+
+
+// -- LEVEL-2 KERNEL CONSTANTS -------------------------------------------------
+
+
+
+
+// -- LEVEL-1F KERNEL CONSTANTS ------------------------------------------------
+
+
+
+
+// -- LEVEL-3 KERNEL DEFINITIONS -----------------------------------------------
+
+// -- gemm --
+
+#define BLIS_SGEMM_UKERNEL         bli_sgemm_opt_4x4
+#define BLIS_DGEMM_UKERNEL         bli_dgemm_opt_4x4
+
+// -- trsm-related --
+
+
+
+
+// -- LEVEL-1M KERNEL DEFINITIONS ----------------------------------------------
+
+// -- packm --
+
+// -- unpackm --
+
+
+
+
+// -- LEVEL-1F KERNEL DEFINITIONS ----------------------------------------------
+
+// -- axpy2v --
+
+// -- dotaxpyv --
+
+// -- axpyf --
+
+// -- dotxf --
+
+// -- dotxaxpyf --
+
+
+
+
+// -- LEVEL-1V KERNEL DEFINITIONS ----------------------------------------------
+
+// -- addv --
+
+// -- axpyv --
+
+// -- copyv --
+
+// -- dotv --
+
+// -- dotxv --
+
+// -- invertv --
+
+// -- scal2v --
+
+// -- scalv --
+
+// -- setv --
+
+// -- subv --
+
+// -- swapv --
+
+
+
+#endif
+

--- a/config/armv8a/kernels
+++ b/config/armv8a/kernels
@@ -1,0 +1,1 @@
+../../kernels/armv8a/

--- a/config/armv8a/make_defs.mk
+++ b/config/armv8a/make_defs.mk
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+#  BLIS    
+#  An object-based framework for developing high-performance BLAS-like
+#  libraries.
+#
+#  Copyright (C) 2014, The University of Texas at Austin
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#   - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   - Neither the name of The University of Texas at Austin nor the names
+#     of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+# Only include this block of code once.
+ifndef MAKE_DEFS_MK_INCLUDED
+MAKE_DEFS_MK_INCLUDED := yes
+
+
+
+#
+# --- Build definitions --------------------------------------------------------
+#
+
+# Variables corresponding to other configure-time options.
+BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := yes
+BLIS_ENABLE_STATIC_BUILD        := yes
+BLIS_ENABLE_DYNAMIC_BUILD       := no
+
+
+
+#
+# --- Utility program definitions ----------------------------------------------
+#
+
+SH         := /bin/sh
+MV         := mv
+MKDIR      := mkdir -p
+RM_F       := rm -f
+RM_RF      := rm -rf
+SYMLINK    := ln -sf
+FIND       := find
+GREP       := grep
+XARGS      := xargs
+RANLIB     := ranlib
+INSTALL    := install -c
+
+# Used to refresh CHANGELOG.
+GIT        := git
+GIT_LOG    := $(GIT) log --decorate
+
+
+
+#
+# --- Development tools definitions --------------------------------------------
+#
+
+# --- Determine the C compiler and related flags ---
+##CC             := gcc
+CC             := aarch64-linux-gnu-gcc
+#CC             := arm-linux-gnueabihf-gcc-4.9.2 
+# Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
+# NOTE: This is needed to enable posix_memalign().
+CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
+#CMISCFLAGS     := -std=c99 -mtune=cortex-a57 -mfpu=neon-fp-armv8 -march=armv8-a #-mfloat-abi=hard -mfpu=neon 
+CMISCFLAGS     := -std=c99 -march=armv8-a+fp+simd -ftree-vectorize -O3 -mcpu=cortex-a57 -mtune=cortex-a57 #-mtune=cortex-a57 -march=armv8-a -mfloat-abi=hard -mfpu=neon 
+CPICFLAGS      := -fPIC
+CDBGFLAGS      := -g
+CWARNFLAGS     := -Wall
+COPTFLAGS      := -march=armv8-a+fp+simd -ftree-vectorize -O3 -mcpu=cortex-a57 -mtune=cortex-a57 #-march=armv8-a -O2 -mtune=cortex-a57 -mfpu=neon-fp-armv8 #-mfpu=neon -O2
+CKOPTFLAGS     := $(COPTFLAGS)
+CVECFLAGS      := -march=armv8-a+fp+simd -ftree-vectorize -O3 -mcpu=cortex-a57 -mtune=cortex-a57 #-march=armv8-a -O2 -mtune=cortex-a57 -mfpu=neon-fp-armv8 
+
+# Aggregate all of the flags into multiple groups: one for standard
+# compilation, and one for each of the supported "special" compilation
+# modes.
+CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
+CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
+CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
+
+# --- Determine the archiver and related flags ---
+AR             := ar
+ARFLAGS        := cru
+
+# --- Determine the linker and related flags ---
+LINKER         := $(CC)
+SOFLAGS        := -shared
+LDFLAGS        := -lm
+
+
+
+# end of ifndef MAKE_DEFS_MK_INCLUDED conditional block
+endif

--- a/kernels/armv8a/neon/3/bli_gemm_opt_4x4.c
+++ b/kernels/armv8a/neon/3/bli_gemm_opt_4x4.c
@@ -1,0 +1,643 @@
+/*
+
+   BLIS    
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name of The University of Texas at Austin nor the names
+      of its contributors may be used to endorse or promote products
+      derived derived derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+#include "blis.h"
+
+/*
+   o 4x4 Single precision micro-kernel fully functional.
+   o Runnable on ARMv8, compiled with aarch64 GCC.
+   o Use it together with the armv8 BLIS configuration.
+   o Tested on Juno board. Around 7.3 GFLOPS @ 1.1 GHz. 
+
+   December 2014.
+*/
+void bli_sgemm_opt_4x4(
+                        dim_t              k,
+                        float*    restrict alpha,
+                        float*    restrict a,
+                        float*    restrict b,
+                        float*    restrict beta,
+                        float*    restrict c, inc_t rs_c, inc_t cs_c,
+                        auxinfo_t*         data
+                      )
+{
+	void* a_next = bli_auxinfo_next_a( data );
+	void* b_next = bli_auxinfo_next_b( data );
+
+	dim_t k_iter = k / 4;
+	dim_t k_left = k % 4;
+
+__asm__ volatile
+(
+"                                            \n\t"
+"                                            \n\t"
+" ldr x0,%[aaddr]                            \n\t" // Load address of A.
+" ldr x1,%[baddr]                            \n\t" // Load address of B.
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+"                                            \n\t"
+" mov x4,#1                                  \n\t" // Init loop counter (i=0).
+"                                            \n\t"
+" ldr x16,%[a_next]                          \n\t" // Pointer to next block of A.
+" ldr x17,%[b_next]                          \n\t" // Pointer to next pointer of B.
+"                                            \n\t"
+" ldr x5,%[k_iter]                           \n\t" // Number of unrolled iterations (k_iter).
+" ldr x6,%[k_left]                           \n\t" // Number of remaining iterations (k_left).
+"                                            \n\t" 
+" ldr x7,%[alpha]                            \n\t" // Alpha address.      
+" ldr x8,%[beta]                             \n\t" // Beta address.     
+"                                            \n\t" 
+" ldr x9,%[cs_c]                             \n\t" // Load cs_c.
+" lsl x10,x9,#2                              \n\t" // cs_c * sizeof(float) -- AUX.
+" lsl x11,x9,#3                              \n\t" // 2 * cs_c * sizeof(float) -- AUX.
+" lsl x12,x9,#4                              \n\t" // 3 * cs_c * sizeof(float) -- AUX.
+"                                            \n\t" 
+" ldr x13,%[rs_c]                            \n\t" // Load rs_c.
+" lsl x14,x13,#2                             \n\t" // rs_c * sizeof(float).
+"                                            \n\t" 
+" ldp q0,q1,[x0,0]                           \n\t" // Preload columns a,a+1 into two quads.
+" ldp q4,q5,[x1,0]                           \n\t" // Preload rows    b,b+1 into two quads.
+"                                            \n\t"
+" prfm pldl1keep,[x2,0]                      \n\t" // Prefetch c.
+" prfm pldl1keep,[x2,x10]                    \n\t" // Prefetch c.
+" prfm pldl1keep,[x2,x11]                    \n\t" // Prefetch c.
+" prfm pldl1keep,[x2,x12]                    \n\t" // Prefetch c.
+"                                            \n\t"
+"                                            \n\t" // Vectors for result columns.
+" movi v8.4s,#0                              \n\t" // Vector for result column 0.
+" movi v9.4s,#0                              \n\t" // Vector for result column 1.
+" movi v10.4s,#0                             \n\t" // Vector for result column 2.
+" movi v11.4s,#0                             \n\t" // Vector for result column 3.
+"                                            \n\t"
+"                                            \n\t" // Replicating accum. vectors for unrolling.
+" movi v12.4s,#0                             \n\t" // Vector 1 for accummulating column 0.
+" movi v13.4s,#0                             \n\t" // Vector 1 for accummulating column 1.
+" movi v14.4s,#0                             \n\t" // Vector 1 for accummulating column 2.
+" movi v15.4s,#0                             \n\t" // Vector 1 for accummulating column 3.
+"                                            \n\t"
+" movi v16.4s,#0                             \n\t" // Vector 2 for accummulating column 0.
+" movi v17.4s,#0                             \n\t" // Vector 2 for accummulating column 1.
+" movi v18.4s,#0                             \n\t" // Vector 2 for accummulating column 2.
+" movi v19.4s,#0                             \n\t" // Vector 2 for accummulating column 3.
+"                                            \n\t"
+" movi v20.4s,#0                             \n\t" // Vector 3 for accummulating column 0.
+" movi v21.4s,#0                             \n\t" // Vector 3 for accummulating column 1.
+" movi v22.4s,#0                             \n\t" // Vector 3 for accummulating column 2.
+" movi v23.4s,#0                             \n\t" // Vector 3 for accummulating column 3.
+"                                            \n\t"
+" movi v24.4s,#0                             \n\t" // Vector 4 for accummulating column 0.
+" movi v25.4s,#0                             \n\t" // Vector 4 for accummulating column 1.
+" movi v26.4s,#0                             \n\t" // Vector 4 for accummulating column 2.
+" movi v27.4s,#0                             \n\t" // Vector 4 for accummulating column 3.
+"                                            \n\t"
+" ld1r {v31.4s},[x8]                         \n\t" // Load beta into quad.
+"                                            \n\t"
+" cmp x5,#0                                  \n\t" // If k_iter == 0, jump to k_left.
+" beq .SCONSIDERKLEFT                        \n\t"
+"                                            \n\t"
+" cmp x5,1                                   \n\t" // If there is just one k_iter, jump to that one. 
+" beq .SLASTITER                             \n\t" // (as loop is do-while-like).
+"                                            \n\t"
+" .SLOOPKITER:                               \n\t" // Body of the k_iter loop.
+"                                            \n\t"
+" prfm pldl1keep,[x0,#1024]                  \n\t" // Prefetch.
+" prfm pldl1keep,[x1,#1024]                  \n\t" // Prefetch.
+"                                            \n\t"
+" fmla v12.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v13.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ldp q6,q7,[x1,32]                          \n\t" // Load rows b+2,b+3 into quads.
+"                                            \n\t"
+" fmla v14.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v15.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ldp q2,q3,[x0,32]                          \n\t" // Load columns a+2,a+3 into quads.
+"                                            \n\t"
+" fmla v16.4s,v1.4s,v5.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v1.4s,v5.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v18.4s,v1.4s,v5.s[2]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v5.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" add x0,x0,64                               \n\t" // Update a_ptr.
+" add x1,x1,64                               \n\t" // Update b_ptr.
+"                                            \n\t"
+" fmla v20.4s,v2.4s,v6.s[0]                  \n\t" // Accummulate.
+" fmla v21.4s,v2.4s,v6.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ldp q0,q1,[x0]                             \n\t" // Load columns a,a+1 into quads (next iteration).
+"                                            \n\t"
+" fmla v22.4s,v2.4s,v6.s[2]                  \n\t" // Accummulate.
+" fmla v23.4s,v2.4s,v6.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ldp q4,q5,[x1]                             \n\t" // Load rows b,b+1 into quads (next iteration).
+"                                            \n\t"
+" fmla v24.4s,v3.4s,v7.s[0]                  \n\t" // Accummulate.
+" fmla v25.4s,v3.4s,v7.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" prfm pldl1keep,[x0,#64]                    \n\t" // Prefetch.
+" prfm pldl1keep,[x1,#64]                    \n\t" // Prefetch.
+"                                            \n\t"
+" fmla v26.4s,v3.4s,v7.s[2]                  \n\t" // Accummulate.
+" fmla v27.4s,v3.4s,v7.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" sub x5,x5,1                                \n\t" // i-=1.
+" cmp x5,1                                   \n\t" // Iterate again if we are not in k_iter == 1.
+" bne .SLOOPKITER                            \n\t"
+"                                            \n\t" 
+//" prfm pldl1keep,[x0,#1024]                \n\t"
+//" prfm pldl1keep,[x1,#1024]                \n\t"
+"                                            \n\t" 
+" .SLASTITER:                                \n\t" // Last iteration of k_iter loop.
+"                                            \n\t" 
+" fmla v12.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v13.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ldp q6,q7,[x1,32]                          \n\t" // Load rows b+2,b+3 into quads.
+"                                            \n\t"
+" fmla v14.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v15.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ldp q2,q3,[x0,32]                          \n\t" // Load columns a+2,a+3 into quads.
+"                                            \n\t"
+" fmla v16.4s,v1.4s,v5.s[0]                  \n\t" // Accummulate.
+" fmla v17.4s,v1.4s,v5.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" ld1r {v30.4s},[x7]                         \n\t" // Load alpha.
+"                                            \n\t"
+" fmla v18.4s,v1.4s,v5.s[2]                  \n\t" // Accummulate.
+" fmla v19.4s,v1.4s,v5.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v20.4s,v2.4s,v6.s[0]                  \n\t" // Accummulate.
+" fmla v21.4s,v2.4s,v6.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v22.4s,v2.4s,v6.s[2]                  \n\t" // Accummulate.
+" fmla v23.4s,v2.4s,v6.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v24.4s,v3.4s,v7.s[0]                  \n\t" // Accummulate.
+" fmla v25.4s,v3.4s,v7.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v26.4s,v3.4s,v7.s[2]                  \n\t" // Accummulate.
+" fmla v27.4s,v3.4s,v7.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+//" ld1 {v8.4s},[x2],x10                       \n\t" // Load c    into quad and increment by cs_c
+//" ld1 {v9.4s},[x2],x10                       \n\t" // Load c+4  into quad and increment by cs_c
+//" ld1 {v10.4s},[x2],x10                      \n\t" // Load c+8  into quad and increment by cs_c
+//" ld1 {v11.4s},[x2],x10                      \n\t" // Load c+16 into quad and increment by cs_c
+"                                            \n\t"
+" fadd v12.4s,v12.4s,v16.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v13.4s,v13.4s,v17.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v14.4s,v14.4s,v18.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v15.4s,v15.4s,v19.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v12.4s,v12.4s,v20.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v13.4s,v13.4s,v21.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v14.4s,v14.4s,v22.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v15.4s,v15.4s,v23.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v12.4s,v12.4s,v24.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v13.4s,v13.4s,v25.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v14.4s,v14.4s,v26.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+" fadd v15.4s,v15.4s,v27.4s                  \n\t" // Final accummulate of temporal accum. vectors.
+"                                            \n\t"
+" add x0,x0,64                               \n\t" // Update a_ptr.
+" add x1,x1,64                               \n\t" // Update b_ptr.
+"                                            \n\t"
+" .SCONSIDERKLEFT:                           \n\t" 
+" cmp x6,0                                   \n\t" // If k_left == 0, we are done.
+" beq .SPOSTACCUM                            \n\t" // else, we enter the k_left loop.
+"                                            \n\t"
+" .SLOOPKLEFT:                               \n\t" // Body of the left iterations
+"                                            \n\t"
+" prfm pldl1keep,[x0,#1024]                  \n\t" // Prefetch.
+" prfm pldl1keep,[x1,#1024]                  \n\t" // Prefetch.
+"                                            \n\t"
+" ldr q0,[x0]                                \n\t" // Load a into quad (next iteration).
+" ldr q4,[x1]                                \n\t" // Load b into quad (next iteration).
+"                                            \n\t"
+" add x0,x0,16                               \n\t" // Update a_ptr.
+" add x1,x1,16                               \n\t" // Update b_ptr.
+"                                            \n\t"
+" sub x6,x6,1                                \n\t" // i = i-1.
+"                                            \n\t"
+" fmla v12.4s,v0.4s,v4.s[0]                  \n\t" // Accummulate.
+" fmla v13.4s,v0.4s,v4.s[1]                  \n\t" // Accummulate.
+"                                            \n\t"
+" fmla v14.4s,v0.4s,v4.s[2]                  \n\t" // Accummulate.
+" fmla v15.4s,v0.4s,v4.s[3]                  \n\t" // Accummulate.
+"                                            \n\t"
+" cmp x6,0                                   \n\t" // Iterate again.
+" bne .SLOOPKLEFT                            \n\t" // if i!=0.
+"                                            \n\t"
+" ld1r {v30.4s},[x7]                         \n\t" // Load alpha.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+"                                            \n\t"
+" .SPOSTACCUM:                               \n\t"
+" cmp x13,#1                                 \n\t" // If rs_c != 1 (column-major)
+" bne .SGENSTORED                            \n\t"
+"                                            \n\t"
+"                                            \n\t"
+" .SCOLSTORED:                               \n\t" // C is column-major.
+"                                            \n\t"
+" fcmp s31,#0.0                              \n\t"
+" beq .BETAZEROCOLSTORED                     \n\t" // Taking care of the beta==0 case.
+"                                            \n\t"
+"                                            \n\t" // If beta!=0, then we can read from C.
+" ld1 {v8.4s},[x2],x10                       \n\t" // Load c    into quad and increment by cs_c.
+" ld1 {v9.4s},[x2],x10                       \n\t" // Load c+4  into quad and increment by cs_c.
+" ld1 {v10.4s},[x2],x10                      \n\t" // Load c+8  into quad and increment by cs_c.
+" ld1 {v11.4s},[x2],x10                      \n\t" // Load c+16 into quad and increment by cs_c.
+"                                            \n\t"
+" prfm pldl1keep,[x16,0]                     \n\t" // Prefetch.
+" prfm pldl1keep,[x17,0]                     \n\t" // Prefetch.
+"                                            \n\t"
+"                                            \n\t"
+" fmul v8.4s,v8.4s,v31.s[0]                  \n\t" // Scale by beta.
+" fmul v9.4s,v9.4s,v31.s[0]                  \n\t" // Scale by beta.
+" fmul v10.4s,v10.4s,v31.s[0]                \n\t" // Scale by beta.
+" fmul v11.4s,v11.4s,v31.s[0]                \n\t" // Scale by beta.
+"                                            \n\t"
+" .BETAZEROCOLSTORED:                        \n\t" // If beta==0, we won't read from C (nor scale).
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+"                                            \n\t"
+" fmla v8.4s,v12.4s,v30.s[0]                 \n\t" // Scale by alpha
+" fmla v9.4s,v13.4s,v30.s[0]                 \n\t" // Scale by alpha
+" fmla v10.4s,v14.4s,v30.s[0]                \n\t" // Scale by alpha
+" fmla v11.4s,v15.4s,v30.s[0]                \n\t" // Scale by alpha
+"                                            \n\t"
+" st1 {v8.4s},[x2],x10                       \n\t" // Store quad into c    and increment by cs_c
+" st1 {v9.4s},[x2],x10                       \n\t" // Store quad into c+4  and increment by cs_c
+" st1 {v10.4s},[x2],x10                      \n\t" // Store quad into c+8  and increment by cs_c
+" st1 {v11.4s},[x2],x10                      \n\t" // Store quad into c+16 and increment by cs_c
+"                                            \n\t"
+" b .SEND                                    \n\t" // Done (TODO: this obviously needs to be moved down to remove jump).
+"                                            \n\t"
+"                                            \n\t"
+" .SGENSTORED:                               \n\t" // C is general-stride stored.
+"                                            \n\t"
+" fcmp s31,#0.0                              \n\t"
+" beq .BETAZEROGENSTORED                     \n\t"
+"                                            \n\t"
+"                                            \n\t" // If beta!=0, then we can read from C.
+"                                            \n\t" // TODO: this was done fast. Rearrange to remove so many address reloads.
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+"                                            \n\t"
+" ld1 {v8.s}[0],[x2],x14                     \n\t" // Load c00  into quad and increment by rs_c.
+" ld1 {v8.s}[1],[x2],x14                     \n\t" // Load c01  into quad and increment by rs_c.
+" ld1 {v8.s}[2],[x2],x14                     \n\t" // Load c02  into quad and increment by rs_c.
+" ld1 {v8.s}[3],[x2],x14                     \n\t" // Load c03  into quad and increment by rs_c.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+"                                            \n\t"
+" ld1 {v9.s}[0],[x2],x14                     \n\t" // Load c10  into quad and increment by rs_c.
+" ld1 {v9.s}[1],[x2],x14                     \n\t" // Load c11  into quad and increment by rs_c.
+" ld1 {v9.s}[2],[x2],x14                     \n\t" // Load c12  into quad and increment by rs_c.
+" ld1 {v9.s}[3],[x2],x14                     \n\t" // Load c13  into quad and increment by rs_c.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+"                                            \n\t"
+" ld1 {v10.s}[0],[x2],x14                    \n\t" // Load c10  into quad and increment by rs_c.
+" ld1 {v10.s}[1],[x2],x14                    \n\t" // Load c11  into quad and increment by rs_c.
+" ld1 {v10.s}[2],[x2],x14                    \n\t" // Load c12  into quad and increment by rs_c.
+" ld1 {v10.s}[3],[x2],x14                    \n\t" // Load c13  into quad and increment by rs_c.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+"                                            \n\t"
+" ld1 {v11.s}[0],[x2],x14                    \n\t" // Load c10  into quad and increment by rs_c.
+" ld1 {v11.s}[1],[x2],x14                    \n\t" // Load c11  into quad and increment by rs_c.
+" ld1 {v11.s}[2],[x2],x14                    \n\t" // Load c12  into quad and increment by rs_c.
+" ld1 {v11.s}[3],[x2],x14                    \n\t" // Load c13  into quad and increment by rs_c.
+"                                            \n\t"
+"                                            \n\t"
+" prfm pldl1keep,[x16,0]                     \n\t" // Prefetch.
+" prfm pldl1keep,[x17,0]                     \n\t" // Prefetch.
+"                                            \n\t"
+" fmul v8.4s,v8.4s,v31.s[0]                  \n\t" // Scale by beta.
+" fmul v9.4s,v9.4s,v31.s[0]                  \n\t" // Scale by beta.
+" fmul v10.4s,v10.4s,v31.s[0]                \n\t" // Scale by beta.
+" fmul v11.4s,v11.4s,v31.s[0]                \n\t" // Scale by beta.
+"                                            \n\t"
+" .BETAZEROGENSTORED:                        \n\t" // If beta==0, we cannot read from C (nor scale).
+"                                            \n\t"
+" fmla v8.4s,v12.4s,v30.s[0]                 \n\t" // Scale by alpha.
+" fmla v9.4s,v13.4s,v30.s[0]                 \n\t" // Scale by alpha.
+" fmla v10.4s,v14.4s,v30.s[0]                \n\t" // Scale by alpha.
+" fmla v11.4s,v15.4s,v30.s[0]                \n\t" // Scale by alpha.
+"                                            \n\t"
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+"                                            \n\t"
+" st1 {v8.s}[0],[x2],x14                     \n\t" // Store c00  into quad and increment by rs_c.
+" st1 {v8.s}[1],[x2],x14                     \n\t" // Store c01  into quad and increment by rs_c.
+" st1 {v8.s}[2],[x2],x14                     \n\t" // Store c02  into quad and increment by rs_c.
+" st1 {v8.s}[3],[x2],x14                     \n\t" // Store c03  into quad and increment by rs_c.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+"                                            \n\t"
+" st1 {v9.s}[0],[x2],x14                     \n\t" // Store c10  into quad and increment by rs_c.
+" st1 {v9.s}[1],[x2],x14                     \n\t" // Store c11  into quad and increment by rs_c.
+" st1 {v9.s}[2],[x2],x14                     \n\t" // Store c12  into quad and increment by rs_c.
+" st1 {v9.s}[3],[x2],x14                     \n\t" // Store c13  into quad and increment by rs_c.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+"                                            \n\t"
+" st1 {v10.s}[0],[x2],x14                    \n\t" // Store c10  into quad and increment by rs_c.
+" st1 {v10.s}[1],[x2],x14                    \n\t" // Store c11  into quad and increment by rs_c.
+" st1 {v10.s}[2],[x2],x14                    \n\t" // Store c12  into quad and increment by rs_c.
+" st1 {v10.s}[3],[x2],x14                    \n\t" // Store c13  into quad and increment by rs_c.
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+" add x2,x2,x10                              \n\t" // c += cs_c.
+"                                            \n\t"
+" st1 {v11.s}[0],[x2],x14                    \n\t" // Store c10  into quad and increment by rs_c.
+" st1 {v11.s}[1],[x2],x14                    \n\t" // Store c11  into quad and increment by rs_c.
+" st1 {v11.s}[2],[x2],x14                    \n\t" // Store c12  into quad and increment by rs_c.
+" st1 {v11.s}[3],[x2],x14                    \n\t" // Store c13  into quad and increment by rs_c.
+"                                            \n\t"
+"                                            \n\t"
+"                                            \n\t"
+" .SEND:                                     \n\t" // Done!
+"                                            \n\t"
+:// output operands (none)
+:// input operands
+ [aaddr]  "m" (a),      // 0
+ [baddr]  "m" (b),      // 1
+ [caddr]  "m" (c),      // 2
+ [k_iter] "m" (k_iter), // 3
+ [k_left] "m" (k_left), // 4
+ [alpha]  "m" (alpha),  // 5
+ [beta]   "m" (beta),   // 6
+ [rs_c]   "m" (rs_c),   // 7
+ [cs_c]   "m" (cs_c),   // 8
+ [a_next] "m" (a_next), // 9
+ [b_next] "m" (b_next), // 10
+ [k]      "m" (k)       // 11
+:// Register clobber list
+ "x0", "x1", "x2", "x4",
+ "x5", "x6", "x7", "x8",
+ "x9", "x10","x11","x12",
+ "x13","x14","x20",
+ "v0", "v1", "v2", "v3",
+ "v4", "v5", "v6", "v7",
+ "v8", "v9", "v10","v11",
+ "v12","v13","v14","v15",
+ "v16","v17","v18","v19",
+ "v20","v21","v22","v23",
+ "v24","v25","v26","v27",
+ "v30","v31"
+);
+
+}
+
+
+/*
+   o 4x4 Double precision micro-kernel NOT fully functional yet.
+   o Runnable on ARMv8, compiled with aarch64 GCC.
+   o Use it together with the armv8 BLIS configuration.
+   o Tested on Juno board. Around 3 GFLOPS @ 1.1 GHz. 
+
+   December 2014.
+*/
+void bli_dgemm_opt_4x4(
+                        dim_t              k,
+                        double*   restrict alpha,
+                        double*   restrict a,
+                        double*   restrict b,
+                        double*   restrict beta,
+                        double*   restrict c, inc_t rs_c, inc_t cs_c,
+                        auxinfo_t*         data
+                      )
+{
+	void* a_next = bli_auxinfo_next_a( data );
+	void* b_next = bli_auxinfo_next_b( data );
+
+	dim_t k_iter = k / 2;
+	dim_t k_left = k % 2;
+
+__asm__ volatile
+(
+"                                            \n\t"
+" ldr x0,%[aaddr]                            \n\t" // Load address of A
+" ldr x1,%[baddr]                            \n\t" // Load address of B
+" ldr x2,%[caddr]                            \n\t" // Load address of C
+"                                            \n\t"
+" mov x4,#0                                  \n\t" // Init loop counter (i=0)
+"                                            \n\t"
+" ldr x16,%[a_next]                          \n\t" // Move pointer
+" ldr x17,%[b_next]                          \n\t" // Move pointer
+"                                            \n\t"
+" ldr x5,%[k_iter]                           \n\t" // Init guard (k_iter)
+" ldr x6,%[k_left]                           \n\t" // Init guard (k_iter)
+"                                            \n\t" 
+" ldr x7,%[alpha]                            \n\t" // Alpha address      
+" ldr x8,%[beta]                             \n\t" // Beta address      
+"                                            \n\t" 
+" ldr x9,%[cs_c]                             \n\t" // Load cs_c
+" lsl x10,x9,#3                              \n\t" // cs_c * sizeof(double)
+"                                            \n\t" 
+" ldp q0,q1,[x0],32                          \n\t" // Load a    into quad
+" ldp q4,q5,[x1],32                          \n\t" // Load b    into quad
+"                                            \n\t"
+" movi v12.2d,#0                             \n\t" // Vector for accummulating column 0 
+" movi v13.2d,#0                             \n\t" // Vector for accummulating column 0
+" movi v14.2d,#0                             \n\t" // Vector for accummulating column 1
+" movi v15.2d,#0                             \n\t" // Vector for accummulating column 1
+" movi v16.2d,#0                             \n\t" // Vector for accummulating column 2 
+" movi v17.2d,#0                             \n\t" // Vector for accummulating column 2
+" movi v18.2d,#0                             \n\t" // Vector for accummulating column 3
+" movi v19.2d,#0                             \n\t" // Vector for accummulating column 3
+"                                            \n\t"
+" ld1r {v31.2d},[x8]                         \n\t" // Load beta
+"                                            \n\t"
+" DLOOP:                                     \n\t" // Body
+"                                            \n\t"
+" ldp q6,q7,[x1],32                          \n\t" // Load b+4  into quad
+"                                            \n\t"
+" fmla v12.2d,v0.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v14.2d,v0.2d,v4.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v13.2d,v1.2d,v4.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v1.2d,v4.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" ldp q2,q3,[x0],32                          \n\t" // Load a+4  into quad
+"                                            \n\t"
+" fmla v16.2d,v0.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v18.2d,v0.2d,v5.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v17.2d,v1.2d,v5.d[0]                  \n\t" // Accummulate
+" fmla v19.2d,v1.2d,v5.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" ldp q0,q1,[x0],32                          \n\t" // Load a    into quad
+"                                            \n\t"
+" fmla v12.2d,v2.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v14.2d,v2.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v13.2d,v3.2d,v6.d[0]                  \n\t" // Accummulate
+" fmla v15.2d,v3.2d,v6.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" ldp q4,q5,[x1],32                          \n\t" // Load b    into quad
+"                                            \n\t"
+" fmla v16.2d,v2.2d,v7.d[0]                  \n\t" // Accummulate
+" fmla v18.2d,v2.2d,v7.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" fmla v17.2d,v3.2d,v7.d[0]                  \n\t" // Accummulate
+" fmla v19.2d,v3.2d,v7.d[1]                  \n\t" // Accummulate
+"                                            \n\t"
+" add x4,x4,1                                \n\t" // i = i+1
+" cmp x4,x5                                  \n\t" // Continue
+" blt DLOOP                                  \n\t" // if i < N 
+"                                            \n\t"
+" ldp q0,q1,[x2]                             \n\t" // Load c    into quad and increment by cs_c
+" add x2,x2,x10                              \n\t"
+" ldp q2,q3,[x2]                             \n\t" // Load c    into quad and increment by cs_c
+" add x2,x2,x10                              \n\t"
+" ldp q4,q5,[x2]                             \n\t" // Load c    into quad and increment by cs_c
+" add x2,x2,x10                              \n\t"
+" ldp q6,q7,[x2]                             \n\t" // Load c    into quad and increment by cs_c
+"                                            \n\t"
+" ld1r {v30.2d},[x7]                         \n\t" // Load alpha
+"                                            \n\t"
+" fmul v0.2d,v0.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v1.2d,v1.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v2.2d,v2.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v3.2d,v3.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v4.2d,v4.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v5.2d,v5.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v6.2d,v6.2d,v31.d[0]                  \n\t" // Scale by beta
+" fmul v7.2d,v7.2d,v31.d[0]                  \n\t" // Scale by beta
+"                                            \n\t"
+" prfm pldl2keep,[x16]                       \n\t"
+" prfm pldl2keep,[x17]                       \n\t"
+"                                            \n\t"
+" fmla v0.2d,v12.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v1.2d,v13.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v2.2d,v14.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v3.2d,v15.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v4.2d,v16.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v5.2d,v17.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v6.2d,v18.2d,v30.d[0]                 \n\t" // Scale by alpha
+" fmla v7.2d,v19.2d,v30.d[0]                 \n\t" // Scale by alpha
+"                                            \n\t"
+" ldr x2,%[caddr]                            \n\t" // Load address of C
+"                                            \n\t"
+" stp q0,q1,[x2]                             \n\t" // Store quad into c    and increment by cs_c
+" add x2,x2,x10                              \n\t"
+" stp q2,q3,[x2]                             \n\t" // Store quad into c+4  and increment by cs_c
+" add x2,x2,x10                              \n\t"
+" stp q4,q5,[x2]                             \n\t" // Store quad into c+8  and increment by cs_c
+" add x2,x2,x10                              \n\t"
+" stp q6,q7,[x2]                             \n\t" // Store quad into c+16 and increment by cs_c
+"                                            \n\t"
+:// output operands (none)
+:// input operands
+ [aaddr]  "m" (a),      // 0
+ [baddr]  "m" (b),      // 1
+ [caddr]  "m" (c),      // 2
+ [k_iter] "m" (k_iter), // 3
+ [k_left] "m" (k_left), // 4
+ [alpha]  "m" (alpha),  // 5
+ [beta]   "m" (beta),   // 6
+ [rs_c]   "m" (rs_c),   // 6
+ [cs_c]   "m" (cs_c),   // 7
+ [a_next] "m" (a_next), // 8
+ [b_next] "m" (b_next)  // 9
+:// Register clobber list
+ "x0","x1","x2",
+ "x4","x5","x6",
+ "x7","x8","x9",
+ "x10","x11","x12",
+ "v0","v1","v2",
+ "v3","v4","v5",
+ "v6","v7","v8",
+ "v9","v10","v11",
+ "v12","v13","v14",
+ "v15","v16","v17","v18","v19",
+ "v30","v31"
+);
+
+
+
+}
+
+void bli_cgemm_opt_4x4(
+                        dim_t              k,
+                        scomplex* restrict alpha,
+                        scomplex* restrict a,
+                        scomplex* restrict b,
+                        scomplex* restrict beta,
+                        scomplex* restrict c, inc_t rs_c, inc_t cs_c,
+                        auxinfo_t*         data
+                      )
+{
+	/* Just call the reference implementation. */
+	BLIS_CGEMM_UKERNEL_REF( k,
+	                   alpha,
+	                   a,
+	                   b,
+	                   beta,
+	                   c, rs_c, cs_c,
+	                   data );
+}
+
+void bli_zgemm_opt_4x4(
+                        dim_t              k,
+                        dcomplex* restrict alpha,
+                        dcomplex* restrict a,
+                        dcomplex* restrict b,
+                        dcomplex* restrict beta,
+                        dcomplex* restrict c, inc_t rs_c, inc_t cs_c,
+                        auxinfo_t*         data
+                      )
+{
+	/* Just call the reference implementation. */
+	BLIS_ZGEMM_UKERNEL_REF( k,
+	                   alpha,
+	                   a,
+	                   b,
+	                   beta,
+	                   c, rs_c, cs_c,
+	                   data );
+}
+


### PR DESCRIPTION
I'd like to add the following functionality to the main BLIS tree:
- ARMv8 configurlation and micro-kernels.
- Only sgemm micro-kernel is fully functional, tested and optimized at this point.
- dgemm is only working for column/row-major, not yet for general stride. Only 
  working for matrix dimensions multiple of 4. Will be fixed really soon.
