### PR TITLE
Enable shared library build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ addons:
 
 script:
   - ./configure $BUILD_CONFIG
-  - make CC=gcc-4.8
+  - make CC=gcc-4.8 BLIS_ENABLE_DYNAMIC_BUILD=yes
   - if [ $RUN_TEST -eq 1 ]; then make BLIS_ENABLE_TEST_OUTPUT=yes test; fi
   - if [ $RUN_TEST -eq 1 ]; then ./build/check-test.sh ./output.testsuite; fi


### PR DESCRIPTION
Seeing some issues locally with linking the bulldozer shared library, let's see if Travis reproduces it.
