### PR TITLE
Fix f2c conflicts

### DIFF
--- a/frame/base/noopt/bli_dlamch.c
+++ b/frame/base/noopt/bli_dlamch.c
@@ -8,17 +8,17 @@ extern "C" {
 #endif
 #include "blis.h"
 
-double bli_pow_di( doublereal* a, integer* n );
+double bli_pow_di( bla_double* a, bla_integer* n );
 
 /* Table of constant values */
 
-//static integer c__1 = 1;
-static doublereal c_b32 = 0.;
+//static bla_integer c__1 = 1;
+static bla_double c_b32 = 0.;
 
-double bli_pow_di(doublereal *ap, integer *bp)
+double bli_pow_di(bla_double *ap, bla_integer *bp)
 {
 	double        pow, x;
-	integer       n;
+	bla_integer       n;
 	unsigned long u;
 
 	pow = 1;
@@ -45,32 +45,32 @@ double bli_pow_di(doublereal *ap, integer *bp)
 	return pow;
 }
 
-doublereal bli_dlamch(character *cmach, ftnlen cmach_len)
+bla_double bli_dlamch(bla_character *cmach, ftnlen cmach_len)
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bla_logical first = TRUE_;
 
     /* System generated locals */
-    integer i__1;
-    doublereal ret_val;
+    bla_integer i__1;
+    bla_double ret_val;
 
     /* Builtin functions */
-    double bli_pow_di(doublereal *, integer *);
+    double bli_pow_di(bla_double *, bla_integer *);
 
     /* Local variables */
-    static doublereal base;
-    static integer beta;
-    static doublereal emin, prec, emax;
-    static integer imin, imax;
-    static logical lrnd;
-    static doublereal rmin, rmax, t, rmach;
-    extern logical bli_lsame(character *, character *, ftnlen, ftnlen);
-    static doublereal smnum, sfmin;
-    extern /* Subroutine */ int bli_dlamc2(integer *, integer *, logical *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *);
-    static integer it;
-    static doublereal rnd, eps;
+    static bla_double base;
+    static bla_integer beta;
+    static bla_double emin, prec, emax;
+    static bla_integer imin, imax;
+    static bla_logical lrnd;
+    static bla_double rmin, rmax, t, rmach;
+    extern bla_logical bli_lsame(bla_character *, bla_character *, ftnlen, ftnlen);
+    static bla_double smnum, sfmin;
+    extern /* Subroutine */ int bli_dlamc2(bla_integer *, bla_integer *, bla_logical *,
+	    bla_double *, bla_integer *, bla_double *, bla_integer *, bla_double *);
+    static bla_integer it;
+    static bla_double rnd, eps;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -132,8 +132,8 @@ doublereal bli_dlamch(character *cmach, ftnlen cmach_len)
 
     if (first) {
 	bli_dlamc2(&beta, &it, &lrnd, &eps, &imin, &rmin, &imax, &rmax);
-	base = (doublereal) beta;
-	t = (doublereal) it;
+	base = (bla_double) beta;
+	t = (bla_double) it;
 	if (lrnd) {
 	    rnd = 1.;
 	    i__1 = 1 - it;
@@ -144,8 +144,8 @@ doublereal bli_dlamch(character *cmach, ftnlen cmach_len)
 	    eps = bli_pow_di(&base, &i__1);
 	}
 	prec = eps * base;
-	emin = (doublereal) imin;
-	emax = (doublereal) imax;
+	emin = (bla_double) imin;
+	emax = (bla_double) imax;
 	sfmin = rmin;
 	smnum = 1. / rmax;
 	if (smnum >= sfmin) {
@@ -190,26 +190,26 @@ doublereal bli_dlamch(character *cmach, ftnlen cmach_len)
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_dlamc1(integer *beta, integer *t, logical *rnd, logical 
+/* Subroutine */ int bli_dlamc1(bla_integer *beta, bla_integer *t, bla_logical *rnd, bla_logical
 	*ieee1)
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bla_logical first = TRUE_;
 
     /* System generated locals */
-    doublereal d__1, d__2;
+    bla_double d__1, d__2;
 
     /* Local variables */
-    static logical lrnd;
-    static doublereal a, b, c__, f;
-    static integer lbeta;
-    static doublereal savec;
-    extern doublereal bli_dlamc3(doublereal *, doublereal *);
-    static logical lieee1;
-    static doublereal t1, t2;
-    static integer lt;
-    static doublereal one, qtr;
+    static bla_logical lrnd;
+    static bla_double a, b, c__, f;
+    static bla_integer lbeta;
+    static bla_double savec;
+    extern bla_double bli_dlamc3(bla_double *, bla_double *);
+    static bla_logical lieee1;
+    static bla_double t1, t2;
+    static bla_integer lt;
+    static bla_double one, qtr;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -279,7 +279,7 @@ doublereal bli_dlamch(character *cmach, ftnlen cmach_len)
 /*        that relevant values are  stored and not held in registers,  or */
 /*        are not affected by optimizers. */
 
-/*        Compute  a = 2.0**m  with the  smallest positive integer m such */
+/*        Compute  a = 2.0**m  with the  smallest positive bla_integer m such */
 /*        that */
 
 /*           fl( a + 1.0 ) = a. */
@@ -298,7 +298,7 @@ L10:
 	}
 /* +       END WHILE */
 
-/*        Now compute  b = 2.0**m  with the smallest positive integer m */
+/*        Now compute  b = 2.0**m  with the smallest positive bla_integer m */
 /*        such that */
 
 /*           fl( a + b ) .gt. a. */
@@ -324,13 +324,13 @@ L20:
 	savec = c__;
 	d__1 = -a;
 	c__ = bli_dlamc3(&c__, &d__1);
-	lbeta = (integer) (c__ + qtr);
+	lbeta = (bla_integer) (c__ + qtr);
 
 
 /*        Now determine whether rounding or chopping occurs,  by adding a */
 /*        bit  less  than  beta/2  and a  bit  more  than  beta/2  to  a. */
 
-	b = (doublereal) lbeta;
+	b = (bla_double) lbeta;
 	d__1 = b / 2;
 	d__2 = -b / 100;
 	f = bli_dlamc3(&d__1, &d__2);
@@ -360,9 +360,9 @@ L20:
 	t2 = bli_dlamc3(&d__1, &savec);
 	lieee1 = t1 == a && t2 > savec && lrnd;
 
-/*        Now find  the  mantissa, t.  It should  be the  integer part of */
+/*        Now find  the  mantissa, t.  It should  be the  bla_integer part of */
 /*        log to the base beta of a,  however it is safer to determine  t */
-/*        by powering.  So we find t as the smallest positive integer for */
+/*        by powering.  So we find t as the smallest positive bla_integer for */
 /*        which */
 
 /*           fl( beta**t + 1.0 ) = 1.0. */
@@ -400,50 +400,50 @@ L30:
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_dlamc2(integer *beta, integer *t, logical *rnd, 
-	doublereal *eps, integer *emin, doublereal *rmin, integer *emax, 
-	doublereal *rmax)
+/* Subroutine */ int bli_dlamc2(bla_integer *beta, bla_integer *t, bla_logical *rnd,
+	bla_double *eps, bla_integer *emin, bla_double *rmin, bla_integer *emax,
+	bla_double *rmax)
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
-    static logical iwarn = FALSE_;
+    static bla_logical first = TRUE_;
+    static bla_logical iwarn = FALSE_;
 
     /* Format strings */
-    static character fmt_9999[] = "(//\002 WARNING. The value EMIN may be incorre\
+    static bla_character fmt_9999[] = "(//\002 WARNING. The value EMIN may be incorre\
 ct:-\002,\002  EMIN = \002,i8,/\002 If, after inspection, the value EMIN loo\
 ks\002,\002 acceptable please comment out \002,/\002 the IF block as marked \
 within the code of routine\002,\002 DLAMC2,\002,/\002 otherwise supply EMIN \
 explicitly.\002,/)";
 
     /* System generated locals */
-    integer i__1;
-    doublereal d__1, d__2, d__3, d__4, d__5;
+    bla_integer i__1;
+    bla_double d__1, d__2, d__3, d__4, d__5;
 
     /* Builtin functions */
-    double bli_pow_di(doublereal *, integer *);
-    //integer s_wsfe(cilist *), do_fio(integer *, character *, ftnlen), e_wsfe();
+    double bli_pow_di(bla_double *, bla_integer *);
+    //bla_integer s_wsfe(cilist *), do_fio(bla_integer *, bla_character *, ftnlen), e_wsfe();
 
     /* Local variables */
-    static logical ieee;
-    static doublereal half;
-    static logical lrnd;
-    static doublereal leps, zero, a, b, c__;
-    static integer i__, lbeta;
-    static doublereal rbase;
-    static integer lemin, lemax, gnmin;
-    static doublereal smnum;
-    static integer gpmin;
-    static doublereal third, lrmin, lrmax, sixth;
-    extern /* Subroutine */ int bli_dlamc1(integer *, integer *, logical *, 
-	    logical *);
-    extern doublereal bli_dlamc3(doublereal *, doublereal *);
-    static logical lieee1;
-    extern /* Subroutine */ int bli_dlamc4(integer *, doublereal *, integer *), 
-	    bli_dlamc5(integer *, integer *, integer *, logical *, integer *, 
-	    doublereal *);
-    static integer lt, ngnmin, ngpmin;
-    static doublereal one, two;
+    static bla_logical ieee;
+    static bla_double half;
+    static bla_logical lrnd;
+    static bla_double leps, zero, a, b, c__;
+    static bla_integer i__, lbeta;
+    static bla_double rbase;
+    static bla_integer lemin, lemax, gnmin;
+    static bla_double smnum;
+    static bla_integer gpmin;
+    static bla_double third, lrmin, lrmax, sixth;
+    extern /* Subroutine */ int bli_dlamc1(bla_integer *, bla_integer *, bla_logical *,
+	    bla_logical *);
+    extern bla_double bli_dlamc3(bla_double *, bla_double *);
+    static bla_logical lieee1;
+    extern /* Subroutine */ int bli_dlamc4(bla_integer *, bla_double *, bla_integer *),
+	    bli_dlamc5(bla_integer *, bla_integer *, bla_integer *, bla_logical *, bla_integer *,
+	    bla_double *);
+    static bla_integer lt, ngnmin, ngpmin;
+    static bla_double one, two;
 
     /* Fortran I/O blocks */
     //static cilist io___58 = { 0, 6, 0, fmt_9999, 0 };
@@ -541,7 +541,7 @@ explicitly.\002,/)";
 
 /*        Start to find EPS. */
 
-	b = (doublereal) lbeta;
+	b = (bla_double) lbeta;
 	i__1 = -lt;
 	a = bli_pow_di(&b, &i__1);
 	leps = a;
@@ -664,7 +664,7 @@ L10:
 	    first = TRUE_;
 /*
 	    s_wsfe(&io___58);
-	    do_fio(&c__1, (character *)&lemin, (ftnlen)sizeof(integer));
+	    do_fio(&c__1, (bla_character *)&lemin, (ftnlen)sizeof(bla_integer));
 	    e_wsfe();
 */
 	    printf( "%s", fmt_9999 );
@@ -715,10 +715,10 @@ L10:
 
 /* *********************************************************************** */
 
-doublereal bli_dlamc3(doublereal *a, doublereal *b)
+bla_double bli_dlamc3(bla_double *a, bla_double *b)
 {
     /* System generated locals */
-    doublereal ret_val;
+    bla_double ret_val;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -757,18 +757,18 @@ doublereal bli_dlamc3(doublereal *a, doublereal *b)
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_dlamc4(integer *emin, doublereal *start, integer *base)
+/* Subroutine */ int bli_dlamc4(bla_integer *emin, bla_double *start, bla_integer *base)
 {
     /* System generated locals */
-    integer i__1;
-    doublereal d__1;
+    bla_integer i__1;
+    bla_double d__1;
 
     /* Local variables */
-    static doublereal zero, a;
-    static integer i__;
-    static doublereal rbase, b1, b2, c1, c2, d1, d2;
-    extern doublereal bli_dlamc3(doublereal *, doublereal *);
-    static doublereal one;
+    static bla_double zero, a;
+    static bla_integer i__;
+    static bla_double rbase, b1, b2, c1, c2, d1, d2;
+    extern bla_double bli_dlamc3(bla_double *, bla_double *);
+    static bla_double one;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -855,22 +855,22 @@ L10:
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_dlamc5(integer *beta, integer *p, integer *emin, 
-	logical *ieee, integer *emax, doublereal *rmax)
+/* Subroutine */ int bli_dlamc5(bla_integer *beta, bla_integer *p, bla_integer *emin,
+	bla_logical *ieee, bla_integer *emax, bla_double *rmax)
 {
     /* System generated locals */
-    integer i__1;
-    doublereal d__1;
+    bla_integer i__1;
+    bla_double d__1;
 
     /* Local variables */
-    static integer lexp;
-    static doublereal oldy;
-    static integer uexp, i__;
-    static doublereal y, z__;
-    static integer nbits;
-    extern doublereal bli_dlamc3(doublereal *, doublereal *);
-    static doublereal recbas;
-    static integer exbits, expsum, try__;
+    static bla_integer lexp;
+    static bla_double oldy;
+    static bla_integer uexp, i__;
+    static bla_double y, z__;
+    static bla_integer nbits;
+    extern bla_double bli_dlamc3(bla_double *, bla_double *);
+    static bla_double recbas;
+    static bla_integer exbits, expsum, try__;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -904,7 +904,7 @@ L10:
 /*          The minimum exponent before (gradual) underflow. */
 
 /*  IEEE    (input) LOGICAL */
-/*          A logical flag specifying whether or not the arithmetic */
+/*          A bla_logical flag specifying whether or not the arithmetic */
 /*          system is thought to comply with the IEEE standard. */
 
 /*  EMAX    (output) INTEGER */

--- a/frame/base/noopt/bli_dlamch.h
+++ b/frame/base/noopt/bli_dlamch.h
@@ -32,4 +32,4 @@
 
 */
 
-doublereal bli_dlamch( character* cmach, ftnlen cmach_len );
+bla_double bli_dlamch( bla_character* cmach, ftnlen cmach_len );

--- a/frame/base/noopt/bli_lsame.c
+++ b/frame/base/noopt/bli_lsame.c
@@ -8,13 +8,13 @@ extern "C" {
 #endif
 #include "blis.h"
 
-logical bli_lsame(character *ca, character *cb, ftnlen ca_len, ftnlen cb_len)
+bla_logical bli_lsame(bla_character *ca, bla_character *cb, ftnlen ca_len, ftnlen cb_len)
 {
     /* System generated locals */
-    logical ret_val;
+    bla_logical ret_val;
 
     /* Local variables */
-    static integer inta, intb, zcode;
+    static bla_integer inta, intb, zcode;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -35,7 +35,7 @@ logical bli_lsame(character *ca, character *cb, ftnlen ca_len, ftnlen cb_len)
 
 /*  CA      (input) CHARACTER*1 */
 /*  CB      (input) CHARACTER*1 */
-/*          CA and CB specify the single characters to be compared. */
+/*          CA and CB specify the single bla_characters to be compared. */
 
 /* ===================================================================== */
 
@@ -45,14 +45,14 @@ logical bli_lsame(character *ca, character *cb, ftnlen ca_len, ftnlen cb_len)
 /*     .. */
 /*     .. Executable Statements .. */
 
-/*     Test if the characters are equal */
+/*     Test if the bla_characters are equal */
 
     ret_val = *(unsigned char *)ca == *(unsigned char *)cb;
     if (ret_val) {
 	return ret_val;
     }
 
-/*     Now test for equivalence if both characters are alphabetic. */
+/*     Now test for equivalence if both bla_characters are alphabetic. */
 
     zcode = 'Z';
 

--- a/frame/base/noopt/bli_lsame.h
+++ b/frame/base/noopt/bli_lsame.h
@@ -32,4 +32,4 @@
 
 */
 
-logical bli_lsame( character* ca, character* cb, ftnlen ca_len, ftnlen cb_len );
+bla_logical bli_lsame( bla_character* ca, bla_character* cb, ftnlen ca_len, ftnlen cb_len );

--- a/frame/base/noopt/bli_slamch.c
+++ b/frame/base/noopt/bli_slamch.c
@@ -8,17 +8,17 @@ extern "C" {
 #endif
 #include "blis.h"
 
-double bli_pow_ri( real* a, integer* n );
+double bli_pow_ri( bla_real* a, bla_integer* n );
 
 /* Table of constant values */
 
-//static integer c__1 = 1;
-static real c_b32 = (float)0.;
+//static bla_integer c__1 = 1;
+static bla_real c_b32 = (float)0.;
 
-double bli_pow_ri(real *ap, integer *bp)
+double bli_pow_ri(bla_real *ap, bla_integer *bp)
 {
 	double        pow, x;
-	integer       n;
+	bla_integer       n;
 	unsigned long u;
 
 	pow = 1;
@@ -45,32 +45,32 @@ double bli_pow_ri(real *ap, integer *bp)
 	return pow;
 }
 
-real bli_slamch(character *cmach, ftnlen cmach_len)
+bla_real bli_slamch(bla_character *cmach, ftnlen cmach_len)
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bla_logical first = TRUE_;
 
     /* System generated locals */
-    integer i__1;
-    real ret_val;
+    bla_integer i__1;
+    bla_real ret_val;
 
     /* Builtin functions */
-    double bli_pow_ri(real *, integer *);
+    double bli_pow_ri(bla_real *, bla_integer *);
 
     /* Local variables */
-    static real base;
-    static integer beta;
-    static real emin, prec, emax;
-    static integer imin, imax;
-    static logical lrnd;
-    static real rmin, rmax, t, rmach;
-    extern logical bli_lsame(character *, character *, ftnlen, ftnlen);
-    static real smnum, sfmin;
-    extern /* Subroutine */ int bli_slamc2(integer *, integer *, logical *, real 
-	    *, integer *, real *, integer *, real *);
-    static integer it;
-    static real rnd, eps;
+    static bla_real base;
+    static bla_integer beta;
+    static bla_real emin, prec, emax;
+    static bla_integer imin, imax;
+    static bla_logical lrnd;
+    static bla_real rmin, rmax, t, rmach;
+    extern bla_logical bli_lsame(bla_character *, bla_character *, ftnlen, ftnlen);
+    static bla_real smnum, sfmin;
+    extern /* Subroutine */ int bli_slamc2(bla_integer *, bla_integer *, bla_logical *, bla_real
+	    *, bla_integer *, bla_real *, bla_integer *, bla_real *);
+    static bla_integer it;
+    static bla_real rnd, eps;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -132,8 +132,8 @@ real bli_slamch(character *cmach, ftnlen cmach_len)
 
     if (first) {
 	bli_slamc2(&beta, &it, &lrnd, &eps, &imin, &rmin, &imax, &rmax);
-	base = (real) beta;
-	t = (real) it;
+	base = (bla_real) beta;
+	t = (bla_real) it;
 	if (lrnd) {
 	    rnd = (float)1.;
 	    i__1 = 1 - it;
@@ -144,8 +144,8 @@ real bli_slamch(character *cmach, ftnlen cmach_len)
 	    eps = bli_pow_ri(&base, &i__1);
 	}
 	prec = eps * base;
-	emin = (real) imin;
-	emax = (real) imax;
+	emin = (bla_real) imin;
+	emax = (bla_real) imax;
 	sfmin = rmin;
 	smnum = (float)1. / rmax;
 	if (smnum >= sfmin) {
@@ -190,26 +190,26 @@ real bli_slamch(character *cmach, ftnlen cmach_len)
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_slamc1(integer *beta, integer *t, logical *rnd, logical 
+/* Subroutine */ int bli_slamc1(bla_integer *beta, bla_integer *t, bla_logical *rnd, bla_logical
 	*ieee1)
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bla_logical first = TRUE_;
 
     /* System generated locals */
-    real r__1, r__2;
+    bla_real r__1, r__2;
 
     /* Local variables */
-    static logical lrnd;
-    static real a, b, c__, f;
-    static integer lbeta;
-    static real savec;
-    static logical lieee1;
-    static real t1, t2;
-    extern real bli_slamc3(real *, real *);
-    static integer lt;
-    static real one, qtr;
+    static bla_logical lrnd;
+    static bla_real a, b, c__, f;
+    static bla_integer lbeta;
+    static bla_real savec;
+    static bla_logical lieee1;
+    static bla_real t1, t2;
+    extern bla_real bli_slamc3(bla_real *, bla_real *);
+    static bla_integer lt;
+    static bla_real one, qtr;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -279,7 +279,7 @@ real bli_slamch(character *cmach, ftnlen cmach_len)
 /*        that relevant values are  stored and not held in registers,  or */
 /*        are not affected by optimizers. */
 
-/*        Compute  a = 2.0**m  with the  smallest positive integer m such */
+/*        Compute  a = 2.0**m  with the  smallest positive bla_integer m such */
 /*        that */
 
 /*           fl( a + 1.0 ) = a. */
@@ -298,7 +298,7 @@ L10:
 	}
 /* +       END WHILE */
 
-/*        Now compute  b = 2.0**m  with the smallest positive integer m */
+/*        Now compute  b = 2.0**m  with the smallest positive bla_integer m */
 /*        such that */
 
 /*           fl( a + b ) .gt. a. */
@@ -329,7 +329,7 @@ L20:
 /*        Now determine whether rounding or chopping occurs,  by adding a */
 /*        bit  less  than  beta/2  and a  bit  more  than  beta/2  to  a. */
 
-	b = (real) lbeta;
+	b = (bla_real) lbeta;
 	r__1 = b / 2;
 	r__2 = -b / 100;
 	f = bli_slamc3(&r__1, &r__2);
@@ -359,9 +359,9 @@ L20:
 	t2 = bli_slamc3(&r__1, &savec);
 	lieee1 = t1 == a && t2 > savec && lrnd;
 
-/*        Now find  the  mantissa, t.  It should  be the  integer part of */
+/*        Now find  the  mantissa, t.  It should  be the  bla_integer part of */
 /*        log to the base beta of a,  however it is safer to determine  t */
-/*        by powering.  So we find t as the smallest positive integer for */
+/*        by powering.  So we find t as the smallest positive bla_integer for */
 /*        which */
 
 /*           fl( beta**t + 1.0 ) = 1.0. */
@@ -398,49 +398,49 @@ L30:
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_slamc2(integer *beta, integer *t, logical *rnd, real *
-	eps, integer *emin, real *rmin, integer *emax, real *rmax)
+/* Subroutine */ int bli_slamc2(bla_integer *beta, bla_integer *t, bla_logical *rnd, bla_real *
+	eps, bla_integer *emin, bla_real *rmin, bla_integer *emax, bla_real *rmax)
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
-    static logical iwarn = FALSE_;
+    static bla_logical first = TRUE_;
+    static bla_logical iwarn = FALSE_;
 
     /* Format strings */
-    static character fmt_9999[] = "(//\002 WARNING. The value EMIN may be incorre\
+    static bla_character fmt_9999[] = "(//\002 WARNING. The value EMIN may be incorre\
 ct:-\002,\002  EMIN = \002,i8,/\002 If, after inspection, the value EMIN loo\
 ks\002,\002 acceptable please comment out \002,/\002 the IF block as marked \
 within the code of routine\002,\002 SLAMC2,\002,/\002 otherwise supply EMIN \
 explicitly.\002,/)";
 
     /* System generated locals */
-    integer i__1;
-    real r__1, r__2, r__3, r__4, r__5;
+    bla_integer i__1;
+    bla_real r__1, r__2, r__3, r__4, r__5;
 
     /* Builtin functions */
-    double bli_pow_ri(real *, integer *);
-    //integer s_wsfe(cilist *), do_fio(integer *, character *, ftnlen), e_wsfe();
+    double bli_pow_ri(bla_real *, bla_integer *);
+    //bla_integer s_wsfe(cilist *), do_fio(bla_integer *, bla_character *, ftnlen), e_wsfe();
 
     /* Local variables */
-    static logical ieee;
-    static real half;
-    static logical lrnd;
-    static real leps, zero, a, b, c__;
-    static integer i__, lbeta;
-    static real rbase;
-    static integer lemin, lemax, gnmin;
-    static real smnum;
-    static integer gpmin;
-    static real third, lrmin, lrmax, sixth;
-    static logical lieee1;
-    extern /* Subroutine */ int bli_slamc1(integer *, integer *, logical *, 
-	    logical *);
-    extern real bli_slamc3(real *, real *);
-    extern /* Subroutine */ int bli_slamc4(integer *, real *, integer *), 
-	    bli_slamc5(integer *, integer *, integer *, logical *, integer *, 
-	    real *);
-    static integer lt, ngnmin, ngpmin;
-    static real one, two;
+    static bla_logical ieee;
+    static bla_real half;
+    static bla_logical lrnd;
+    static bla_real leps, zero, a, b, c__;
+    static bla_integer i__, lbeta;
+    static bla_real rbase;
+    static bla_integer lemin, lemax, gnmin;
+    static bla_real smnum;
+    static bla_integer gpmin;
+    static bla_real third, lrmin, lrmax, sixth;
+    static bla_logical lieee1;
+    extern /* Subroutine */ int bli_slamc1(bla_integer *, bla_integer *, bla_logical *,
+	    bla_logical *);
+    extern bla_real bli_slamc3(bla_real *, bla_real *);
+    extern /* Subroutine */ int bli_slamc4(bla_integer *, bla_real *, bla_integer *),
+	    bli_slamc5(bla_integer *, bla_integer *, bla_integer *, bla_logical *, bla_integer *,
+	    bla_real *);
+    static bla_integer lt, ngnmin, ngpmin;
+    static bla_real one, two;
 
     /* Fortran I/O blocks */
     //static cilist io___58 = { 0, 6, 0, fmt_9999, 0 };
@@ -538,7 +538,7 @@ explicitly.\002,/)";
 
 /*        Start to find EPS. */
 
-	b = (real) lbeta;
+	b = (bla_real) lbeta;
 	i__1 = -lt;
 	a = bli_pow_ri(&b, &i__1);
 	leps = a;
@@ -660,7 +660,7 @@ L10:
 	    first = TRUE_;
 /*
 	    s_wsfe(&io___58);
-	    do_fio(&c__1, (character *)&lemin, (ftnlen)sizeof(integer));
+	    do_fio(&c__1, (bla_character *)&lemin, (ftnlen)sizeof(bla_integer));
 	    e_wsfe();
 */
 	    printf( "%s", fmt_9999 );
@@ -710,10 +710,10 @@ L10:
 
 /* *********************************************************************** */
 
-real bli_slamc3(real *a, real *b)
+bla_real bli_slamc3(bla_real *a, bla_real *b)
 {
     /* System generated locals */
-    real ret_val;
+    bla_real ret_val;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -752,18 +752,18 @@ real bli_slamc3(real *a, real *b)
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_slamc4(integer *emin, real *start, integer *base)
+/* Subroutine */ int bli_slamc4(bla_integer *emin, bla_real *start, bla_integer *base)
 {
     /* System generated locals */
-    integer i__1;
-    real r__1;
+    bla_integer i__1;
+    bla_real r__1;
 
     /* Local variables */
-    static real zero, a;
-    static integer i__;
-    static real rbase, b1, b2, c1, c2, d1, d2;
-    extern real bli_slamc3(real *, real *);
-    static real one;
+    static bla_real zero, a;
+    static bla_integer i__;
+    static bla_real rbase, b1, b2, c1, c2, d1, d2;
+    extern bla_real bli_slamc3(bla_real *, bla_real *);
+    static bla_real one;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -850,22 +850,22 @@ L10:
 
 /* *********************************************************************** */
 
-/* Subroutine */ int bli_slamc5(integer *beta, integer *p, integer *emin, 
-	logical *ieee, integer *emax, real *rmax)
+/* Subroutine */ int bli_slamc5(bla_integer *beta, bla_integer *p, bla_integer *emin,
+	bla_logical *ieee, bla_integer *emax, bla_real *rmax)
 {
     /* System generated locals */
-    integer i__1;
-    real r__1;
+    bla_integer i__1;
+    bla_real r__1;
 
     /* Local variables */
-    static integer lexp;
-    static real oldy;
-    static integer uexp, i__;
-    static real y, z__;
-    static integer nbits;
-    extern real bli_slamc3(real *, real *);
-    static real recbas;
-    static integer exbits, expsum, try__;
+    static bla_integer lexp;
+    static bla_real oldy;
+    static bla_integer uexp, i__;
+    static bla_real y, z__;
+    static bla_integer nbits;
+    extern bla_real bli_slamc3(bla_real *, bla_real *);
+    static bla_real recbas;
+    static bla_integer exbits, expsum, try__;
 
 
 /*  -- LAPACK auxiliary routine (version 3.2) -- */
@@ -899,7 +899,7 @@ L10:
 /*          The minimum exponent before (gradual) underflow. */
 
 /*  IEEE    (input) LOGICAL */
-/*          A logical flag specifying whether or not the arithmetic */
+/*          A bla_logical flag specifying whether or not the arithmetic */
 /*          system is thought to comply with the IEEE standard. */
 
 /*  EMAX    (output) INTEGER */

--- a/frame/base/noopt/bli_slamch.h
+++ b/frame/base/noopt/bli_slamch.h
@@ -32,4 +32,4 @@
 
 */
 
-real bli_slamch( character* cmach, ftnlen cmach_len );
+bla_real bli_slamch( bla_character* cmach, ftnlen cmach_len );

--- a/frame/compat/f2c/bla_gbmv.c
+++ b/frame/compat/f2c/bla_gbmv.c
@@ -1382,7 +1382,7 @@
 
 /*     Quick return if possible. */
 
-    if (*m == 0 || *n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zbla_real(*beta) == 
+    if (*m == 0 || *n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zreal(*beta) == 
 	    1. && bli_zimag(*beta) == 0.))) {
 	return 0;
     }
@@ -1415,9 +1415,9 @@
 
 /*     First form  y := beta*y. */
 
-    if (bli_zbla_real(*beta) != 1. || bli_zimag(*beta) != 0.) {
+    if (bli_zreal(*beta) != 1. || bli_zimag(*beta) != 0.) {
 	if (*incy == 1) {
-	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = leny;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
@@ -1429,14 +1429,14 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
 		    i__3 = i__;
-		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L20: */
 		}
 	    }
 	} else {
 	    iy = ky;
-	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = leny;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
@@ -1449,15 +1449,15 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
 		    i__3 = iy;
-		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    iy += *incy;
 /* L40: */
 		}
 	    }
 	}
     }
-    if (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
+    if (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
 	return 0;
     }
     kup1 = *ku + 1;
@@ -1470,10 +1470,10 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 		    k = kup1 - j;
 /* Computing MAX */
 		    i__2 = 1, i__3 = j - *ku;
@@ -1484,9 +1484,9 @@
 			i__2 = i__;
 			i__3 = i__;
 			i__5 = k + i__ + j * a_dim1;
-			bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
-			bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+			bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
+			bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L50: */
 		    }
 		}
@@ -1497,10 +1497,10 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__4 = jx;
-		if (bli_zbla_real(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
+		if (bli_zreal(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zbla_real(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zbla_real(x[i__4])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zreal(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zreal(x[i__4])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 		    iy = ky;
 		    k = kup1 - j;
 /* Computing MAX */
@@ -1512,9 +1512,9 @@
 			i__4 = iy;
 			i__2 = iy;
 			i__5 = k + i__ + j * a_dim1;
-			bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
-			bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
+			bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
+			bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
 			iy += *incy;
 /* L70: */
 		    }
@@ -1545,9 +1545,9 @@
 		    for (i__ = f2c_max(i__3,i__4); i__ <= i__2; ++i__) {
 			i__3 = k + i__ + j * a_dim1;
 			i__4 = i__;
-			bli_zsets( (bli_zbla_real(a[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zbla_real(x[i__4])), z__2 );
-			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zreal(a[i__3]) * bli_zreal(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zreal(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zreal(x[i__4])), z__2 );
+			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L90: */
 		    }
 		} else {
@@ -1559,17 +1559,17 @@
 		    for (i__ = f2c_max(i__2,i__3); i__ <= i__4; ++i__) {
 			bla_d_cnjg(&z__3, &a[k + i__ + j * a_dim1]);
 			i__2 = i__;
-			bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L100: */
 		    }
 		}
 		i__4 = jy;
 		i__2 = jy;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zbla_real(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zbla_real(temp)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zreal(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zreal(temp)), z__2 );
+		bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
 		jy += *incy;
 /* L110: */
 	    }
@@ -1588,9 +1588,9 @@
 		    for (i__ = f2c_max(i__4,i__2); i__ <= i__3; ++i__) {
 			i__4 = k + i__ + j * a_dim1;
 			i__2 = ix;
-			bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__2])), z__2 );
-			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zreal(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zreal(x[i__2])), z__2 );
+			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			ix += *incx;
 /* L120: */
 		    }
@@ -1603,18 +1603,18 @@
 		    for (i__ = f2c_max(i__3,i__4); i__ <= i__2; ++i__) {
 			bla_d_cnjg(&z__3, &a[k + i__ + j * a_dim1]);
 			i__3 = ix;
-			bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			ix += *incx;
 /* L130: */
 		    }
 		}
 		i__2 = jy;
 		i__3 = jy;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zbla_real(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zbla_real(temp)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zreal(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zreal(temp)), z__2 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		jy += *incy;
 		if (j > *ku) {
 		    kx += *incx;

--- a/frame/compat/f2c/bla_gbmv.c
+++ b/frame/compat/f2c/bla_gbmv.c
@@ -41,24 +41,24 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, singlecomplex *alpha, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y, integer *incy)
+/* Subroutine */ int PASTEF77(c,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_scomplex *alpha, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx, bla_scomplex *beta, bla_scomplex *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
-    singlecomplex q__1, q__2, q__3;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp;
-    integer lenx, leny, i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj;
-    integer kup1;
+    bla_integer info;
+    bla_scomplex temp;
+    bla_integer lenx, leny, i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj;
+    bla_integer kup1;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -482,19 +482,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, doublereal *alpha, doublereal *a, integer *lda, doublereal *x, integer *incx, doublereal *beta, doublereal *y, integer *incy)
+/* Subroutine */ int PASTEF77(d,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_double *alpha, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx, bla_double *beta, bla_double *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
 
     /* Local variables */
-    integer info;
-    doublereal temp;
-    integer lenx, leny, i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    integer kup1;
+    bla_integer info;
+    bla_double temp;
+    bla_integer lenx, leny, i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_integer kup1;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -838,19 +838,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, real *alpha, real *a, integer *lda, real *x, integer * incx, real *beta, real *y, integer *incy)
+/* Subroutine */ int PASTEF77(s,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_real *alpha, bla_real *a, bla_integer *lda, bla_real *x, bla_integer * incx, bla_real *beta, bla_real *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
 
     /* Local variables */
-    integer info;
-    real temp;
-    integer lenx, leny, i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    integer kup1;
+    bla_integer info;
+    bla_real temp;
+    bla_integer lenx, leny, i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_integer kup1;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1194,24 +1194,24 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex * y, integer *incy)
+/* Subroutine */ int PASTEF77(z,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_dcomplex *alpha, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *beta, bla_dcomplex * y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
-    doublecomplex z__1, z__2, z__3;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    bla_dcomplex z__1, z__2, z__3;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp;
-    integer lenx, leny, i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj;
-    integer kup1;
+    bla_integer info;
+    bla_dcomplex temp;
+    bla_integer lenx, leny, i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj;
+    bla_integer kup1;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1382,7 +1382,7 @@
 
 /*     Quick return if possible. */
 
-    if (*m == 0 || *n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zreal(*beta) == 
+    if (*m == 0 || *n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zbla_real(*beta) == 
 	    1. && bli_zimag(*beta) == 0.))) {
 	return 0;
     }
@@ -1415,9 +1415,9 @@
 
 /*     First form  y := beta*y. */
 
-    if (bli_zreal(*beta) != 1. || bli_zimag(*beta) != 0.) {
+    if (bli_zbla_real(*beta) != 1. || bli_zimag(*beta) != 0.) {
 	if (*incy == 1) {
-	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = leny;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
@@ -1429,14 +1429,14 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
 		    i__3 = i__;
-		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L20: */
 		}
 	    }
 	} else {
 	    iy = ky;
-	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = leny;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
@@ -1449,15 +1449,15 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
 		    i__3 = iy;
-		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    iy += *incy;
 /* L40: */
 		}
 	    }
 	}
     }
-    if (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
+    if (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
 	return 0;
     }
     kup1 = *ku + 1;
@@ -1470,10 +1470,10 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 		    k = kup1 - j;
 /* Computing MAX */
 		    i__2 = 1, i__3 = j - *ku;
@@ -1484,9 +1484,9 @@
 			i__2 = i__;
 			i__3 = i__;
 			i__5 = k + i__ + j * a_dim1;
-			bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
-			bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+			bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
+			bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L50: */
 		    }
 		}
@@ -1497,10 +1497,10 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__4 = jx;
-		if (bli_zreal(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
+		if (bli_zbla_real(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zreal(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zreal(x[i__4])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zbla_real(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zbla_real(x[i__4])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 		    iy = ky;
 		    k = kup1 - j;
 /* Computing MAX */
@@ -1512,9 +1512,9 @@
 			i__4 = iy;
 			i__2 = iy;
 			i__5 = k + i__ + j * a_dim1;
-			bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
-			bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
+			bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
+			bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
 			iy += *incy;
 /* L70: */
 		    }
@@ -1545,9 +1545,9 @@
 		    for (i__ = f2c_max(i__3,i__4); i__ <= i__2; ++i__) {
 			i__3 = k + i__ + j * a_dim1;
 			i__4 = i__;
-			bli_zsets( (bli_zreal(a[i__3]) * bli_zreal(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zreal(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zreal(x[i__4])), z__2 );
-			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zbla_real(a[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zbla_real(x[i__4])), z__2 );
+			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L90: */
 		    }
 		} else {
@@ -1559,17 +1559,17 @@
 		    for (i__ = f2c_max(i__2,i__3); i__ <= i__4; ++i__) {
 			bla_d_cnjg(&z__3, &a[k + i__ + j * a_dim1]);
 			i__2 = i__;
-			bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L100: */
 		    }
 		}
 		i__4 = jy;
 		i__2 = jy;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zreal(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zreal(temp)), z__2 );
-		bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zbla_real(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zbla_real(temp)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
 		jy += *incy;
 /* L110: */
 	    }
@@ -1588,9 +1588,9 @@
 		    for (i__ = f2c_max(i__4,i__2); i__ <= i__3; ++i__) {
 			i__4 = k + i__ + j * a_dim1;
 			i__2 = ix;
-			bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zreal(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zreal(x[i__2])), z__2 );
-			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__2])), z__2 );
+			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			ix += *incx;
 /* L120: */
 		    }
@@ -1603,18 +1603,18 @@
 		    for (i__ = f2c_max(i__3,i__4); i__ <= i__2; ++i__) {
 			bla_d_cnjg(&z__3, &a[k + i__ + j * a_dim1]);
 			i__3 = ix;
-			bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-			bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+			bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			ix += *incx;
 /* L130: */
 		    }
 		}
 		i__2 = jy;
 		i__3 = jy;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zreal(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zreal(temp)), z__2 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp) - bli_zimag(*alpha) * bli_zimag(temp)), (bli_zbla_real(*alpha) * bli_zimag(temp) + bli_zimag(*alpha) * bli_zbla_real(temp)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		jy += *incy;
 		if (j > *ku) {
 		    kx += *incx;

--- a/frame/compat/f2c/bla_gbmv.h
+++ b/frame/compat/f2c/bla_gbmv.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, singlecomplex *alpha, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y, integer *incy);
-int PASTEF77(d,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, doublereal *alpha, doublereal *a, integer *lda, doublereal *x, integer *incx, doublereal *beta, doublereal *y, integer *incy);
-int PASTEF77(s,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, real *alpha, real *a, integer *lda, real *x, integer * incx, real *beta, real *y, integer *incy);
-int PASTEF77(z,gbmv)(character *trans, integer *m, integer *n, integer *kl, integer *ku, doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex * y, integer *incy);
+int PASTEF77(c,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_scomplex *alpha, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx, bla_scomplex *beta, bla_scomplex *y, bla_integer *incy);
+int PASTEF77(d,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_double *alpha, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx, bla_double *beta, bla_double *y, bla_integer *incy);
+int PASTEF77(s,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_real *alpha, bla_real *a, bla_integer *lda, bla_real *x, bla_integer * incx, bla_real *beta, bla_real *y, bla_integer *incy);
+int PASTEF77(z,gbmv)(bla_character *trans, bla_integer *m, bla_integer *n, bla_integer *kl, bla_integer *ku, bla_dcomplex *alpha, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *beta, bla_dcomplex * y, bla_integer *incy);
 
 #endif

--- a/frame/compat/f2c/bla_hbmv.c
+++ b/frame/compat/f2c/bla_hbmv.c
@@ -671,7 +671,7 @@
 
 /*     Quick return if possible. */
 
-    if (*n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zbla_real(*beta) == 1. && 
+    if (*n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zreal(*beta) == 1. && 
 	    bli_zimag(*beta) == 0.))) {
 	return 0;
     }
@@ -694,9 +694,9 @@
 
 /*     First form  y := beta*y. */
 
-    if (bli_zbla_real(*beta) != 1. || bli_zimag(*beta) != 0.) {
+    if (bli_zreal(*beta) != 1. || bli_zimag(*beta) != 0.) {
 	if (*incy == 1) {
-	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
@@ -708,14 +708,14 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
 		    i__3 = i__;
-		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L20: */
 		}
 	    }
 	} else {
 	    iy = ky;
-	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
@@ -728,15 +728,15 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
 		    i__3 = iy;
-		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    iy += *incy;
 /* L40: */
 		}
 	    }
 	}
     }
-    if (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
+    if (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
 	return 0;
     }
     if (PASTEF770(lsame)(uplo, "U", (ftnlen)1, (ftnlen)1)) {
@@ -748,8 +748,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		l = kplus1 - j;
 /* Computing MAX */
@@ -759,25 +759,25 @@
 		    i__2 = i__;
 		    i__3 = i__;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__2 = i__;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 /* L50: */
 		}
 		i__4 = j;
 		i__2 = j;
 		i__3 = kplus1 + j * a_dim1;
-		d__1 = bli_zbla_real(a[i__3]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__3)), (bli_zimag(y[i__2]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
-		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
+		d__1 = bli_zreal(a[i__3]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__3)), (bli_zimag(y[i__2]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
+		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
 /* L60: */
 	    }
 	} else {
@@ -786,8 +786,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__4 = jx;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zbla_real(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zbla_real(x[i__4])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zreal(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zreal(x[i__4])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		ix = kx;
 		iy = ky;
@@ -799,14 +799,14 @@
 		    i__4 = iy;
 		    i__2 = iy;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__4 = ix;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    ix += *incx;
 		    iy += *incy;
 /* L70: */
@@ -814,12 +814,12 @@
 		i__3 = jy;
 		i__4 = jy;
 		i__2 = kplus1 + j * a_dim1;
-		d__1 = bli_zbla_real(a[i__2]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__3)), (bli_zimag(y[i__4]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
-		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		d__1 = bli_zreal(a[i__2]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__3)), (bli_zimag(y[i__4]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
+		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		jx += *incx;
 		jy += *incy;
 		if (j > *k) {
@@ -837,16 +837,16 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__3 = j;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zbla_real(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zbla_real(x[i__3])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zreal(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zreal(x[i__3])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__3 = j;
 		i__4 = j;
 		i__2 = j * a_dim1 + 1;
-		d__1 = bli_zbla_real(a[i__2]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		d__1 = bli_zreal(a[i__2]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		l = 1 - j;
 /* Computing MIN */
 		i__4 = *n, i__2 = j + *k;
@@ -855,21 +855,21 @@
 		    i__4 = i__;
 		    i__2 = i__;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__4 = i__;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 /* L90: */
 		}
 		i__3 = j;
 		i__4 = j;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
+		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 /* L100: */
 	    }
 	} else {
@@ -878,16 +878,16 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__3 = jx;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zbla_real(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zbla_real(x[i__3])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zreal(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zreal(x[i__3])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__3 = jy;
 		i__4 = jy;
 		i__2 = j * a_dim1 + 1;
-		d__1 = bli_zbla_real(a[i__2]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		d__1 = bli_zreal(a[i__2]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		l = 1 - j;
 		ix = jx;
 		iy = jy;
@@ -900,21 +900,21 @@
 		    i__4 = iy;
 		    i__2 = iy;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__4 = ix;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 /* L110: */
 		}
 		i__3 = jy;
 		i__4 = jy;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
+		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		jx += *incx;
 		jy += *incy;
 /* L120: */

--- a/frame/compat/f2c/bla_hbmv.c
+++ b/frame/compat/f2c/bla_hbmv.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,hbmv)(character *uplo, integer *n, integer *k, singlecomplex * alpha, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y, integer *incy)
+/* Subroutine */ int PASTEF77(c,hbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_scomplex * alpha, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx, bla_scomplex *beta, bla_scomplex *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
-    real r__1;
-    singlecomplex q__1, q__2, q__3, q__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+    bla_real r__1;
+    bla_scomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp1, temp2;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_scomplex temp1, temp2;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -487,23 +487,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,hbmv)(character *uplo, integer *n, integer *k, doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x, integer * incx, doublecomplex *beta, doublecomplex *y, integer *incy)
+/* Subroutine */ int PASTEF77(z,hbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_dcomplex *alpha, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer * incx, bla_dcomplex *beta, bla_dcomplex *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
-    doublereal d__1;
-    doublecomplex z__1, z__2, z__3, z__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+    bla_double d__1;
+    bla_dcomplex z__1, z__2, z__3, z__4;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp1, temp2;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_dcomplex temp1, temp2;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -671,7 +671,7 @@
 
 /*     Quick return if possible. */
 
-    if (*n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zreal(*beta) == 1. && 
+    if (*n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zbla_real(*beta) == 1. && 
 	    bli_zimag(*beta) == 0.))) {
 	return 0;
     }
@@ -694,9 +694,9 @@
 
 /*     First form  y := beta*y. */
 
-    if (bli_zreal(*beta) != 1. || bli_zimag(*beta) != 0.) {
+    if (bli_zbla_real(*beta) != 1. || bli_zimag(*beta) != 0.) {
 	if (*incy == 1) {
-	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
@@ -708,14 +708,14 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
 		    i__3 = i__;
-		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L20: */
 		}
 	    }
 	} else {
 	    iy = ky;
-	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
@@ -728,15 +728,15 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
 		    i__3 = iy;
-		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    iy += *incy;
 /* L40: */
 		}
 	    }
 	}
     }
-    if (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
+    if (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
 	return 0;
     }
     if (PASTEF770(lsame)(uplo, "U", (ftnlen)1, (ftnlen)1)) {
@@ -748,8 +748,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		l = kplus1 - j;
 /* Computing MAX */
@@ -759,25 +759,25 @@
 		    i__2 = i__;
 		    i__3 = i__;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__2 = i__;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 /* L50: */
 		}
 		i__4 = j;
 		i__2 = j;
 		i__3 = kplus1 + j * a_dim1;
-		d__1 = bli_zreal(a[i__3]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__3)), (bli_zimag(y[i__2]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
-		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
+		d__1 = bli_zbla_real(a[i__3]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__3)), (bli_zimag(y[i__2]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
+		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
 /* L60: */
 	    }
 	} else {
@@ -786,8 +786,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__4 = jx;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zreal(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zreal(x[i__4])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__4]) - bli_zimag(*alpha) * bli_zimag(x[i__4])), (bli_zbla_real(*alpha) * bli_zimag(x[i__4]) + bli_zimag(*alpha) * bli_zbla_real(x[i__4])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		ix = kx;
 		iy = ky;
@@ -799,14 +799,14 @@
 		    i__4 = iy;
 		    i__2 = iy;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__4 = ix;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    ix += *incx;
 		    iy += *incy;
 /* L70: */
@@ -814,12 +814,12 @@
 		i__3 = jy;
 		i__4 = jy;
 		i__2 = kplus1 + j * a_dim1;
-		d__1 = bli_zreal(a[i__2]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__3)), (bli_zimag(y[i__4]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
-		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		d__1 = bli_zbla_real(a[i__2]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__3)), (bli_zimag(y[i__4]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
+		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		jx += *incx;
 		jy += *incy;
 		if (j > *k) {
@@ -837,16 +837,16 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__3 = j;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zreal(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zreal(x[i__3])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zbla_real(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zbla_real(x[i__3])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__3 = j;
 		i__4 = j;
 		i__2 = j * a_dim1 + 1;
-		d__1 = bli_zreal(a[i__2]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		d__1 = bli_zbla_real(a[i__2]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		l = 1 - j;
 /* Computing MIN */
 		i__4 = *n, i__2 = j + *k;
@@ -855,21 +855,21 @@
 		    i__4 = i__;
 		    i__2 = i__;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__4 = i__;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 /* L90: */
 		}
 		i__3 = j;
 		i__4 = j;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
-		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 /* L100: */
 	    }
 	} else {
@@ -878,16 +878,16 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__3 = jx;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zreal(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zreal(x[i__3])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__3]) - bli_zimag(*alpha) * bli_zimag(x[i__3])), (bli_zbla_real(*alpha) * bli_zimag(x[i__3]) + bli_zimag(*alpha) * bli_zbla_real(x[i__3])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__3 = jy;
 		i__4 = jy;
 		i__2 = j * a_dim1 + 1;
-		d__1 = bli_zreal(a[i__2]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		d__1 = bli_zbla_real(a[i__2]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		l = 1 - j;
 		ix = jx;
 		iy = jy;
@@ -900,21 +900,21 @@
 		    i__4 = iy;
 		    i__2 = iy;
 		    i__5 = l + i__ + j * a_dim1;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zreal(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zreal(a[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__2]) + bli_zreal(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__4] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(a[i__5]) - bli_zimag(temp1) * bli_zimag(a[i__5])), (bli_zbla_real(temp1) * bli_zimag(a[i__5]) + bli_zimag(temp1) * bli_zbla_real(a[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__2]) + bli_zbla_real(z__2)), (bli_zimag(y[i__2]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__4] );
 		    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 		    i__4 = ix;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 /* L110: */
 		}
 		i__3 = jy;
 		i__4 = jy;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
-		bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		jx += *incx;
 		jy += *incy;
 /* L120: */

--- a/frame/compat/f2c/bla_hbmv.h
+++ b/frame/compat/f2c/bla_hbmv.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,hbmv)(character *uplo, integer *n, integer *k, singlecomplex * alpha, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y, integer *incy);
-int PASTEF77(z,hbmv)(character *uplo, integer *n, integer *k, doublecomplex *alpha, doublecomplex *a, integer *lda, doublecomplex *x, integer * incx, doublecomplex *beta, doublecomplex *y, integer *incy);
+int PASTEF77(c,hbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_scomplex * alpha, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx, bla_scomplex *beta, bla_scomplex *y, bla_integer *incy);
+int PASTEF77(z,hbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_dcomplex *alpha, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer * incx, bla_dcomplex *beta, bla_dcomplex *y, bla_integer *incy);
 
 #endif

--- a/frame/compat/f2c/bla_hpmv.c
+++ b/frame/compat/f2c/bla_hpmv.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,hpmv)(character *uplo, integer *n, singlecomplex *alpha, singlecomplex * ap, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y, integer *incy)
+/* Subroutine */ int PASTEF77(c,hpmv)(bla_character *uplo, bla_integer *n, bla_scomplex *alpha, bla_scomplex * ap, bla_scomplex *x, bla_integer *incx, bla_scomplex *beta, bla_scomplex *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    real r__1;
-    singlecomplex q__1, q__2, q__3, q__4;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_real r__1;
+    bla_scomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_scomplex temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -439,23 +439,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,hpmv)(character *uplo, integer *n, doublecomplex *alpha, doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex *y, integer *incy)
+/* Subroutine */ int PASTEF77(z,hpmv)(bla_character *uplo, bla_integer *n, bla_dcomplex *alpha, bla_dcomplex *ap, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *beta, bla_dcomplex *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    doublereal d__1;
-    doublecomplex z__1, z__2, z__3, z__4;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_double d__1;
+    bla_dcomplex z__1, z__2, z__3, z__4;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_dcomplex temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -583,7 +583,7 @@
 
 /*     Quick return if possible. */
 
-    if (*n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zreal(*beta) == 1. && 
+    if (*n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zbla_real(*beta) == 1. && 
 	    bli_zimag(*beta) == 0.))) {
 	return 0;
     }
@@ -606,9 +606,9 @@
 
 /*     First form  y := beta*y. */
 
-    if (bli_zreal(*beta) != 1. || bli_zimag(*beta) != 0.) {
+    if (bli_zbla_real(*beta) != 1. || bli_zimag(*beta) != 0.) {
 	if (*incy == 1) {
-	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
@@ -620,14 +620,14 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
 		    i__3 = i__;
-		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L20: */
 		}
 	    }
 	} else {
 	    iy = ky;
-	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
@@ -640,15 +640,15 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
 		    i__3 = iy;
-		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    iy += *incy;
 /* L40: */
 		}
 	    }
 	}
     }
-    if (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
+    if (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
 	return 0;
     }
     kk = 1;
@@ -660,8 +660,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		k = kk;
 		i__2 = j - 1;
@@ -669,26 +669,26 @@
 		    i__3 = i__;
 		    i__4 = i__;
 		    i__5 = k;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = i__;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    ++k;
 /* L50: */
 		}
 		i__2 = j;
 		i__3 = j;
 		i__4 = kk + j - 1;
-		d__1 = bli_zreal(ap[i__4]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
-		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zbla_real(ap[i__4]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
+		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		kk += j;
 /* L60: */
 	    }
@@ -698,8 +698,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		ix = kx;
 		iy = ky;
@@ -708,14 +708,14 @@
 		    i__3 = iy;
 		    i__4 = iy;
 		    i__5 = k;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = ix;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    ix += *incx;
 		    iy += *incy;
 /* L70: */
@@ -723,12 +723,12 @@
 		i__2 = jy;
 		i__3 = jy;
 		i__4 = kk + j - 1;
-		d__1 = bli_zreal(ap[i__4]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
-		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zbla_real(ap[i__4]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
+		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		jx += *incx;
 		jy += *incy;
 		kk += j;
@@ -743,38 +743,38 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__2 = j;
 		i__3 = j;
 		i__4 = kk;
-		d__1 = bli_zreal(ap[i__4]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zbla_real(ap[i__4]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		k = kk + 1;
 		i__2 = *n;
 		for (i__ = j + 1; i__ <= i__2; ++i__) {
 		    i__3 = i__;
 		    i__4 = i__;
 		    i__5 = k;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = i__;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    ++k;
 /* L90: */
 		}
 		i__2 = j;
 		i__3 = j;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		kk += *n - j + 1;
 /* L100: */
 	    }
@@ -784,16 +784,16 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__2 = jy;
 		i__3 = jy;
 		i__4 = kk;
-		d__1 = bli_zreal(ap[i__4]);
-		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zbla_real(ap[i__4]);
+		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		ix = jx;
 		iy = jy;
 		i__2 = kk + *n - j;
@@ -803,21 +803,21 @@
 		    i__3 = iy;
 		    i__4 = iy;
 		    i__5 = k;
-		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = ix;
-		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 /* L110: */
 		}
 		i__2 = jy;
 		i__3 = jy;
-		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
-		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
+		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
+		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
 		jx += *incx;
 		jy += *incy;
 		kk += *n - j + 1;

--- a/frame/compat/f2c/bla_hpmv.c
+++ b/frame/compat/f2c/bla_hpmv.c
@@ -583,7 +583,7 @@
 
 /*     Quick return if possible. */
 
-    if (*n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zbla_real(*beta) == 1. && 
+    if (*n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0. && (bli_zreal(*beta) == 1. && 
 	    bli_zimag(*beta) == 0.))) {
 	return 0;
     }
@@ -606,9 +606,9 @@
 
 /*     First form  y := beta*y. */
 
-    if (bli_zbla_real(*beta) != 1. || bli_zimag(*beta) != 0.) {
+    if (bli_zreal(*beta) != 1. || bli_zimag(*beta) != 0.) {
 	if (*incy == 1) {
-	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
@@ -620,14 +620,14 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = i__;
 		    i__3 = i__;
-		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 /* L20: */
 		}
 	    }
 	} else {
 	    iy = ky;
-	    if (bli_zbla_real(*beta) == 0. && bli_zimag(*beta) == 0.) {
+	    if (bli_zreal(*beta) == 0. && bli_zimag(*beta) == 0.) {
 		i__1 = *n;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
@@ -640,15 +640,15 @@
 		for (i__ = 1; i__ <= i__1; ++i__) {
 		    i__2 = iy;
 		    i__3 = iy;
-		    bli_zsets( (bli_zbla_real(*beta) * bli_zbla_real(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zbla_real(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zbla_real(y[i__3])), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		    bli_zsets( (bli_zreal(*beta) * bli_zreal(y[i__3]) - bli_zimag(*beta) * bli_zimag(y[i__3])), (bli_zreal(*beta) * bli_zimag(y[i__3]) + bli_zimag(*beta) * bli_zreal(y[i__3])), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		    iy += *incy;
 /* L40: */
 		}
 	    }
 	}
     }
-    if (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
+    if (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.) {
 	return 0;
     }
     kk = 1;
@@ -660,8 +660,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		k = kk;
 		i__2 = j - 1;
@@ -669,26 +669,26 @@
 		    i__3 = i__;
 		    i__4 = i__;
 		    i__5 = k;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = i__;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    ++k;
 /* L50: */
 		}
 		i__2 = j;
 		i__3 = j;
 		i__4 = kk + j - 1;
-		d__1 = bli_zbla_real(ap[i__4]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
-		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zreal(ap[i__4]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
+		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		kk += j;
 /* L60: */
 	    }
@@ -698,8 +698,8 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		ix = kx;
 		iy = ky;
@@ -708,14 +708,14 @@
 		    i__3 = iy;
 		    i__4 = iy;
 		    i__5 = k;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = ix;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    ix += *incx;
 		    iy += *incy;
 /* L70: */
@@ -723,12 +723,12 @@
 		i__2 = jy;
 		i__3 = jy;
 		i__4 = kk + j - 1;
-		d__1 = bli_zbla_real(ap[i__4]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__4 );
-		bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zreal(ap[i__4]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__3 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__3)), (bli_zimag(y[i__3]) + bli_zimag(z__3)), z__2 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__4 );
+		bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		jx += *incx;
 		jy += *incy;
 		kk += j;
@@ -743,38 +743,38 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__2 = j;
 		i__3 = j;
 		i__4 = kk;
-		d__1 = bli_zbla_real(ap[i__4]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zreal(ap[i__4]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		k = kk + 1;
 		i__2 = *n;
 		for (i__ = j + 1; i__ <= i__2; ++i__) {
 		    i__3 = i__;
 		    i__4 = i__;
 		    i__5 = k;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = i__;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    ++k;
 /* L90: */
 		}
 		i__2 = j;
 		i__3 = j;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		kk += *n - j + 1;
 /* L100: */
 	    }
@@ -784,16 +784,16 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		bli_zsets( (0.), (0.), temp2 );
 		i__2 = jy;
 		i__3 = jy;
 		i__4 = kk;
-		d__1 = bli_zbla_real(ap[i__4]);
-		bli_zsets( (d__1 * bli_zbla_real(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		d__1 = bli_zreal(ap[i__4]);
+		bli_zsets( (d__1 * bli_zreal(temp1)), (d__1 * bli_zimag(temp1)), z__2 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		ix = jx;
 		iy = jy;
 		i__2 = kk + *n - j;
@@ -803,21 +803,21 @@
 		    i__3 = iy;
 		    i__4 = iy;
 		    i__5 = k;
-		    bli_zsets( (bli_zbla_real(temp1) * bli_zbla_real(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zbla_real(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zbla_real(ap[i__5])), z__2 );
-		    bli_zsets( (bli_zbla_real(y[i__4]) + bli_zbla_real(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__3] );
+		    bli_zsets( (bli_zreal(temp1) * bli_zreal(ap[i__5]) - bli_zimag(temp1) * bli_zimag(ap[i__5])), (bli_zreal(temp1) * bli_zimag(ap[i__5]) + bli_zimag(temp1) * bli_zreal(ap[i__5])), z__2 );
+		    bli_zsets( (bli_zreal(y[i__4]) + bli_zreal(z__2)), (bli_zimag(y[i__4]) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__3] );
 		    bla_d_cnjg(&z__3, &ap[k]);
 		    i__3 = ix;
-		    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-		    bli_zsets( (bli_zbla_real(temp2) + bli_zbla_real(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+		    bli_zsets( (bli_zreal(temp2) + bli_zreal(z__2)), (bli_zimag(temp2) + bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 /* L110: */
 		}
 		i__2 = jy;
 		i__3 = jy;
-		bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zbla_real(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zbla_real(temp2)), z__2 );
-		bli_zsets( (bli_zbla_real(y[i__3]) + bli_zbla_real(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
-		bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), y[i__2] );
+		bli_zsets( (bli_zreal(*alpha) * bli_zreal(temp2) - bli_zimag(*alpha) * bli_zimag(temp2)), (bli_zreal(*alpha) * bli_zimag(temp2) + bli_zimag(*alpha) * bli_zreal(temp2)), z__2 );
+		bli_zsets( (bli_zreal(y[i__3]) + bli_zreal(z__2)), (bli_zimag(y[i__3]) + bli_zimag(z__2)), z__1 );
+		bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), y[i__2] );
 		jx += *incx;
 		jy += *incy;
 		kk += *n - j + 1;

--- a/frame/compat/f2c/bla_hpmv.h
+++ b/frame/compat/f2c/bla_hpmv.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,hpmv)(character *uplo, integer *n, singlecomplex *alpha, singlecomplex * ap, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y, integer *incy);
-int PASTEF77(z,hpmv)(character *uplo, integer *n, doublecomplex *alpha, doublecomplex *ap, doublecomplex *x, integer *incx, doublecomplex *beta, doublecomplex *y, integer *incy);
+int PASTEF77(c,hpmv)(bla_character *uplo, bla_integer *n, bla_scomplex *alpha, bla_scomplex * ap, bla_scomplex *x, bla_integer *incx, bla_scomplex *beta, bla_scomplex *y, bla_integer *incy);
+int PASTEF77(z,hpmv)(bla_character *uplo, bla_integer *n, bla_dcomplex *alpha, bla_dcomplex *ap, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *beta, bla_dcomplex *y, bla_integer *incy);
 
 #endif

--- a/frame/compat/f2c/bla_hpr.c
+++ b/frame/compat/f2c/bla_hpr.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,hpr)(character *uplo, integer *n, real *alpha, singlecomplex *x, integer *incx, singlecomplex *ap)
+/* Subroutine */ int PASTEF77(c,hpr)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_scomplex *x, bla_integer *incx, bla_scomplex *ap)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    real r__1;
-    singlecomplex q__1, q__2;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_real r__1;
+    bla_scomplex q__1, q__2;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_scomplex temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -70,7 +70,7 @@
 
 /*     A := alpha*x*conjg( x' ) + A, */
 
-/*  where alpha is a real scalar, x is an n element vector and A is an */
+/*  where alpha is a bla_real scalar, x is an n element vector and A is an */
 /*  n by n hermitian matrix, supplied in packed form. */
 
 /*  Parameters */
@@ -353,23 +353,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,hpr)(character *uplo, integer *n, doublereal *alpha, doublecomplex *x, integer *incx, doublecomplex *ap)
+/* Subroutine */ int PASTEF77(z,hpr)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *ap)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    doublereal d__1;
-    doublecomplex z__1, z__2;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_double d__1;
+    bla_dcomplex z__1, z__2;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_dcomplex temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -382,7 +382,7 @@
 
 /*     A := alpha*x*conjg( x' ) + A, */
 
-/*  where alpha is a real scalar, x is an n element vector and A is an */
+/*  where alpha is a bla_real scalar, x is an n element vector and A is an */
 /*  n by n hermitian matrix, supplied in packed form. */
 
 /*  Parameters */
@@ -506,32 +506,32 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[j]);
-		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 		    k = kk;
 		    i__2 = j - 1;
 		    for (i__ = 1; i__ <= i__2; ++i__) {
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L10: */
 		    }
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zreal(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zreal(temp)), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zbla_real(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zbla_real(temp)), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk += j;
@@ -542,32 +542,32 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[jx]);
-		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 		    ix = kx;
 		    i__2 = kk + j - 2;
 		    for (k = kk; k <= i__2; ++k) {
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			ix += *incx;
 /* L30: */
 		    }
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zreal(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zreal(temp)), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zbla_real(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zbla_real(temp)), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;
@@ -583,15 +583,15 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[j]);
-		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(temp) * bli_zreal(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zreal(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zreal(x[i__4])), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zbla_real(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zbla_real(x[i__4])), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    k = kk + 1;
 		    i__2 = *n;
@@ -599,16 +599,16 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L50: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk = kk + *n - j + 1;
@@ -619,15 +619,15 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[jx]);
-		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(temp) * bli_zreal(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zreal(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zreal(x[i__4])), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zbla_real(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zbla_real(x[i__4])), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    ix = jx;
 		    i__2 = kk + *n - j;
@@ -636,15 +636,15 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 /* L70: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;

--- a/frame/compat/f2c/bla_hpr.c
+++ b/frame/compat/f2c/bla_hpr.c
@@ -506,32 +506,32 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[j]);
-		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 		    k = kk;
 		    i__2 = j - 1;
 		    for (i__ = 1; i__ <= i__2; ++i__) {
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L10: */
 		    }
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zbla_real(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zbla_real(temp)), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zreal(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zreal(temp)), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk += j;
@@ -542,32 +542,32 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[jx]);
-		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 		    ix = kx;
 		    i__2 = kk + j - 2;
 		    for (k = kk; k <= i__2; ++k) {
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			ix += *incx;
 /* L30: */
 		    }
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zbla_real(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zbla_real(temp)), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp) - bli_zimag(x[i__4]) * bli_zimag(temp)), (bli_zreal(x[i__4]) * bli_zimag(temp) + bli_zimag(x[i__4]) * bli_zreal(temp)), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;
@@ -583,15 +583,15 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[j]);
-		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zbla_real(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zbla_real(x[i__4])), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(temp) * bli_zreal(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zreal(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zreal(x[i__4])), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    k = kk + 1;
 		    i__2 = *n;
@@ -599,16 +599,16 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L50: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk = kk + *n - j + 1;
@@ -619,15 +619,15 @@
 	    i__1 = *n;
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 		    bla_d_cnjg(&z__2, &x[jx]);
-		    bli_zsets( (*alpha * bli_zbla_real(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+		    bli_zsets( (*alpha * bli_zreal(z__2)), (*alpha * bli_zimag(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zbla_real(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zbla_real(x[i__4])), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(temp) * bli_zreal(x[i__4]) - bli_zimag(temp) * bli_zimag(x[i__4])), (bli_zreal(temp) * bli_zimag(x[i__4]) + bli_zimag(temp) * bli_zreal(x[i__4])), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    ix = jx;
 		    i__2 = kk + *n - j;
@@ -636,15 +636,15 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zbla_real(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zbla_real(temp)), z__2 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp) - bli_zimag(x[i__5]) * bli_zimag(temp)), (bli_zreal(x[i__5]) * bli_zimag(temp) + bli_zimag(x[i__5]) * bli_zreal(temp)), z__2 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__2)), (bli_zimag(ap[i__4]) + bli_zimag(z__2)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 /* L70: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;

--- a/frame/compat/f2c/bla_hpr.h
+++ b/frame/compat/f2c/bla_hpr.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,hpr)(character *uplo, integer *n, real *alpha, singlecomplex *x, integer *incx, singlecomplex *ap);
-int PASTEF77(z,hpr)(character *uplo, integer *n, doublereal *alpha, doublecomplex *x, integer *incx, doublecomplex *ap);
+int PASTEF77(c,hpr)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_scomplex *x, bla_integer *incx, bla_scomplex *ap);
+int PASTEF77(z,hpr)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *ap);
 
 #endif

--- a/frame/compat/f2c/bla_hpr2.c
+++ b/frame/compat/f2c/bla_hpr2.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,hpr2)(character *uplo, integer *n, singlecomplex *alpha, singlecomplex *x, integer *incx, singlecomplex *y, integer *incy, singlecomplex *ap)
+/* Subroutine */ int PASTEF77(c,hpr2)(bla_character *uplo, bla_integer *n, bla_scomplex *alpha, bla_scomplex *x, bla_integer *incx, bla_scomplex *y, bla_integer *incy, bla_scomplex *ap)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5, i__6;
-    real r__1;
-    singlecomplex q__1, q__2, q__3, q__4;
+    bla_integer i__1, i__2, i__3, i__4, i__5, i__6;
+    bla_real r__1;
+    bla_scomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_scomplex temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -429,23 +429,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,hpr2)(character *uplo, integer *n, doublecomplex *alpha, doublecomplex *x, integer *incx, doublecomplex *y, integer *incy, doublecomplex *ap)
+/* Subroutine */ int PASTEF77(z,hpr2)(bla_character *uplo, bla_integer *n, bla_dcomplex *alpha, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *y, bla_integer *incy, bla_dcomplex *ap)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5, i__6;
-    doublereal d__1;
-    doublecomplex z__1, z__2, z__3, z__4;
+    bla_integer i__1, i__2, i__3, i__4, i__5, i__6;
+    bla_double d__1;
+    bla_dcomplex z__1, z__2, z__3, z__4;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_dcomplex temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -572,7 +572,7 @@
 
 /*     Quick return if possible. */
 
-    if (*n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.)) {
+    if (*n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.)) {
 	return 0;
     }
 
@@ -607,43 +607,43 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
 		i__3 = j;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[j]);
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    k = kk;
 		    i__2 = j - 1;
 		    for (i__ = 1; i__ <= i__2; ++i__) {
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = i__;
-			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
-			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
+			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L10: */
 		    }
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
+		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
 		    i__5 = j;
-		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
-		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
+		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk += j;
@@ -654,15 +654,15 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
 		i__3 = jy;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[jy]);
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    ix = kx;
 		    iy = ky;
 		    i__2 = kk + j - 2;
@@ -670,12 +670,12 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = iy;
-			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
-			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
+			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			ix += *incx;
 			iy += *incy;
 /* L30: */
@@ -683,16 +683,16 @@
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
+		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
 		    i__5 = jy;
-		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
-		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
+		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;
@@ -710,23 +710,23 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
 		i__3 = j;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[j]);
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
+		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
 		    i__5 = j;
-		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
-		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
+		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    k = kk + 1;
 		    i__2 = *n;
@@ -734,19 +734,19 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = i__;
-			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
-			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
+			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L50: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk = kk + *n - j + 1;
@@ -757,23 +757,23 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
 		i__3 = jy;
-		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
+		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[jy]);
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
+		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
+		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
 		    i__5 = jy;
-		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
-		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
+		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
+		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    ix = jx;
 		    iy = jy;
@@ -784,18 +784,18 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
-			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
+			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = iy;
-			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
-			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
+			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
 /* L70: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zreal(ap[i__3]);
+		    d__1 = bli_zbla_real(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;

--- a/frame/compat/f2c/bla_hpr2.c
+++ b/frame/compat/f2c/bla_hpr2.c
@@ -572,7 +572,7 @@
 
 /*     Quick return if possible. */
 
-    if (*n == 0 || (bli_zbla_real(*alpha) == 0. && bli_zimag(*alpha) == 0.)) {
+    if (*n == 0 || (bli_zreal(*alpha) == 0. && bli_zimag(*alpha) == 0.)) {
 	return 0;
     }
 
@@ -607,43 +607,43 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
 		i__3 = j;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[j]);
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    k = kk;
 		    i__2 = j - 1;
 		    for (i__ = 1; i__ <= i__2; ++i__) {
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = i__;
-			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
-			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
+			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L10: */
 		    }
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
+		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
 		    i__5 = j;
-		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
-		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
+		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk += j;
@@ -654,15 +654,15 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
 		i__3 = jy;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[jy]);
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    ix = kx;
 		    iy = ky;
 		    i__2 = kk + j - 2;
@@ -670,12 +670,12 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = iy;
-			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
-			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
+			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			ix += *incx;
 			iy += *incy;
 /* L30: */
@@ -683,16 +683,16 @@
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
+		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
 		    i__5 = jy;
-		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
-		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
+		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		} else {
 		    i__2 = kk + j - 1;
 		    i__3 = kk + j - 1;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;
@@ -710,23 +710,23 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = j;
 		i__3 = j;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[j]);
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
+		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
 		    i__5 = j;
-		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
-		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
+		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    k = kk + 1;
 		    i__2 = *n;
@@ -734,19 +734,19 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = i__;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = i__;
-			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
-			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
+			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 			++k;
 /* L50: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		kk = kk + *n - j + 1;
@@ -757,23 +757,23 @@
 	    for (j = 1; j <= i__1; ++j) {
 		i__2 = jx;
 		i__3 = jy;
-		if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zbla_real(y[i__3]) != 0. || 
+		if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0. || (bli_zreal(y[i__3]) != 0. || 
 			bli_zimag(y[i__3]) != 0.)) {
 		    bla_d_cnjg(&z__2, &y[jy]);
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zbla_real(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zbla_real(z__2)), z__1 );
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp1 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(z__2) - bli_zimag(*alpha) * bli_zimag(z__2)), (bli_zreal(*alpha) * bli_zimag(z__2) + bli_zimag(*alpha) * bli_zreal(z__2)), z__1 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp1 );
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(*alpha) * bli_zbla_real(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zbla_real(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zbla_real(x[i__2])), z__2 );
+		    bli_zsets( (bli_zreal(*alpha) * bli_zreal(x[i__2]) - bli_zimag(*alpha) * bli_zimag(x[i__2])), (bli_zreal(*alpha) * bli_zimag(x[i__2]) + bli_zimag(*alpha) * bli_zreal(x[i__2])), z__2 );
 		    bla_d_cnjg(&z__1, &z__2);
-		    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp2 );
+		    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp2 );
 		    i__2 = kk;
 		    i__3 = kk;
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zbla_real(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zbla_real(temp1)), z__2 );
+		    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(temp1) - bli_zimag(x[i__4]) * bli_zimag(temp1)), (bli_zreal(x[i__4]) * bli_zimag(temp1) + bli_zimag(x[i__4]) * bli_zreal(temp1)), z__2 );
 		    i__5 = jy;
-		    bli_zsets( (bli_zbla_real(y[i__5]) * bli_zbla_real(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zbla_real(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zbla_real(temp2)), z__3 );
-		    bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-		    d__1 = bli_zbla_real(ap[i__3]) + bli_zbla_real(z__1);
+		    bli_zsets( (bli_zreal(y[i__5]) * bli_zreal(temp2) - bli_zimag(y[i__5]) * bli_zimag(temp2)), (bli_zreal(y[i__5]) * bli_zimag(temp2) + bli_zimag(y[i__5]) * bli_zreal(temp2)), z__3 );
+		    bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+		    d__1 = bli_zreal(ap[i__3]) + bli_zreal(z__1);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		    ix = jx;
 		    iy = jy;
@@ -784,18 +784,18 @@
 			i__3 = k;
 			i__4 = k;
 			i__5 = ix;
-			bli_zsets( (bli_zbla_real(x[i__5]) * bli_zbla_real(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zbla_real(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zbla_real(temp1)), z__3 );
-			bli_zsets( (bli_zbla_real(ap[i__4]) + bli_zbla_real(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
+			bli_zsets( (bli_zreal(x[i__5]) * bli_zreal(temp1) - bli_zimag(x[i__5]) * bli_zimag(temp1)), (bli_zreal(x[i__5]) * bli_zimag(temp1) + bli_zimag(x[i__5]) * bli_zreal(temp1)), z__3 );
+			bli_zsets( (bli_zreal(ap[i__4]) + bli_zreal(z__3)), (bli_zimag(ap[i__4]) + bli_zimag(z__3)), z__2 );
 			i__6 = iy;
-			bli_zsets( (bli_zbla_real(y[i__6]) * bli_zbla_real(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zbla_real(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zbla_real(temp2)), z__4 );
-			bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
-			bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ap[i__3] );
+			bli_zsets( (bli_zreal(y[i__6]) * bli_zreal(temp2) - bli_zimag(y[i__6]) * bli_zimag(temp2)), (bli_zreal(y[i__6]) * bli_zimag(temp2) + bli_zimag(y[i__6]) * bli_zreal(temp2)), z__4 );
+			bli_zsets( (bli_zreal(z__2) + bli_zreal(z__4)), (bli_zimag(z__2) + bli_zimag(z__4)), z__1 );
+			bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ap[i__3] );
 /* L70: */
 		    }
 		} else {
 		    i__2 = kk;
 		    i__3 = kk;
-		    d__1 = bli_zbla_real(ap[i__3]);
+		    d__1 = bli_zreal(ap[i__3]);
 		    bli_zsets( (d__1), (0.), ap[i__2] );
 		}
 		jx += *incx;

--- a/frame/compat/f2c/bla_hpr2.h
+++ b/frame/compat/f2c/bla_hpr2.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,hpr2)(character *uplo, integer *n, singlecomplex *alpha, singlecomplex *x, integer *incx, singlecomplex *y, integer *incy, singlecomplex *ap);
-int PASTEF77(z,hpr2)(character *uplo, integer *n, doublecomplex *alpha, doublecomplex *x, integer *incx, doublecomplex *y, integer *incy, doublecomplex *ap);
+int PASTEF77(c,hpr2)(bla_character *uplo, bla_integer *n, bla_scomplex *alpha, bla_scomplex *x, bla_integer *incx, bla_scomplex *y, bla_integer *incy, bla_scomplex *ap);
+int PASTEF77(z,hpr2)(bla_character *uplo, bla_integer *n, bla_dcomplex *alpha, bla_dcomplex *x, bla_integer *incx, bla_dcomplex *y, bla_integer *incy, bla_dcomplex *ap);
 
 #endif

--- a/frame/compat/f2c/bla_lsame.c
+++ b/frame/compat/f2c/bla_lsame.c
@@ -41,13 +41,13 @@
 	-lf2c -lm   (in that order)
 */
 
-logical PASTEF770(lsame)(character *ca, character *cb, ftnlen ca_len, ftnlen cb_len)
+bla_logical PASTEF770(lsame)(bla_character *ca, bla_character *cb, ftnlen ca_len, ftnlen cb_len)
 {
     /* System generated locals */
-    logical ret_val;
+    bla_logical ret_val;
 
     /* Local variables */
-    integer inta, intb, zcode;
+    bla_integer inta, intb, zcode;
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) -- */
@@ -69,7 +69,7 @@ logical PASTEF770(lsame)(character *ca, character *cb, ftnlen ca_len, ftnlen cb_
 
 /*  CA      (input) CHARACTER*1 */
 /*  CB      (input) CHARACTER*1 */
-/*          CA and CB specify the single characters to be compared. */
+/*          CA and CB specify the single bla_characters to be compared. */
 
 /* ===================================================================== */
 
@@ -79,14 +79,14 @@ logical PASTEF770(lsame)(character *ca, character *cb, ftnlen ca_len, ftnlen cb_
 /*     .. */
 /*     .. Executable Statements .. */
 
-/*     Test if the characters are equal */
+/*     Test if the bla_characters are equal */
 
     ret_val = *(unsigned char *)ca == *(unsigned char *)cb;
     if (ret_val) {
 	return ret_val;
     }
 
-/*     Now test for equivalence if both characters are alphabetic. */
+/*     Now test for equivalence if both bla_characters are alphabetic. */
 
     zcode = 'Z';
 

--- a/frame/compat/f2c/bla_lsame.h
+++ b/frame/compat/f2c/bla_lsame.h
@@ -36,6 +36,6 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-logical PASTEF770(lsame)(character *ca, character *cb, ftnlen ca_len, ftnlen cb_len);
+bla_logical PASTEF770(lsame)(bla_character *ca, bla_character *cb, ftnlen ca_len, ftnlen cb_len);
 
 #endif

--- a/frame/compat/f2c/bla_rot.c
+++ b/frame/compat/f2c/bla_rot.c
@@ -41,15 +41,15 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,rot)(integer *n, real *sx, integer *incx, real *sy, integer *incy, real *c__, real *s)
+/* Subroutine */ int PASTEF77(s,rot)(bla_integer *n, bla_real *sx, bla_integer *incx, bla_real *sy, bla_integer *incy, bla_real *c__, bla_real *s)
 {
     /* System generated locals */
-    integer i__1;
+    bla_integer i__1;
 
     /* Local variables */
-    integer i__;
-    real stemp;
-    integer ix, iy;
+    bla_integer i__;
+    bla_real stemp;
+    bla_integer ix, iy;
 
 
 /*     applies a plane rotation. */
@@ -109,15 +109,15 @@ L20:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,rot)(integer *n, doublereal *dx, integer *incx, doublereal *dy, integer *incy, doublereal *c__, doublereal *s)
+/* Subroutine */ int PASTEF77(d,rot)(bla_integer *n, bla_double *dx, bla_integer *incx, bla_double *dy, bla_integer *incy, bla_double *c__, bla_double *s)
 {
     /* System generated locals */
-    integer i__1;
+    bla_integer i__1;
 
     /* Local variables */
-    integer i__;
-    doublereal dtemp;
-    integer ix, iy;
+    bla_integer i__;
+    bla_double dtemp;
+    bla_integer ix, iy;
 
 
 /*     applies a plane rotation. */
@@ -177,19 +177,19 @@ L20:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(cs,rot)(integer *n, singlecomplex *cx, integer *incx, singlecomplex *cy, integer *incy, real *c__, real *s)
+/* Subroutine */ int PASTEF77(cs,rot)(bla_integer *n, bla_scomplex *cx, bla_integer *incx, bla_scomplex *cy, bla_integer *incy, bla_real *c__, bla_real *s)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
-    singlecomplex q__1, q__2, q__3;
+    bla_integer i__1, i__2, i__3, i__4;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Local variables */
-    integer i__;
-    singlecomplex ctemp;
-    integer ix, iy;
+    bla_integer i__;
+    bla_scomplex ctemp;
+    bla_integer ix, iy;
 
 
-/*     applies a plane rotation, where the cos and sin (c and s) are real */
+/*     applies a plane rotation, where the cos and sin (c and s) are bla_real */
 /*     and the vectors cx and cy are complex. */
 /*     jack dongarra, linpack, 3/11/78. */
 
@@ -270,16 +270,16 @@ L20:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(zd,rot)(integer *n, doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy, doublereal *c__, doublereal *s)
+/* Subroutine */ int PASTEF77(zd,rot)(bla_integer *n, bla_dcomplex *zx, bla_integer *incx, bla_dcomplex *zy, bla_integer *incy, bla_double *c__, bla_double *s)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
-    doublecomplex z__1, z__2, z__3;
+    bla_integer i__1, i__2, i__3, i__4;
+    bla_dcomplex z__1, z__2, z__3;
 
     /* Local variables */
-    integer i__;
-    doublecomplex ztemp;
-    integer ix, iy;
+    bla_integer i__;
+    bla_dcomplex ztemp;
+    bla_integer ix, iy;
 
 
 /*     applies a plane rotation, where the cos and sin (c and s) are */
@@ -313,20 +313,20 @@ L20:
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	i__2 = ix;
-	bli_zsets( (*c__ * bli_zreal(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
+	bli_zsets( (*c__ * bli_zbla_real(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
 	i__3 = iy;
-	bli_zsets( (*s * bli_zreal(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
-	bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ztemp );
+	bli_zsets( (*s * bli_zbla_real(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
+	bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ztemp );
 	i__2 = iy;
 	i__3 = iy;
-	bli_zsets( (*c__ * bli_zreal(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
+	bli_zsets( (*c__ * bli_zbla_real(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
 	i__4 = ix;
-	bli_zsets( (*s * bli_zreal(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
-	bli_zsets( (bli_zreal(z__2) - bli_zreal(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), zy[i__2] );
+	bli_zsets( (*s * bli_zbla_real(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
+	bli_zsets( (bli_zbla_real(z__2) - bli_zbla_real(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), zy[i__2] );
 	i__2 = ix;
-	bli_zsets( (bli_zreal(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
+	bli_zsets( (bli_zbla_real(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
 	ix += *incx;
 	iy += *incy;
 /* L10: */
@@ -339,20 +339,20 @@ L20:
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	i__2 = i__;
-	bli_zsets( (*c__ * bli_zreal(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
+	bli_zsets( (*c__ * bli_zbla_real(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
 	i__3 = i__;
-	bli_zsets( (*s * bli_zreal(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
-	bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ztemp );
+	bli_zsets( (*s * bli_zbla_real(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
+	bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ztemp );
 	i__2 = i__;
 	i__3 = i__;
-	bli_zsets( (*c__ * bli_zreal(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
+	bli_zsets( (*c__ * bli_zbla_real(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
 	i__4 = i__;
-	bli_zsets( (*s * bli_zreal(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
-	bli_zsets( (bli_zreal(z__2) - bli_zreal(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), zy[i__2] );
+	bli_zsets( (*s * bli_zbla_real(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
+	bli_zsets( (bli_zbla_real(z__2) - bli_zbla_real(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), zy[i__2] );
 	i__2 = i__;
-	bli_zsets( (bli_zreal(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
+	bli_zsets( (bli_zbla_real(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
 /* L30: */
     }
     return 0;

--- a/frame/compat/f2c/bla_rot.c
+++ b/frame/compat/f2c/bla_rot.c
@@ -313,20 +313,20 @@ L20:
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	i__2 = ix;
-	bli_zsets( (*c__ * bli_zbla_real(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
+	bli_zsets( (*c__ * bli_zreal(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
 	i__3 = iy;
-	bli_zsets( (*s * bli_zbla_real(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
-	bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ztemp );
+	bli_zsets( (*s * bli_zreal(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
+	bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ztemp );
 	i__2 = iy;
 	i__3 = iy;
-	bli_zsets( (*c__ * bli_zbla_real(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
+	bli_zsets( (*c__ * bli_zreal(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
 	i__4 = ix;
-	bli_zsets( (*s * bli_zbla_real(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
-	bli_zsets( (bli_zbla_real(z__2) - bli_zbla_real(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), zy[i__2] );
+	bli_zsets( (*s * bli_zreal(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
+	bli_zsets( (bli_zreal(z__2) - bli_zreal(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), zy[i__2] );
 	i__2 = ix;
-	bli_zsets( (bli_zbla_real(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
+	bli_zsets( (bli_zreal(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
 	ix += *incx;
 	iy += *incy;
 /* L10: */
@@ -339,20 +339,20 @@ L20:
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	i__2 = i__;
-	bli_zsets( (*c__ * bli_zbla_real(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
+	bli_zsets( (*c__ * bli_zreal(zx[i__2])), (*c__ * bli_zimag(zx[i__2])), z__2 );
 	i__3 = i__;
-	bli_zsets( (*s * bli_zbla_real(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
-	bli_zsets( (bli_zbla_real(z__2) + bli_zbla_real(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), ztemp );
+	bli_zsets( (*s * bli_zreal(zy[i__3])), (*s * bli_zimag(zy[i__3])), z__3 );
+	bli_zsets( (bli_zreal(z__2) + bli_zreal(z__3)), (bli_zimag(z__2) + bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), ztemp );
 	i__2 = i__;
 	i__3 = i__;
-	bli_zsets( (*c__ * bli_zbla_real(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
+	bli_zsets( (*c__ * bli_zreal(zy[i__3])), (*c__ * bli_zimag(zy[i__3])), z__2 );
 	i__4 = i__;
-	bli_zsets( (*s * bli_zbla_real(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
-	bli_zsets( (bli_zbla_real(z__2) - bli_zbla_real(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
-	bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), zy[i__2] );
+	bli_zsets( (*s * bli_zreal(zx[i__4])), (*s * bli_zimag(zx[i__4])), z__3 );
+	bli_zsets( (bli_zreal(z__2) - bli_zreal(z__3)), (bli_zimag(z__2) - bli_zimag(z__3)), z__1 );
+	bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), zy[i__2] );
 	i__2 = i__;
-	bli_zsets( (bli_zbla_real(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
+	bli_zsets( (bli_zreal(ztemp)), (bli_zimag(ztemp)), zx[i__2] );
 /* L30: */
     }
     return 0;

--- a/frame/compat/f2c/bla_rot.h
+++ b/frame/compat/f2c/bla_rot.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(s,rot)(integer *n, real *sx, integer *incx, real *sy, integer *incy, real *c__, real *s);
-int PASTEF77(d,rot)(integer *n, doublereal *dx, integer *incx, doublereal *dy, integer *incy, doublereal *c__, doublereal *s);
-int PASTEF77(cs,rot)(integer *n, singlecomplex *cx, integer *incx, singlecomplex *cy, integer *incy, real *c__, real *s);
-int PASTEF77(zd,rot)(integer *n, doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy, doublereal *c__, doublereal *s);
+int PASTEF77(s,rot)(bla_integer *n, bla_real *sx, bla_integer *incx, bla_real *sy, bla_integer *incy, bla_real *c__, bla_real *s);
+int PASTEF77(d,rot)(bla_integer *n, bla_double *dx, bla_integer *incx, bla_double *dy, bla_integer *incy, bla_double *c__, bla_double *s);
+int PASTEF77(cs,rot)(bla_integer *n, bla_scomplex *cx, bla_integer *incx, bla_scomplex *cy, bla_integer *incy, bla_real *c__, bla_real *s);
+int PASTEF77(zd,rot)(bla_integer *n, bla_dcomplex *zx, bla_integer *incx, bla_dcomplex *zy, bla_integer *incy, bla_double *c__, bla_double *s);
 
 #endif

--- a/frame/compat/f2c/bla_rotg.c
+++ b/frame/compat/f2c/bla_rotg.c
@@ -43,18 +43,18 @@
 
 /* Table of constant values */
 
-static real sc_b4 = 1.f;
+static bla_real sc_b4 = 1.f;
 
-/* Subroutine */ int PASTEF77(s,rotg)(real *sa, real *sb, real *c__, real *s)
+/* Subroutine */ int PASTEF77(s,rotg)(bla_real *sa, bla_real *sb, bla_real *c__, bla_real *s)
 {
     /* System generated locals */
-    real r__1, r__2;
+    bla_real r__1, r__2;
 
     /* Builtin functions */
-    double sqrt(doublereal), bla_r_sign(real *, real *);
+    double sqrt(bla_double), bla_r_sign(bla_real *, bla_real *);
 
     /* Local variables */
-    real r__, scale, z__, roe;
+    bla_real r__, scale, z__, roe;
 
 
 /*     construct givens plane rotation. */
@@ -103,18 +103,18 @@ L20:
 
 /* Table of constant values */
 
-static doublereal dc_b4 = 1.;
+static bla_double dc_b4 = 1.;
 
-/* Subroutine */ int PASTEF77(d,rotg)(doublereal *da, doublereal *db, doublereal *c__, doublereal *s)
+/* Subroutine */ int PASTEF77(d,rotg)(bla_double *da, bla_double *db, bla_double *c__, bla_double *s)
 {
     /* System generated locals */
-    doublereal d__1, d__2;
+    bla_double d__1, d__2;
 
     /* Builtin functions */
-    double sqrt(doublereal), bla_d_sign(doublereal *, doublereal *);
+    double sqrt(bla_double), bla_d_sign(bla_double *, bla_double *);
 
     /* Local variables */
-    doublereal r__, scale, z__, roe;
+    bla_double r__, scale, z__, roe;
 
 
 /*     construct givens plane rotation. */
@@ -161,20 +161,20 @@ L20:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,rotg)(singlecomplex *ca, singlecomplex *cb, real *c__, singlecomplex *s)
+/* Subroutine */ int PASTEF77(c,rotg)(bla_scomplex *ca, bla_scomplex *cb, bla_real *c__, bla_scomplex *s)
 {
     /* System generated locals */
-    real r__1, r__2;
-    singlecomplex q__1, q__2, q__3;
+    bla_real r__1, r__2;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    double bla_c_abs(singlecomplex *), sqrt(doublereal);
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    double bla_c_abs(bla_scomplex *), sqrt(bla_double);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    real norm;
-    singlecomplex alpha;
-    real scale;
+    bla_real norm;
+    bla_scomplex alpha;
+    bla_real scale;
 
     if (bla_c_abs(ca) != 0.f) {
 	goto L10;
@@ -211,29 +211,29 @@ L20:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,rotg)(doublecomplex *ca, doublecomplex *cb, doublereal *c__, doublecomplex *s)
+/* Subroutine */ int PASTEF77(z,rotg)(bla_dcomplex *ca, bla_dcomplex *cb, bla_double *c__, bla_dcomplex *s)
 {
     /* System generated locals */
-    doublereal d__1, d__2;
-    doublecomplex z__1, z__2, z__3, z__4;
+    bla_double d__1, d__2;
+    bla_dcomplex z__1, z__2, z__3, z__4;
 
     /* Builtin functions */
-    double bla_z_abs(doublecomplex *);
-    void bla_z_div(doublecomplex *, doublecomplex *, doublecomplex *);
-    double sqrt(doublereal);
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    double bla_z_abs(bla_dcomplex *);
+    void bla_z_div(bla_dcomplex *, bla_dcomplex *, bla_dcomplex *);
+    double sqrt(bla_double);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    doublereal norm;
-    doublecomplex alpha;
-    doublereal scale;
+    bla_double norm;
+    bla_dcomplex alpha;
+    bla_double scale;
 
     if (bla_z_abs(ca) != 0.) {
 	goto L10;
     }
     *c__ = 0.;
     bli_zsets( 1., 0., *s );
-    bli_zsets( bli_zreal(*cb), bli_zimag(*cb), *ca );
+    bli_zsets( bli_zbla_real(*cb), bli_zimag(*cb), *ca );
     goto L20;
 L10:
     scale = bla_z_abs(ca) + bla_z_abs(cb);
@@ -247,15 +247,15 @@ L10:
     d__2 = bla_z_abs(&z__3);
     norm = scale * sqrt(d__1 * d__1 + d__2 * d__2);
     d__1 = bla_z_abs(ca);
-    bli_zsets( (bli_zreal(*ca) / d__1), (bli_zimag(*ca) / d__1), z__1 );
-    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), alpha );
+    bli_zsets( (bli_zbla_real(*ca) / d__1), (bli_zimag(*ca) / d__1), z__1 );
+    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), alpha );
     *c__ = bla_z_abs(ca) / norm;
     bla_d_cnjg(&z__3, cb);
-    bli_zsets( (bli_zreal(alpha) * bli_zreal(z__3) - bli_zimag(alpha) * bli_zimag(z__3)), (bli_zreal(alpha) * bli_zimag(z__3) + bli_zimag(alpha) * bli_zreal(z__3)), z__2 );
-    bli_zsets( (bli_zreal(z__2) / norm), (bli_zimag(z__2) / norm), z__1 );
-    bli_zsets( bli_zreal(z__1), bli_zimag(z__1), *s );
-    bli_zsets( (norm * bli_zreal(alpha)), (norm * bli_zimag(alpha)), z__1 );
-    bli_zsets( bli_zreal(z__1), bli_zimag(z__1), *ca );
+    bli_zsets( (bli_zbla_real(alpha) * bli_zbla_real(z__3) - bli_zimag(alpha) * bli_zimag(z__3)), (bli_zbla_real(alpha) * bli_zimag(z__3) + bli_zimag(alpha) * bli_zbla_real(z__3)), z__2 );
+    bli_zsets( (bli_zbla_real(z__2) / norm), (bli_zimag(z__2) / norm), z__1 );
+    bli_zsets( bli_zbla_real(z__1), bli_zimag(z__1), *s );
+    bli_zsets( (norm * bli_zbla_real(alpha)), (norm * bli_zimag(alpha)), z__1 );
+    bli_zsets( bli_zbla_real(z__1), bli_zimag(z__1), *ca );
 L20:
     return 0;
 } /* zrotg_ */

--- a/frame/compat/f2c/bla_rotg.c
+++ b/frame/compat/f2c/bla_rotg.c
@@ -233,7 +233,7 @@ L20:
     }
     *c__ = 0.;
     bli_zsets( 1., 0., *s );
-    bli_zsets( bli_zbla_real(*cb), bli_zimag(*cb), *ca );
+    bli_zsets( bli_zreal(*cb), bli_zimag(*cb), *ca );
     goto L20;
 L10:
     scale = bla_z_abs(ca) + bla_z_abs(cb);
@@ -247,15 +247,15 @@ L10:
     d__2 = bla_z_abs(&z__3);
     norm = scale * sqrt(d__1 * d__1 + d__2 * d__2);
     d__1 = bla_z_abs(ca);
-    bli_zsets( (bli_zbla_real(*ca) / d__1), (bli_zimag(*ca) / d__1), z__1 );
-    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), alpha );
+    bli_zsets( (bli_zreal(*ca) / d__1), (bli_zimag(*ca) / d__1), z__1 );
+    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), alpha );
     *c__ = bla_z_abs(ca) / norm;
     bla_d_cnjg(&z__3, cb);
-    bli_zsets( (bli_zbla_real(alpha) * bli_zbla_real(z__3) - bli_zimag(alpha) * bli_zimag(z__3)), (bli_zbla_real(alpha) * bli_zimag(z__3) + bli_zimag(alpha) * bli_zbla_real(z__3)), z__2 );
-    bli_zsets( (bli_zbla_real(z__2) / norm), (bli_zimag(z__2) / norm), z__1 );
-    bli_zsets( bli_zbla_real(z__1), bli_zimag(z__1), *s );
-    bli_zsets( (norm * bli_zbla_real(alpha)), (norm * bli_zimag(alpha)), z__1 );
-    bli_zsets( bli_zbla_real(z__1), bli_zimag(z__1), *ca );
+    bli_zsets( (bli_zreal(alpha) * bli_zreal(z__3) - bli_zimag(alpha) * bli_zimag(z__3)), (bli_zreal(alpha) * bli_zimag(z__3) + bli_zimag(alpha) * bli_zreal(z__3)), z__2 );
+    bli_zsets( (bli_zreal(z__2) / norm), (bli_zimag(z__2) / norm), z__1 );
+    bli_zsets( bli_zreal(z__1), bli_zimag(z__1), *s );
+    bli_zsets( (norm * bli_zreal(alpha)), (norm * bli_zimag(alpha)), z__1 );
+    bli_zsets( bli_zreal(z__1), bli_zimag(z__1), *ca );
 L20:
     return 0;
 } /* zrotg_ */

--- a/frame/compat/f2c/bla_rotg.h
+++ b/frame/compat/f2c/bla_rotg.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(s,rotg)(real *sa, real *sb, real *c__, real *s);
-int PASTEF77(d,rotg)(doublereal *da, doublereal *db, doublereal *c__, doublereal *s);
-int PASTEF77(c,rotg)(singlecomplex *ca, singlecomplex *cb, real *c__, singlecomplex *s);
-int PASTEF77(z,rotg)(doublecomplex *ca, doublecomplex *cb, doublereal *c__, doublecomplex *s);
+int PASTEF77(s,rotg)(bla_real *sa, bla_real *sb, bla_real *c__, bla_real *s);
+int PASTEF77(d,rotg)(bla_double *da, bla_double *db, bla_double *c__, bla_double *s);
+int PASTEF77(c,rotg)(bla_scomplex *ca, bla_scomplex *cb, bla_real *c__, bla_scomplex *s);
+int PASTEF77(z,rotg)(bla_dcomplex *ca, bla_dcomplex *cb, bla_double *c__, bla_dcomplex *s);
 
 #endif

--- a/frame/compat/f2c/bla_rotm.c
+++ b/frame/compat/f2c/bla_rotm.c
@@ -41,21 +41,21 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,rotm)(integer *n, real *sx, integer *incx, real *sy, integer *incy, real *sparam)
+/* Subroutine */ int PASTEF77(s,rotm)(bla_integer *n, bla_real *sx, bla_integer *incx, bla_real *sy, bla_integer *incy, bla_real *sparam)
 {
     /* Initialized data */
 
-    static real zero = 0.f;
-    static real two = 2.f;
+    static bla_real zero = 0.f;
+    static bla_real two = 2.f;
 
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer i__;
-    real w, z__, sflag;
-    integer kx, ky, nsteps;
-    real sh11, sh12, sh21, sh22;
+    bla_integer i__;
+    bla_real w, z__, sflag;
+    bla_integer kx, ky, nsteps;
+    bla_real sh11, sh12, sh21, sh22;
 
 
 /*     APPLY THE MODIFIED GIVENS TRANSFORMATION, H, TO THE 2 BY N MATRIX */
@@ -207,21 +207,21 @@ L140:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,rotm)(integer *n, doublereal *dx, integer *incx, doublereal *dy, integer *incy, doublereal *dparam)
+/* Subroutine */ int PASTEF77(d,rotm)(bla_integer *n, bla_double *dx, bla_integer *incx, bla_double *dy, bla_integer *incy, bla_double *dparam)
 {
     /* Initialized data */
 
-    static doublereal zero = 0.;
-    static doublereal two = 2.;
+    static bla_double zero = 0.;
+    static bla_double two = 2.;
 
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer i__;
-    doublereal dflag, w, z__;
-    integer kx, ky, nsteps;
-    doublereal dh11, dh12, dh22, dh21;
+    bla_integer i__;
+    bla_double dflag, w, z__;
+    bla_integer kx, ky, nsteps;
+    bla_double dh11, dh12, dh22, dh21;
 
 
 /*     APPLY THE MODIFIED GIVENS TRANSFORMATION, H, TO THE 2 BY N MATRIX */

--- a/frame/compat/f2c/bla_rotm.h
+++ b/frame/compat/f2c/bla_rotm.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(s,rotm)(integer *n, real *sx, integer *incx, real *sy, integer *incy, real *sparam);
-int PASTEF77(d,rotm)(integer *n, doublereal *dx, integer *incx, doublereal *dy, integer *incy, doublereal *dparam);
+int PASTEF77(s,rotm)(bla_integer *n, bla_real *sx, bla_integer *incx, bla_real *sy, bla_integer *incy, bla_real *sparam);
+int PASTEF77(d,rotm)(bla_integer *n, bla_double *dx, bla_integer *incx, bla_double *dy, bla_integer *incy, bla_double *dparam);
 
 #endif

--- a/frame/compat/f2c/bla_rotmg.c
+++ b/frame/compat/f2c/bla_rotmg.c
@@ -41,26 +41,26 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,rotmg)(real *sd1, real *sd2, real *sx1, real *sy1, real *sparam)
+/* Subroutine */ int PASTEF77(s,rotmg)(bla_real *sd1, bla_real *sd2, bla_real *sx1, bla_real *sy1, bla_real *sparam)
 {
     /* Initialized data */
 
-    static real zero = 0.f;
-    static real one = 1.f;
-    static real two = 2.f;
-    static real gam = 4096.f;
-    static real gamsq = 16777200.f;
-    static real rgamsq = 5.96046e-8f;
+    static bla_real zero = 0.f;
+    static bla_real one = 1.f;
+    static bla_real two = 2.f;
+    static bla_real gam = 4096.f;
+    static bla_real gamsq = 16777200.f;
+    static bla_real rgamsq = 5.96046e-8f;
 
     /* Format strings */
 
     /* System generated locals */
-    real r__1;
+    bla_real r__1;
 
     /* Local variables */
-    real sflag, stemp, su, sp1, sp2, sq2, sq1,
+    bla_real sflag, stemp, su, sp1, sp2, sq2, sq1,
          sh11 = 0.f, sh21 = 0.f, sh12 = 0.f, sh22 = 0.f;
-    integer igo;
+    bla_integer igo;
 
     /* Assigned format variables */
 
@@ -281,26 +281,26 @@ L260:
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,rotmg)(doublereal *dd1, doublereal *dd2, doublereal *dx1, doublereal *dy1, doublereal *dparam)
+/* Subroutine */ int PASTEF77(d,rotmg)(bla_double *dd1, bla_double *dd2, bla_double *dx1, bla_double *dy1, bla_double *dparam)
 {
     /* Initialized data */
 
-    static doublereal zero = 0.;
-    static doublereal one = 1.;
-    static doublereal two = 2.;
-    static doublereal gam = 4096.;
-    static doublereal gamsq = 16777216.;
-    static doublereal rgamsq = 5.9604645e-8;
+    static bla_double zero = 0.;
+    static bla_double one = 1.;
+    static bla_double two = 2.;
+    static bla_double gam = 4096.;
+    static bla_double gamsq = 16777216.;
+    static bla_double rgamsq = 5.9604645e-8;
 
     /* Format strings */
 
     /* System generated locals */
-    doublereal d__1;
+    bla_double d__1;
 
     /* Local variables */
-    doublereal dflag, dtemp, du, dp1, dp2, dq2, dq1,
+    bla_double dflag, dtemp, du, dp1, dp2, dq2, dq1,
                dh11 = 0.f, dh21 = 0.f, dh12 = 0.f, dh22 = 0.f;
-    integer igo;
+    bla_integer igo;
 
     /* Assigned format variables */
 

--- a/frame/compat/f2c/bla_rotmg.h
+++ b/frame/compat/f2c/bla_rotmg.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(s,rotmg)(real *sd1, real *sd2, real *sx1, real *sy1, real *sparam);
-int PASTEF77(d,rotmg)(doublereal *dd1, doublereal *dd2, doublereal *dx1, doublereal *dy1, doublereal *dparam);
+int PASTEF77(s,rotmg)(bla_real *sd1, bla_real *sd2, bla_real *sx1, bla_real *sy1, bla_real *sparam);
+int PASTEF77(d,rotmg)(bla_double *dd1, bla_double *dd2, bla_double *dx1, bla_double *dy1, bla_double *dparam);
 
 #endif

--- a/frame/compat/f2c/bla_sbmv.c
+++ b/frame/compat/f2c/bla_sbmv.c
@@ -41,18 +41,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,sbmv)(character *uplo, integer *n, integer *k, doublereal *alpha, doublereal *a, integer *lda, doublereal *x, integer *incx, doublereal *beta, doublereal *y, integer *incy)
+/* Subroutine */ int PASTEF77(d,sbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_double *alpha, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx, bla_double *beta, bla_double *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
 
     /* Local variables */
-    integer info;
-    doublereal temp1, temp2;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_double temp1, temp2;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -392,18 +392,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,sbmv)(character *uplo, integer *n, integer *k, real *alpha, real *a, integer *lda, real *x, integer *incx, real *beta, real *y, integer *incy)
+/* Subroutine */ int PASTEF77(s,sbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_real *alpha, bla_real *a, bla_integer *lda, bla_real *x, bla_integer *incx, bla_real *beta, bla_real *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
 
     /* Local variables */
-    integer info;
-    real temp1, temp2;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_real temp1, temp2;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */

--- a/frame/compat/f2c/bla_sbmv.h
+++ b/frame/compat/f2c/bla_sbmv.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(d,sbmv)(character *uplo, integer *n, integer *k, doublereal *alpha, doublereal *a, integer *lda, doublereal *x, integer *incx, doublereal *beta, doublereal *y, integer *incy);
-int PASTEF77(s,sbmv)(character *uplo, integer *n, integer *k, real *alpha, real *a, integer *lda, real *x, integer *incx, real *beta, real *y, integer *incy);
+int PASTEF77(d,sbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_double *alpha, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx, bla_double *beta, bla_double *y, bla_integer *incy);
+int PASTEF77(s,sbmv)(bla_character *uplo, bla_integer *n, bla_integer *k, bla_real *alpha, bla_real *a, bla_integer *lda, bla_real *x, bla_integer *incx, bla_real *beta, bla_real *y, bla_integer *incy);
 
 #endif

--- a/frame/compat/f2c/bla_spmv.c
+++ b/frame/compat/f2c/bla_spmv.c
@@ -41,18 +41,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,spmv)(character *uplo, integer *n, doublereal *alpha, doublereal *ap, doublereal *x, integer *incx, doublereal *beta, doublereal *y, integer *incy)
+/* Subroutine */ int PASTEF77(d,spmv)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_double *ap, bla_double *x, bla_integer *incx, bla_double *beta, bla_double *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    doublereal temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_double temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -342,18 +342,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,spmv)(character *uplo, integer *n, real *alpha, real *ap, real *x, integer *incx, real *beta, real *y, integer *incy)
+/* Subroutine */ int PASTEF77(s,spmv)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_real *ap, bla_real *x, bla_integer *incx, bla_real *beta, bla_real *y, bla_integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    real temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx, jy, kx, ky;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_real temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx, jy, kx, ky;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */

--- a/frame/compat/f2c/bla_spmv.h
+++ b/frame/compat/f2c/bla_spmv.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(d,spmv)(character *uplo, integer *n, doublereal *alpha, doublereal *ap, doublereal *x, integer *incx, doublereal *beta, doublereal *y, integer *incy);
-int PASTEF77(s,spmv)(character *uplo, integer *n, real *alpha, real *ap, real *x, integer *incx, real *beta, real *y, integer *incy);
+int PASTEF77(d,spmv)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_double *ap, bla_double *x, bla_integer *incx, bla_double *beta, bla_double *y, bla_integer *incy);
+int PASTEF77(s,spmv)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_real *ap, bla_real *x, bla_integer *incx, bla_real *beta, bla_real *y, bla_integer *incy);
 
 #endif

--- a/frame/compat/f2c/bla_spr.c
+++ b/frame/compat/f2c/bla_spr.c
@@ -41,18 +41,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,spr)(character *uplo, integer *n, doublereal *alpha, doublereal *x, integer *incx, doublereal *ap)
+/* Subroutine */ int PASTEF77(d,spr)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_double *x, bla_integer *incx, bla_double *ap)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    doublereal temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_double temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -65,7 +65,7 @@
 
 /*     A := alpha*x*x' + A, */
 
-/*  where alpha is a real scalar, x is an n element vector and A is an */
+/*  where alpha is a bla_real scalar, x is an n element vector and A is an */
 /*  n by n symmetric matrix, supplied in packed form. */
 
 /*  Parameters */
@@ -268,18 +268,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,spr)(character *uplo, integer *n, real *alpha, real *x, integer *incx, real *ap)
+/* Subroutine */ int PASTEF77(s,spr)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_real *x, bla_integer *incx, bla_real *ap)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    real temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_real temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -292,7 +292,7 @@
 
 /*     A := alpha*x*x' + A, */
 
-/*  where alpha is a real scalar, x is an n element vector and A is an */
+/*  where alpha is a bla_real scalar, x is an n element vector and A is an */
 /*  n by n symmetric matrix, supplied in packed form. */
 
 /*  Parameters */

--- a/frame/compat/f2c/bla_spr.h
+++ b/frame/compat/f2c/bla_spr.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(d,spr)(character *uplo, integer *n, doublereal *alpha, doublereal *x, integer *incx, doublereal *ap);
-int PASTEF77(s,spr)(character *uplo, integer *n, real *alpha, real *x, integer *incx, real *ap);
+int PASTEF77(d,spr)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_double *x, bla_integer *incx, bla_double *ap);
+int PASTEF77(s,spr)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_real *x, bla_integer *incx, bla_real *ap);
 
 #endif

--- a/frame/compat/f2c/bla_spr2.c
+++ b/frame/compat/f2c/bla_spr2.c
@@ -41,18 +41,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,spr2)(character *uplo, integer *n, doublereal *alpha, doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *ap)
+/* Subroutine */ int PASTEF77(d,spr2)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_double *x, bla_integer *incx, bla_double *y, bla_integer *incy, bla_double *ap)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    doublereal temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_double temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -300,18 +300,18 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,spr2)(character *uplo, integer *n, real *alpha, real *x, integer *incx, real *y, integer *incy, real *ap)
+/* Subroutine */ int PASTEF77(s,spr2)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_real *x, bla_integer *incx, bla_real *y, bla_integer *incy, bla_real *ap)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    real temp1, temp2;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
+    bla_integer info;
+    bla_real temp1, temp2;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, iy, jx = 0, jy = 0, kx = 0, ky = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */

--- a/frame/compat/f2c/bla_spr2.h
+++ b/frame/compat/f2c/bla_spr2.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(d,spr2)(character *uplo, integer *n, doublereal *alpha, doublereal *x, integer *incx, doublereal *y, integer *incy, doublereal *ap);
-int PASTEF77(s,spr2)(character *uplo, integer *n, real *alpha, real *x, integer *incx, real *y, integer *incy, real *ap);
+int PASTEF77(d,spr2)(bla_character *uplo, bla_integer *n, bla_double *alpha, bla_double *x, bla_integer *incx, bla_double *y, bla_integer *incy, bla_double *ap);
+int PASTEF77(s,spr2)(bla_character *uplo, bla_integer *n, bla_real *alpha, bla_real *x, bla_integer *incx, bla_real *y, bla_integer *incy, bla_real *ap);
 
 #endif

--- a/frame/compat/f2c/bla_tbmv.c
+++ b/frame/compat/f2c/bla_tbmv.c
@@ -1656,9 +1656,9 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			i__2 = j;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 			l = kplus1 - j;
 /* Computing MAX */
 			i__2 = 1, i__3 = j - *k;
@@ -1667,17 +1667,17 @@
 			    i__2 = i__;
 			    i__3 = i__;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 /* L10: */
 			}
 			if (nounit) {
 			    i__4 = j;
 			    i__2 = j;
 			    i__3 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(x[i__2]) * bli_zbla_real(a[i__3]) - bli_zimag(x[i__2]) * bli_zimag(a[i__3])), (bli_zbla_real(x[i__2]) * bli_zimag(a[i__3]) + bli_zimag(x[i__2]) * bli_zbla_real(a[i__3])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zreal(x[i__2]) * bli_zreal(a[i__3]) - bli_zimag(x[i__2]) * bli_zimag(a[i__3])), (bli_zreal(x[i__2]) * bli_zimag(a[i__3]) + bli_zimag(x[i__2]) * bli_zreal(a[i__3])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
 			}
 		    }
 /* L20: */
@@ -1687,9 +1687,9 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__4 = jx;
-		    if (bli_zbla_real(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
+		    if (bli_zreal(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
 			i__4 = jx;
-			bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
+			bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
 			ix = kx;
 			l = kplus1 - j;
 /* Computing MAX */
@@ -1699,9 +1699,9 @@
 			    i__4 = ix;
 			    i__2 = ix;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__2]) + bli_zbla_real(z__2)), (bli_zimag(x[i__2]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__2]) + bli_zreal(z__2)), (bli_zimag(x[i__2]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
 			    ix += *incx;
 /* L30: */
 			}
@@ -1709,8 +1709,8 @@
 			    i__3 = jx;
 			    i__4 = jx;
 			    i__2 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(a[i__2]) - bli_zimag(x[i__4]) * bli_zimag(a[i__2])), (bli_zbla_real(x[i__4]) * bli_zimag(a[i__2]) + bli_zimag(x[i__4]) * bli_zbla_real(a[i__2])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(a[i__2]) - bli_zimag(x[i__4]) * bli_zimag(a[i__2])), (bli_zreal(x[i__4]) * bli_zimag(a[i__2]) + bli_zimag(x[i__4]) * bli_zreal(a[i__2])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 			}
 		    }
 		    jx += *incx;
@@ -1724,9 +1724,9 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			i__1 = j;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 			l = 1 - j;
 /* Computing MIN */
 			i__1 = *n, i__3 = j + *k;
@@ -1735,17 +1735,17 @@
 			    i__1 = i__;
 			    i__3 = i__;
 			    i__2 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zbla_real(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zbla_real(a[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zreal(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zreal(a[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 /* L50: */
 			}
 			if (nounit) {
 			    i__4 = j;
 			    i__1 = j;
 			    i__3 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zbla_real(x[i__1]) * bli_zbla_real(a[i__3]) - bli_zimag(x[i__1]) * bli_zimag(a[i__3])), (bli_zbla_real(x[i__1]) * bli_zimag(a[i__3]) + bli_zimag(x[i__1]) * bli_zbla_real(a[i__3])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zreal(x[i__1]) * bli_zreal(a[i__3]) - bli_zimag(x[i__1]) * bli_zimag(a[i__3])), (bli_zreal(x[i__1]) * bli_zimag(a[i__3]) + bli_zimag(x[i__1]) * bli_zreal(a[i__3])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
 			}
 		    }
 /* L60: */
@@ -1755,9 +1755,9 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__4 = jx;
-		    if (bli_zbla_real(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
+		    if (bli_zreal(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
 			i__4 = jx;
-			bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
+			bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
 			ix = kx;
 			l = 1 - j;
 /* Computing MIN */
@@ -1767,9 +1767,9 @@
 			    i__4 = ix;
 			    i__1 = ix;
 			    i__2 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zbla_real(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zbla_real(a[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__1]) + bli_zbla_real(z__2)), (bli_zimag(x[i__1]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zreal(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zreal(a[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__1]) + bli_zreal(z__2)), (bli_zimag(x[i__1]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
 			    ix -= *incx;
 /* L70: */
 			}
@@ -1777,8 +1777,8 @@
 			    i__3 = jx;
 			    i__4 = jx;
 			    i__1 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(a[i__1]) - bli_zimag(x[i__4]) * bli_zimag(a[i__1])), (bli_zbla_real(x[i__4]) * bli_zimag(a[i__1]) + bli_zimag(x[i__4]) * bli_zbla_real(a[i__1])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(a[i__1]) - bli_zimag(x[i__4]) * bli_zimag(a[i__1])), (bli_zreal(x[i__4]) * bli_zimag(a[i__1]) + bli_zimag(x[i__4]) * bli_zreal(a[i__1])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 			}
 		    }
 		    jx -= *incx;
@@ -1798,13 +1798,13 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__3 = j;
-		    bli_zsets( (bli_zbla_real(x[i__3])), (bli_zimag(x[i__3])), temp );
+		    bli_zsets( (bli_zreal(x[i__3])), (bli_zimag(x[i__3])), temp );
 		    l = kplus1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__3 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zbla_real(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zbla_real(a[i__3])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zreal(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zreal(a[i__3])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1812,16 +1812,16 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    i__4 = l + i__ + j * a_dim1;
 			    i__1 = i__;
-			    bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__1])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zreal(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zreal(x[i__1])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L90: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1829,14 +1829,14 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__4 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L100: */
 			}
 		    }
 		    i__3 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__3] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__3] );
 /* L110: */
 		}
 	    } else {
@@ -1844,15 +1844,15 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__3 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__3])), (bli_zimag(x[i__3])), temp );
+		    bli_zsets( (bli_zreal(x[i__3])), (bli_zimag(x[i__3])), temp );
 		    kx -= *incx;
 		    ix = kx;
 		    l = kplus1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__3 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zbla_real(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zbla_real(a[i__3])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zreal(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zreal(a[i__3])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1860,17 +1860,17 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    i__4 = l + i__ + j * a_dim1;
 			    i__1 = ix;
-			    bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__1])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zreal(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zreal(x[i__1])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L120: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1878,15 +1878,15 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__4 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L130: */
 			}
 		    }
 		    i__3 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__3] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__3] );
 		    jx -= *incx;
 /* L140: */
 		}
@@ -1896,13 +1896,13 @@
 		i__3 = *n;
 		for (j = 1; j <= i__3; ++j) {
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
+		    bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
 		    l = 1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__4 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1910,16 +1910,16 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    i__1 = l + i__ + j * a_dim1;
 			    i__2 = i__;
-			    bli_zsets( (bli_zbla_real(a[i__1]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__1]) * bli_zreal(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zreal(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L150: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1927,14 +1927,14 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__1 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L160: */
 			}
 		    }
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
 /* L170: */
 		}
 	    } else {
@@ -1942,15 +1942,15 @@
 		i__3 = *n;
 		for (j = 1; j <= i__3; ++j) {
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
+		    bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
 		    kx += *incx;
 		    ix = kx;
 		    l = 1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__4 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1958,17 +1958,17 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    i__1 = l + i__ + j * a_dim1;
 			    i__2 = ix;
-			    bli_zsets( (bli_zbla_real(a[i__1]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__1]) * bli_zreal(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zreal(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L180: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1976,15 +1976,15 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__1 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L190: */
 			}
 		    }
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
 		    jx += *incx;
 /* L200: */
 		}

--- a/frame/compat/f2c/bla_tbmv.c
+++ b/frame/compat/f2c/bla_tbmv.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx) 
+/* Subroutine */ int PASTEF77(c,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx) 
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
-    singlecomplex q__1, q__2, q__3;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_scomplex temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -611,19 +611,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx)
+/* Subroutine */ int PASTEF77(d,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
 
     /* Local variables */
-    integer info;
-    doublereal temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_double temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1022,19 +1022,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, real *a, integer *lda, real *x, integer *incx)
+/* Subroutine */ int PASTEF77(s,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_real *a, bla_integer *lda, bla_real *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
 
     /* Local variables */
-    integer info;
-    real temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_real temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1433,23 +1433,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublecomplex *a, integer *lda, doublecomplex *x, integer *incx)
+/* Subroutine */ int PASTEF77(z,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
-    doublecomplex z__1, z__2, z__3;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+    bla_dcomplex z__1, z__2, z__3;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_dcomplex temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1656,9 +1656,9 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			i__2 = j;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 			l = kplus1 - j;
 /* Computing MAX */
 			i__2 = 1, i__3 = j - *k;
@@ -1667,17 +1667,17 @@
 			    i__2 = i__;
 			    i__3 = i__;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 /* L10: */
 			}
 			if (nounit) {
 			    i__4 = j;
 			    i__2 = j;
 			    i__3 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zreal(x[i__2]) * bli_zreal(a[i__3]) - bli_zimag(x[i__2]) * bli_zimag(a[i__3])), (bli_zreal(x[i__2]) * bli_zimag(a[i__3]) + bli_zimag(x[i__2]) * bli_zreal(a[i__3])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zbla_real(x[i__2]) * bli_zbla_real(a[i__3]) - bli_zimag(x[i__2]) * bli_zimag(a[i__3])), (bli_zbla_real(x[i__2]) * bli_zimag(a[i__3]) + bli_zimag(x[i__2]) * bli_zbla_real(a[i__3])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
 			}
 		    }
 /* L20: */
@@ -1687,9 +1687,9 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__4 = jx;
-		    if (bli_zreal(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
+		    if (bli_zbla_real(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
 			i__4 = jx;
-			bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
+			bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
 			ix = kx;
 			l = kplus1 - j;
 /* Computing MAX */
@@ -1699,9 +1699,9 @@
 			    i__4 = ix;
 			    i__2 = ix;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__2]) + bli_zreal(z__2)), (bli_zimag(x[i__2]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__2]) + bli_zbla_real(z__2)), (bli_zimag(x[i__2]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
 			    ix += *incx;
 /* L30: */
 			}
@@ -1709,8 +1709,8 @@
 			    i__3 = jx;
 			    i__4 = jx;
 			    i__2 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(a[i__2]) - bli_zimag(x[i__4]) * bli_zimag(a[i__2])), (bli_zreal(x[i__4]) * bli_zimag(a[i__2]) + bli_zimag(x[i__4]) * bli_zreal(a[i__2])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(a[i__2]) - bli_zimag(x[i__4]) * bli_zimag(a[i__2])), (bli_zbla_real(x[i__4]) * bli_zimag(a[i__2]) + bli_zimag(x[i__4]) * bli_zbla_real(a[i__2])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 			}
 		    }
 		    jx += *incx;
@@ -1724,9 +1724,9 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			i__1 = j;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 			l = 1 - j;
 /* Computing MIN */
 			i__1 = *n, i__3 = j + *k;
@@ -1735,17 +1735,17 @@
 			    i__1 = i__;
 			    i__3 = i__;
 			    i__2 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zreal(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zreal(a[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zbla_real(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zbla_real(a[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 /* L50: */
 			}
 			if (nounit) {
 			    i__4 = j;
 			    i__1 = j;
 			    i__3 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zreal(x[i__1]) * bli_zreal(a[i__3]) - bli_zimag(x[i__1]) * bli_zimag(a[i__3])), (bli_zreal(x[i__1]) * bli_zimag(a[i__3]) + bli_zimag(x[i__1]) * bli_zreal(a[i__3])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zbla_real(x[i__1]) * bli_zbla_real(a[i__3]) - bli_zimag(x[i__1]) * bli_zimag(a[i__3])), (bli_zbla_real(x[i__1]) * bli_zimag(a[i__3]) + bli_zimag(x[i__1]) * bli_zbla_real(a[i__3])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
 			}
 		    }
 /* L60: */
@@ -1755,9 +1755,9 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__4 = jx;
-		    if (bli_zreal(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
+		    if (bli_zbla_real(x[i__4]) != 0. || bli_zimag(x[i__4]) != 0.) {
 			i__4 = jx;
-			bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
+			bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
 			ix = kx;
 			l = 1 - j;
 /* Computing MIN */
@@ -1767,9 +1767,9 @@
 			    i__4 = ix;
 			    i__1 = ix;
 			    i__2 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zreal(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zreal(a[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__1]) + bli_zreal(z__2)), (bli_zimag(x[i__1]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__4] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__2]) - bli_zimag(temp) * bli_zimag(a[i__2])), (bli_zbla_real(temp) * bli_zimag(a[i__2]) + bli_zimag(temp) * bli_zbla_real(a[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__1]) + bli_zbla_real(z__2)), (bli_zimag(x[i__1]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__4] );
 			    ix -= *incx;
 /* L70: */
 			}
@@ -1777,8 +1777,8 @@
 			    i__3 = jx;
 			    i__4 = jx;
 			    i__1 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zreal(x[i__4]) * bli_zreal(a[i__1]) - bli_zimag(x[i__4]) * bli_zimag(a[i__1])), (bli_zreal(x[i__4]) * bli_zimag(a[i__1]) + bli_zimag(x[i__4]) * bli_zreal(a[i__1])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(x[i__4]) * bli_zbla_real(a[i__1]) - bli_zimag(x[i__4]) * bli_zimag(a[i__1])), (bli_zbla_real(x[i__4]) * bli_zimag(a[i__1]) + bli_zimag(x[i__4]) * bli_zbla_real(a[i__1])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 			}
 		    }
 		    jx -= *incx;
@@ -1798,13 +1798,13 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__3 = j;
-		    bli_zsets( (bli_zreal(x[i__3])), (bli_zimag(x[i__3])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__3])), (bli_zimag(x[i__3])), temp );
 		    l = kplus1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__3 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zreal(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zreal(a[i__3])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zbla_real(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zbla_real(a[i__3])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1812,16 +1812,16 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    i__4 = l + i__ + j * a_dim1;
 			    i__1 = i__;
-			    bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zreal(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zreal(x[i__1])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__1])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L90: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1829,14 +1829,14 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__4 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L100: */
 			}
 		    }
 		    i__3 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__3] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__3] );
 /* L110: */
 		}
 	    } else {
@@ -1844,15 +1844,15 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__3 = jx;
-		    bli_zsets( (bli_zreal(x[i__3])), (bli_zimag(x[i__3])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__3])), (bli_zimag(x[i__3])), temp );
 		    kx -= *incx;
 		    ix = kx;
 		    l = kplus1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__3 = kplus1 + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zreal(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zreal(a[i__3])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__3]) - bli_zimag(temp) * bli_zimag(a[i__3])), (bli_zbla_real(temp) * bli_zimag(a[i__3]) + bli_zimag(temp) * bli_zbla_real(a[i__3])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1860,17 +1860,17 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    i__4 = l + i__ + j * a_dim1;
 			    i__1 = ix;
-			    bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zreal(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zreal(x[i__1])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__1]) - bli_zimag(a[i__4]) * bli_zimag(x[i__1])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__1]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__1])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L120: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MAX */
 			i__4 = 1, i__1 = j - *k;
@@ -1878,15 +1878,15 @@
 			for (i__ = j - 1; i__ >= i__3; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__4 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L130: */
 			}
 		    }
 		    i__3 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__3] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__3] );
 		    jx -= *incx;
 /* L140: */
 		}
@@ -1896,13 +1896,13 @@
 		i__3 = *n;
 		for (j = 1; j <= i__3; ++j) {
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
 		    l = 1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__4 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1910,16 +1910,16 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    i__1 = l + i__ + j * a_dim1;
 			    i__2 = i__;
-			    bli_zsets( (bli_zreal(a[i__1]) * bli_zreal(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zreal(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__1]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L150: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1927,14 +1927,14 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__1 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L160: */
 			}
 		    }
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
 /* L170: */
 		}
 	    } else {
@@ -1942,15 +1942,15 @@
 		i__3 = *n;
 		for (j = 1; j <= i__3; ++j) {
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
 		    kx += *incx;
 		    ix = kx;
 		    l = 1 - j;
 		    if (noconj) {
 			if (nounit) {
 			    i__4 = j * a_dim1 + 1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1958,17 +1958,17 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    i__1 = l + i__ + j * a_dim1;
 			    i__2 = ix;
-			    bli_zsets( (bli_zreal(a[i__1]) * bli_zreal(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zreal(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__1]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__1]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__1]) * bli_zimag(x[i__2]) + bli_zimag(a[i__1]) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L180: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 /* Computing MIN */
 			i__1 = *n, i__2 = j + *k;
@@ -1976,15 +1976,15 @@
 			for (i__ = j + 1; i__ <= i__4; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__1 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L190: */
 			}
 		    }
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
 		    jx += *incx;
 /* L200: */
 		}

--- a/frame/compat/f2c/bla_tbmv.h
+++ b/frame/compat/f2c/bla_tbmv.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx);
-int PASTEF77(d,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
-int PASTEF77(s,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, real *a, integer *lda, real *x, integer *incx);
-int PASTEF77(z,tbmv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
+int PASTEF77(c,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx);
+int PASTEF77(d,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx);
+int PASTEF77(s,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_real *a, bla_integer *lda, bla_real *x, bla_integer *incx);
+int PASTEF77(z,tbmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer *incx);
 
 #endif

--- a/frame/compat/f2c/bla_tbsv.c
+++ b/frame/compat/f2c/bla_tbsv.c
@@ -1660,15 +1660,15 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			l = kplus1 - j;
 			if (nounit) {
 			    i__1 = j;
 			    bla_z_div(&z__1, &x[j], &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = j;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 /* Computing MAX */
 			i__2 = 1, i__3 = j - *k;
 			i__1 = f2c_max(i__2,i__3);
@@ -1676,9 +1676,9 @@
 			    i__2 = i__;
 			    i__3 = i__;
 			    i__4 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) - bli_zbla_real(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) - bli_zreal(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 /* L10: */
 			}
 		    }
@@ -1690,16 +1690,16 @@
 		for (j = *n; j >= 1; --j) {
 		    kx -= *incx;
 		    i__1 = jx;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			ix = kx;
 			l = kplus1 - j;
 			if (nounit) {
 			    i__1 = jx;
 			    bla_z_div(&z__1, &x[jx], &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = jx;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 /* Computing MAX */
 			i__2 = 1, i__3 = j - *k;
 			i__1 = f2c_max(i__2,i__3);
@@ -1707,9 +1707,9 @@
 			    i__2 = ix;
 			    i__3 = ix;
 			    i__4 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) - bli_zbla_real(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) - bli_zreal(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			    ix -= *incx;
 /* L30: */
 			}
@@ -1723,15 +1723,15 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			l = 1 - j;
 			if (nounit) {
 			    i__2 = j;
 			    bla_z_div(&z__1, &x[j], &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = j;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 /* Computing MIN */
 			i__3 = *n, i__4 = j + *k;
 			i__2 = f2c_min(i__3,i__4);
@@ -1739,9 +1739,9 @@
 			    i__3 = i__;
 			    i__4 = i__;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 /* L50: */
 			}
 		    }
@@ -1753,16 +1753,16 @@
 		for (j = 1; j <= i__1; ++j) {
 		    kx += *incx;
 		    i__2 = jx;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			ix = kx;
 			l = 1 - j;
 			if (nounit) {
 			    i__2 = jx;
 			    bla_z_div(&z__1, &x[jx], &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = jx;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 /* Computing MIN */
 			i__3 = *n, i__4 = j + *k;
 			i__2 = f2c_min(i__3,i__4);
@@ -1770,9 +1770,9 @@
 			    i__3 = ix;
 			    i__4 = ix;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ix += *incx;
 /* L70: */
 			}
@@ -1792,7 +1792,7 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    l = kplus1 - j;
 		    if (noconj) {
 /* Computing MAX */
@@ -1801,14 +1801,14 @@
 			for (i__ = f2c_max(i__2,i__3); i__ <= i__4; ++i__) {
 			    i__2 = l + i__ + j * a_dim1;
 			    i__3 = i__;
-			    bli_zsets( (bli_zbla_real(a[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(a[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(a[i__2]) * bli_zimag(x[i__3]) + bli_zimag(a[i__2]) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__2]) * bli_zreal(x[i__3]) - bli_zimag(a[i__2]) * bli_zimag(x[i__3])), (bli_zreal(a[i__2]) * bli_zimag(x[i__3]) + bli_zimag(a[i__2]) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L90: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MAX */
@@ -1817,19 +1817,19 @@
 			for (i__ = f2c_max(i__4,i__2); i__ <= i__3; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__4 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L100: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__3 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__3] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__3] );
 /* L110: */
 		}
 	    } else {
@@ -1837,7 +1837,7 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__3 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__3])), (bli_zimag(x[i__3])), temp );
+		    bli_zsets( (bli_zreal(x[i__3])), (bli_zimag(x[i__3])), temp );
 		    ix = kx;
 		    l = kplus1 - j;
 		    if (noconj) {
@@ -1847,15 +1847,15 @@
 			for (i__ = f2c_max(i__3,i__4); i__ <= i__2; ++i__) {
 			    i__3 = l + i__ + j * a_dim1;
 			    i__4 = ix;
-			    bli_zsets( (bli_zbla_real(a[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__3]) * bli_zreal(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zreal(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L120: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MAX */
@@ -1864,20 +1864,20 @@
 			for (i__ = f2c_max(i__2,i__3); i__ <= i__4; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__2 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L130: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
 		    jx += *incx;
 		    if (j > *k) {
 			kx += *incx;
@@ -1889,7 +1889,7 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    l = 1 - j;
 		    if (noconj) {
 /* Computing MIN */
@@ -1898,14 +1898,14 @@
 			for (i__ = f2c_min(i__1,i__4); i__ >= i__2; --i__) {
 			    i__1 = l + i__ + j * a_dim1;
 			    i__4 = i__;
-			    bli_zsets( (bli_zbla_real(a[i__1]) * bli_zbla_real(x[i__4]) - bli_zimag(a[i__1]) * bli_zimag(x[i__4])), (bli_zbla_real(a[i__1]) * bli_zimag(x[i__4]) + bli_zimag(a[i__1]) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__1]) * bli_zreal(x[i__4]) - bli_zimag(a[i__1]) * bli_zimag(x[i__4])), (bli_zreal(a[i__1]) * bli_zimag(x[i__4]) + bli_zimag(a[i__1]) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L150: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MIN */
@@ -1914,19 +1914,19 @@
 			for (i__ = f2c_min(i__2,i__1); i__ >= i__4; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__2 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L160: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__4 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
 /* L170: */
 		}
 	    } else {
@@ -1934,7 +1934,7 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__4 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
+		    bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
 		    ix = kx;
 		    l = 1 - j;
 		    if (noconj) {
@@ -1944,15 +1944,15 @@
 			for (i__ = f2c_min(i__4,i__2); i__ >= i__1; --i__) {
 			    i__4 = l + i__ + j * a_dim1;
 			    i__2 = ix;
-			    bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zreal(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L180: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MIN */
@@ -1961,20 +1961,20 @@
 			for (i__ = f2c_min(i__1,i__4); i__ >= i__2; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__1 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L190: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
 		    jx -= *incx;
 		    if (*n - j >= *k) {
 			kx -= *incx;

--- a/frame/compat/f2c/bla_tbsv.c
+++ b/frame/compat/f2c/bla_tbsv.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx) 
+/* Subroutine */ int PASTEF77(c,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx) 
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
-    singlecomplex q__1, q__2, q__3;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void bla_c_div(singlecomplex *, singlecomplex *, singlecomplex *), bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_c_div(bla_scomplex *, bla_scomplex *, bla_scomplex *), bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_scomplex temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -603,19 +603,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx)
+/* Subroutine */ int PASTEF77(d,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
 
     /* Local variables */
-    integer info;
-    doublereal temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_double temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1018,19 +1018,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, real *a, integer *lda, real *x, integer *incx)
+/* Subroutine */ int PASTEF77(s,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_real *a, bla_integer *lda, bla_real *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4;
 
     /* Local variables */
-    integer info;
-    real temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_real temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1433,24 +1433,24 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublecomplex *a, integer *lda, doublecomplex *x, integer *incx)
+/* Subroutine */ int PASTEF77(z,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
-    doublecomplex z__1, z__2, z__3;
+    bla_integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+    bla_dcomplex z__1, z__2, z__3;
 
     /* Builtin functions */
-    void bla_z_div(doublecomplex *, doublecomplex *, doublecomplex *), bla_d_cnjg(
-	    doublecomplex *, doublecomplex *);
+    void bla_z_div(bla_dcomplex *, bla_dcomplex *, bla_dcomplex *), bla_d_cnjg(
+	    bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp;
-    integer i__, j, l;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kplus1, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_dcomplex temp;
+    bla_integer i__, j, l;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kplus1, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1660,15 +1660,15 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			l = kplus1 - j;
 			if (nounit) {
 			    i__1 = j;
 			    bla_z_div(&z__1, &x[j], &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = j;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 /* Computing MAX */
 			i__2 = 1, i__3 = j - *k;
 			i__1 = f2c_max(i__2,i__3);
@@ -1676,9 +1676,9 @@
 			    i__2 = i__;
 			    i__3 = i__;
 			    i__4 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) - bli_zreal(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) - bli_zbla_real(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 /* L10: */
 			}
 		    }
@@ -1690,16 +1690,16 @@
 		for (j = *n; j >= 1; --j) {
 		    kx -= *incx;
 		    i__1 = jx;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			ix = kx;
 			l = kplus1 - j;
 			if (nounit) {
 			    i__1 = jx;
 			    bla_z_div(&z__1, &x[jx], &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = jx;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 /* Computing MAX */
 			i__2 = 1, i__3 = j - *k;
 			i__1 = f2c_max(i__2,i__3);
@@ -1707,9 +1707,9 @@
 			    i__2 = ix;
 			    i__3 = ix;
 			    i__4 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zreal(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zreal(a[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) - bli_zreal(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__4]) - bli_zimag(temp) * bli_zimag(a[i__4])), (bli_zbla_real(temp) * bli_zimag(a[i__4]) + bli_zimag(temp) * bli_zbla_real(a[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) - bli_zbla_real(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			    ix -= *incx;
 /* L30: */
 			}
@@ -1723,15 +1723,15 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			l = 1 - j;
 			if (nounit) {
 			    i__2 = j;
 			    bla_z_div(&z__1, &x[j], &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = j;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 /* Computing MIN */
 			i__3 = *n, i__4 = j + *k;
 			i__2 = f2c_min(i__3,i__4);
@@ -1739,9 +1739,9 @@
 			    i__3 = i__;
 			    i__4 = i__;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 /* L50: */
 			}
 		    }
@@ -1753,16 +1753,16 @@
 		for (j = 1; j <= i__1; ++j) {
 		    kx += *incx;
 		    i__2 = jx;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			ix = kx;
 			l = 1 - j;
 			if (nounit) {
 			    i__2 = jx;
 			    bla_z_div(&z__1, &x[jx], &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = jx;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 /* Computing MIN */
 			i__3 = *n, i__4 = j + *k;
 			i__2 = f2c_min(i__3,i__4);
@@ -1770,9 +1770,9 @@
 			    i__3 = ix;
 			    i__4 = ix;
 			    i__5 = l + i__ + j * a_dim1;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zreal(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zreal(a[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(a[i__5]) - bli_zimag(temp) * bli_zimag(a[i__5])), (bli_zbla_real(temp) * bli_zimag(a[i__5]) + bli_zimag(temp) * bli_zbla_real(a[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ix += *incx;
 /* L70: */
 			}
@@ -1792,7 +1792,7 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    l = kplus1 - j;
 		    if (noconj) {
 /* Computing MAX */
@@ -1801,14 +1801,14 @@
 			for (i__ = f2c_max(i__2,i__3); i__ <= i__4; ++i__) {
 			    i__2 = l + i__ + j * a_dim1;
 			    i__3 = i__;
-			    bli_zsets( (bli_zreal(a[i__2]) * bli_zreal(x[i__3]) - bli_zimag(a[i__2]) * bli_zimag(x[i__3])), (bli_zreal(a[i__2]) * bli_zimag(x[i__3]) + bli_zimag(a[i__2]) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(a[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(a[i__2]) * bli_zimag(x[i__3]) + bli_zimag(a[i__2]) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L90: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MAX */
@@ -1817,19 +1817,19 @@
 			for (i__ = f2c_max(i__4,i__2); i__ <= i__3; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__4 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zreal(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__4]) - bli_zimag(z__3) * bli_zimag(x[i__4])), (bli_zbla_real(z__3) * bli_zimag(x[i__4]) + bli_zimag(z__3) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L100: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__3 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__3] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__3] );
 /* L110: */
 		}
 	    } else {
@@ -1837,7 +1837,7 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__3 = jx;
-		    bli_zsets( (bli_zreal(x[i__3])), (bli_zimag(x[i__3])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__3])), (bli_zimag(x[i__3])), temp );
 		    ix = kx;
 		    l = kplus1 - j;
 		    if (noconj) {
@@ -1847,15 +1847,15 @@
 			for (i__ = f2c_max(i__3,i__4); i__ <= i__2; ++i__) {
 			    i__3 = l + i__ + j * a_dim1;
 			    i__4 = ix;
-			    bli_zsets( (bli_zreal(a[i__3]) * bli_zreal(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zreal(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(a[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(a[i__3]) * bli_zimag(x[i__4]) + bli_zimag(a[i__3]) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L120: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[kplus1 + j * a_dim1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MAX */
@@ -1864,20 +1864,20 @@
 			for (i__ = f2c_max(i__2,i__3); i__ <= i__4; ++i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__2 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L130: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[kplus1 + j * a_dim1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
 		    jx += *incx;
 		    if (j > *k) {
 			kx += *incx;
@@ -1889,7 +1889,7 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    l = 1 - j;
 		    if (noconj) {
 /* Computing MIN */
@@ -1898,14 +1898,14 @@
 			for (i__ = f2c_min(i__1,i__4); i__ >= i__2; --i__) {
 			    i__1 = l + i__ + j * a_dim1;
 			    i__4 = i__;
-			    bli_zsets( (bli_zreal(a[i__1]) * bli_zreal(x[i__4]) - bli_zimag(a[i__1]) * bli_zimag(x[i__4])), (bli_zreal(a[i__1]) * bli_zimag(x[i__4]) + bli_zimag(a[i__1]) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__1]) * bli_zbla_real(x[i__4]) - bli_zimag(a[i__1]) * bli_zimag(x[i__4])), (bli_zbla_real(a[i__1]) * bli_zimag(x[i__4]) + bli_zimag(a[i__1]) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L150: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MIN */
@@ -1914,19 +1914,19 @@
 			for (i__ = f2c_min(i__2,i__1); i__ >= i__4; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__2 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L160: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__4 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__4] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__4] );
 /* L170: */
 		}
 	    } else {
@@ -1934,7 +1934,7 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__4 = jx;
-		    bli_zsets( (bli_zreal(x[i__4])), (bli_zimag(x[i__4])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__4])), (bli_zimag(x[i__4])), temp );
 		    ix = kx;
 		    l = 1 - j;
 		    if (noconj) {
@@ -1944,15 +1944,15 @@
 			for (i__ = f2c_min(i__4,i__2); i__ >= i__1; --i__) {
 			    i__4 = l + i__ + j * a_dim1;
 			    i__2 = ix;
-			    bli_zsets( (bli_zreal(a[i__4]) * bli_zreal(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zreal(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(a[i__4]) * bli_zbla_real(x[i__2]) - bli_zimag(a[i__4]) * bli_zimag(x[i__2])), (bli_zbla_real(a[i__4]) * bli_zimag(x[i__2]) + bli_zimag(a[i__4]) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L180: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &a[j * a_dim1 + 1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 /* Computing MIN */
@@ -1961,20 +1961,20 @@
 			for (i__ = f2c_min(i__1,i__4); i__ >= i__2; --i__) {
 			    bla_d_cnjg(&z__3, &a[l + i__ + j * a_dim1]);
 			    i__1 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L190: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &a[j * a_dim1 + 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
 		    jx -= *incx;
 		    if (*n - j >= *k) {
 			kx -= *incx;

--- a/frame/compat/f2c/bla_tbsv.h
+++ b/frame/compat/f2c/bla_tbsv.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx);
-int PASTEF77(d,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublereal *a, integer *lda, doublereal *x, integer *incx);
-int PASTEF77(s,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, real *a, integer *lda, real *x, integer *incx);
-int PASTEF77(z,tbsv)(character *uplo, character *trans, character *diag, integer *n, integer *k, doublecomplex *a, integer *lda, doublecomplex *x, integer *incx);
+int PASTEF77(c,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_scomplex *a, bla_integer *lda, bla_scomplex *x, bla_integer *incx);
+int PASTEF77(d,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_double *a, bla_integer *lda, bla_double *x, bla_integer *incx);
+int PASTEF77(s,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_real *a, bla_integer *lda, bla_real *x, bla_integer *incx);
+int PASTEF77(z,tbsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_integer *k, bla_dcomplex *a, bla_integer *lda, bla_dcomplex *x, bla_integer *incx);
 
 #endif

--- a/frame/compat/f2c/bla_tpmv.c
+++ b/frame/compat/f2c/bla_tpmv.c
@@ -1415,18 +1415,18 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			i__2 = j;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 			k = kk;
 			i__2 = j - 1;
 			for (i__ = 1; i__ <= i__2; ++i__) {
 			    i__3 = i__;
 			    i__4 = i__;
 			    i__5 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__4]) + bli_zbla_real(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__4]) + bli_zreal(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ++k;
 /* L10: */
 			}
@@ -1434,8 +1434,8 @@
 			    i__2 = j;
 			    i__3 = j;
 			    i__4 = kk + j - 1;
-			    bli_zsets( (bli_zbla_real(x[i__3]) * bli_zbla_real(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zbla_real(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zbla_real(ap[i__4])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(x[i__3]) * bli_zreal(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zreal(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zreal(ap[i__4])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 		    }
 		    kk += j;
@@ -1446,18 +1446,18 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			i__2 = jx;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 			ix = kx;
 			i__2 = kk + j - 2;
 			for (k = kk; k <= i__2; ++k) {
 			    i__3 = ix;
 			    i__4 = ix;
 			    i__5 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__4]) + bli_zbla_real(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__4]) + bli_zreal(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ix += *incx;
 /* L30: */
 			}
@@ -1465,8 +1465,8 @@
 			    i__2 = jx;
 			    i__3 = jx;
 			    i__4 = kk + j - 1;
-			    bli_zsets( (bli_zbla_real(x[i__3]) * bli_zbla_real(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zbla_real(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zbla_real(ap[i__4])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(x[i__3]) * bli_zreal(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zreal(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zreal(ap[i__4])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 		    }
 		    jx += *incx;
@@ -1479,18 +1479,18 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			i__1 = j;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 			k = kk;
 			i__1 = j + 1;
 			for (i__ = *n; i__ >= i__1; --i__) {
 			    i__2 = i__;
 			    i__3 = i__;
 			    i__4 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zbla_real(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zbla_real(ap[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zreal(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zreal(ap[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			    --k;
 /* L50: */
 			}
@@ -1498,8 +1498,8 @@
 			    i__1 = j;
 			    i__2 = j;
 			    i__3 = kk - *n + j;
-			    bli_zsets( (bli_zbla_real(x[i__2]) * bli_zbla_real(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zbla_real(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zbla_real(ap[i__3])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(x[i__2]) * bli_zreal(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zreal(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zreal(ap[i__3])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 		    }
 		    kk -= *n - j + 1;
@@ -1510,18 +1510,18 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			i__1 = jx;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 			ix = kx;
 			i__1 = kk - (*n - (j + 1));
 			for (k = kk; k >= i__1; --k) {
 			    i__2 = ix;
 			    i__3 = ix;
 			    i__4 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zbla_real(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zbla_real(ap[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zreal(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zreal(ap[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			    ix -= *incx;
 /* L70: */
 			}
@@ -1529,8 +1529,8 @@
 			    i__1 = jx;
 			    i__2 = jx;
 			    i__3 = kk - *n + j;
-			    bli_zsets( (bli_zbla_real(x[i__2]) * bli_zbla_real(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zbla_real(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zbla_real(ap[i__3])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(x[i__2]) * bli_zreal(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zreal(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zreal(ap[i__3])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 		    }
 		    jx -= *incx;
@@ -1548,41 +1548,41 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    k = kk - 1;
 		    if (noconj) {
 			if (nounit) {
 			    i__1 = kk;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zbla_real(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zbla_real(ap[i__1])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zreal(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zreal(ap[i__1])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			for (i__ = j - 1; i__ >= 1; --i__) {
 			    i__1 = k;
 			    i__2 = i__;
-			    bli_zsets( (bli_zbla_real(ap[i__1]) * bli_zbla_real(x[i__2]) - bli_zimag(ap[i__1]) * bli_zimag(x[i__2])), (bli_zbla_real(ap[i__1]) * bli_zimag(x[i__2]) + bli_zimag(ap[i__1]) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__1]) * bli_zreal(x[i__2]) - bli_zimag(ap[i__1]) * bli_zimag(x[i__2])), (bli_zreal(ap[i__1]) * bli_zimag(x[i__2]) + bli_zimag(ap[i__1]) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L90: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			for (i__ = j - 1; i__ >= 1; --i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__1 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L100: */
 			}
 		    }
 		    i__1 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
 		    kk -= j;
 /* L110: */
 		}
@@ -1590,43 +1590,43 @@
 		jx = kx + (*n - 1) * *incx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    ix = jx;
 		    if (noconj) {
 			if (nounit) {
 			    i__1 = kk;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zbla_real(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zbla_real(ap[i__1])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zreal(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zreal(ap[i__1])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__1 = kk - j + 1;
 			for (k = kk - 1; k >= i__1; --k) {
 			    ix -= *incx;
 			    i__2 = k;
 			    i__3 = ix;
-			    bli_zsets( (bli_zbla_real(ap[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__2]) * bli_zreal(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zreal(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L120: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__1 = kk - j + 1;
 			for (k = kk - 1; k >= i__1; --k) {
 			    ix -= *incx;
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__2 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L130: */
 			}
 		    }
 		    i__1 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
 		    jx -= *incx;
 		    kk -= j;
 /* L140: */
@@ -1638,43 +1638,43 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    k = kk + 1;
 		    if (noconj) {
 			if (nounit) {
 			    i__2 = kk;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zbla_real(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zbla_real(ap[i__2])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zreal(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zreal(ap[i__2])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = *n;
 			for (i__ = j + 1; i__ <= i__2; ++i__) {
 			    i__3 = k;
 			    i__4 = i__;
-			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L150: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = *n;
 			for (i__ = j + 1; i__ <= i__2; ++i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L160: */
 			}
 		    }
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
 		    kk += *n - j + 1;
 /* L170: */
 		}
@@ -1683,43 +1683,43 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    ix = jx;
 		    if (noconj) {
 			if (nounit) {
 			    i__2 = kk;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zbla_real(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zbla_real(ap[i__2])), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zreal(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zreal(ap[i__2])), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = kk + *n - j;
 			for (k = kk + 1; k <= i__2; ++k) {
 			    ix += *incx;
 			    i__3 = k;
 			    i__4 = ix;
-			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L180: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = kk + *n - j;
 			for (k = kk + 1; k <= i__2; ++k) {
 			    ix += *incx;
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 /* L190: */
 			}
 		    }
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
 		    jx += *incx;
 		    kk += *n - j + 1;
 /* L200: */

--- a/frame/compat/f2c/bla_tpmv.c
+++ b/frame/compat/f2c/bla_tpmv.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,tpmv)(character *uplo, character *trans, character *diag, integer *n, singlecomplex *ap, singlecomplex *x, integer *incx)
+/* Subroutine */ int PASTEF77(c,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_scomplex *ap, bla_scomplex *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    singlecomplex q__1, q__2, q__3;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_scomplex temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -542,19 +542,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,tpmv)(character *uplo, character *trans, character *diag, integer *n, doublereal *ap, doublereal *x, integer *incx)
+/* Subroutine */ int PASTEF77(d,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_double *ap, bla_double *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    doublereal temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_double temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -890,19 +890,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,tpmv)(character *uplo, character *trans, character *diag, integer *n, real *ap, real *x, integer *incx)
+/* Subroutine */ int PASTEF77(s,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_real *ap, bla_real *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    real temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_real temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1238,23 +1238,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,tpmv)(character *uplo, character *trans, character *diag, integer *n, doublecomplex *ap, doublecomplex *x, integer *incx)
+/* Subroutine */ int PASTEF77(z,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_dcomplex *ap, bla_dcomplex *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    doublecomplex z__1, z__2, z__3;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_dcomplex z__1, z__2, z__3;
 
     /* Builtin functions */
-    void bla_d_cnjg(doublecomplex *, doublecomplex *);
+    void bla_d_cnjg(bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_dcomplex temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1415,18 +1415,18 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			i__2 = j;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 			k = kk;
 			i__2 = j - 1;
 			for (i__ = 1; i__ <= i__2; ++i__) {
 			    i__3 = i__;
 			    i__4 = i__;
 			    i__5 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__4]) + bli_zreal(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__4]) + bli_zbla_real(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ++k;
 /* L10: */
 			}
@@ -1434,8 +1434,8 @@
 			    i__2 = j;
 			    i__3 = j;
 			    i__4 = kk + j - 1;
-			    bli_zsets( (bli_zreal(x[i__3]) * bli_zreal(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zreal(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zreal(ap[i__4])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(x[i__3]) * bli_zbla_real(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zbla_real(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zbla_real(ap[i__4])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 		    }
 		    kk += j;
@@ -1446,18 +1446,18 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			i__2 = jx;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 			ix = kx;
 			i__2 = kk + j - 2;
 			for (k = kk; k <= i__2; ++k) {
 			    i__3 = ix;
 			    i__4 = ix;
 			    i__5 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__4]) + bli_zreal(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__4]) + bli_zbla_real(z__2)), (bli_zimag(x[i__4]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ix += *incx;
 /* L30: */
 			}
@@ -1465,8 +1465,8 @@
 			    i__2 = jx;
 			    i__3 = jx;
 			    i__4 = kk + j - 1;
-			    bli_zsets( (bli_zreal(x[i__3]) * bli_zreal(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zreal(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zreal(ap[i__4])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(x[i__3]) * bli_zbla_real(ap[i__4]) - bli_zimag(x[i__3]) * bli_zimag(ap[i__4])), (bli_zbla_real(x[i__3]) * bli_zimag(ap[i__4]) + bli_zimag(x[i__3]) * bli_zbla_real(ap[i__4])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 		    }
 		    jx += *incx;
@@ -1479,18 +1479,18 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			i__1 = j;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 			k = kk;
 			i__1 = j + 1;
 			for (i__ = *n; i__ >= i__1; --i__) {
 			    i__2 = i__;
 			    i__3 = i__;
 			    i__4 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zreal(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zreal(ap[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zbla_real(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zbla_real(ap[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			    --k;
 /* L50: */
 			}
@@ -1498,8 +1498,8 @@
 			    i__1 = j;
 			    i__2 = j;
 			    i__3 = kk - *n + j;
-			    bli_zsets( (bli_zreal(x[i__2]) * bli_zreal(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zreal(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zreal(ap[i__3])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(x[i__2]) * bli_zbla_real(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zbla_real(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zbla_real(ap[i__3])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 		    }
 		    kk -= *n - j + 1;
@@ -1510,18 +1510,18 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			i__1 = jx;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 			ix = kx;
 			i__1 = kk - (*n - (j + 1));
 			for (k = kk; k >= i__1; --k) {
 			    i__2 = ix;
 			    i__3 = ix;
 			    i__4 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zreal(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zreal(ap[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) + bli_zreal(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zbla_real(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zbla_real(ap[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) + bli_zbla_real(z__2)), (bli_zimag(x[i__3]) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			    ix -= *incx;
 /* L70: */
 			}
@@ -1529,8 +1529,8 @@
 			    i__1 = jx;
 			    i__2 = jx;
 			    i__3 = kk - *n + j;
-			    bli_zsets( (bli_zreal(x[i__2]) * bli_zreal(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zreal(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zreal(ap[i__3])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(x[i__2]) * bli_zbla_real(ap[i__3]) - bli_zimag(x[i__2]) * bli_zimag(ap[i__3])), (bli_zbla_real(x[i__2]) * bli_zimag(ap[i__3]) + bli_zimag(x[i__2]) * bli_zbla_real(ap[i__3])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 		    }
 		    jx -= *incx;
@@ -1548,41 +1548,41 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    k = kk - 1;
 		    if (noconj) {
 			if (nounit) {
 			    i__1 = kk;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zreal(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zreal(ap[i__1])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zbla_real(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zbla_real(ap[i__1])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			for (i__ = j - 1; i__ >= 1; --i__) {
 			    i__1 = k;
 			    i__2 = i__;
-			    bli_zsets( (bli_zreal(ap[i__1]) * bli_zreal(x[i__2]) - bli_zimag(ap[i__1]) * bli_zimag(x[i__2])), (bli_zreal(ap[i__1]) * bli_zimag(x[i__2]) + bli_zimag(ap[i__1]) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__1]) * bli_zbla_real(x[i__2]) - bli_zimag(ap[i__1]) * bli_zimag(x[i__2])), (bli_zbla_real(ap[i__1]) * bli_zimag(x[i__2]) + bli_zimag(ap[i__1]) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L90: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			for (i__ = j - 1; i__ >= 1; --i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__1 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zreal(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zreal(x[i__1])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__1]) - bli_zimag(z__3) * bli_zimag(x[i__1])), (bli_zbla_real(z__3) * bli_zimag(x[i__1]) + bli_zimag(z__3) * bli_zbla_real(x[i__1])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L100: */
 			}
 		    }
 		    i__1 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
 		    kk -= j;
 /* L110: */
 		}
@@ -1590,43 +1590,43 @@
 		jx = kx + (*n - 1) * *incx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    ix = jx;
 		    if (noconj) {
 			if (nounit) {
 			    i__1 = kk;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zreal(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zreal(ap[i__1])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__1]) - bli_zimag(temp) * bli_zimag(ap[i__1])), (bli_zbla_real(temp) * bli_zimag(ap[i__1]) + bli_zimag(temp) * bli_zbla_real(ap[i__1])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__1 = kk - j + 1;
 			for (k = kk - 1; k >= i__1; --k) {
 			    ix -= *incx;
 			    i__2 = k;
 			    i__3 = ix;
-			    bli_zsets( (bli_zreal(ap[i__2]) * bli_zreal(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zreal(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L120: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__1 = kk - j + 1;
 			for (k = kk - 1; k >= i__1; --k) {
 			    ix -= *incx;
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__2 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L130: */
 			}
 		    }
 		    i__1 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
 		    jx -= *incx;
 		    kk -= j;
 /* L140: */
@@ -1638,43 +1638,43 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    k = kk + 1;
 		    if (noconj) {
 			if (nounit) {
 			    i__2 = kk;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zreal(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zreal(ap[i__2])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zbla_real(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zbla_real(ap[i__2])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = *n;
 			for (i__ = j + 1; i__ <= i__2; ++i__) {
 			    i__3 = k;
 			    i__4 = i__;
-			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L150: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = *n;
 			for (i__ = j + 1; i__ <= i__2; ++i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L160: */
 			}
 		    }
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
 		    kk += *n - j + 1;
 /* L170: */
 		}
@@ -1683,43 +1683,43 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    ix = jx;
 		    if (noconj) {
 			if (nounit) {
 			    i__2 = kk;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zreal(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zreal(ap[i__2])), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__2]) - bli_zimag(temp) * bli_zimag(ap[i__2])), (bli_zbla_real(temp) * bli_zimag(ap[i__2]) + bli_zimag(temp) * bli_zbla_real(ap[i__2])), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = kk + *n - j;
 			for (k = kk + 1; k <= i__2; ++k) {
 			    ix += *incx;
 			    i__3 = k;
 			    i__4 = ix;
-			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L180: */
 			}
 		    } else {
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk]);
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zreal(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zreal(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(z__2) - bli_zimag(temp) * bli_zimag(z__2)), (bli_zbla_real(temp) * bli_zimag(z__2) + bli_zimag(temp) * bli_zbla_real(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 			i__2 = kk + *n - j;
 			for (k = kk + 1; k <= i__2; ++k) {
 			    ix += *incx;
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) + bli_zreal(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) + bli_zbla_real(z__2)), (bli_zimag(temp) + bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 /* L190: */
 			}
 		    }
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
 		    jx += *incx;
 		    kk += *n - j + 1;
 /* L200: */

--- a/frame/compat/f2c/bla_tpmv.h
+++ b/frame/compat/f2c/bla_tpmv.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,tpmv)(character *uplo, character *trans, character *diag, integer *n, singlecomplex *ap, singlecomplex *x, integer *incx);
-int PASTEF77(d,tpmv)(character *uplo, character *trans, character *diag, integer *n, doublereal *ap, doublereal *x, integer *incx);
-int PASTEF77(s,tpmv)(character *uplo, character *trans, character *diag, integer *n, real *ap, real *x, integer *incx);
-int PASTEF77(z,tpmv)(character *uplo, character *trans, character *diag, integer *n, doublecomplex *ap, doublecomplex *x, integer *incx);
+int PASTEF77(c,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_scomplex *ap, bla_scomplex *x, bla_integer *incx);
+int PASTEF77(d,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_double *ap, bla_double *x, bla_integer *incx);
+int PASTEF77(s,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_real *ap, bla_real *x, bla_integer *incx);
+int PASTEF77(z,tpmv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_dcomplex *ap, bla_dcomplex *x, bla_integer *incx);
 
 #endif

--- a/frame/compat/f2c/bla_tpsv.c
+++ b/frame/compat/f2c/bla_tpsv.c
@@ -41,23 +41,23 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(c,tpsv)(character *uplo, character *trans, character *diag, integer *n, singlecomplex *ap, singlecomplex *x, integer *incx)
+/* Subroutine */ int PASTEF77(c,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_scomplex *ap, bla_scomplex *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    singlecomplex q__1, q__2, q__3;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_scomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void bla_c_div(singlecomplex *, singlecomplex *, singlecomplex *), bla_r_cnjg(singlecomplex *, singlecomplex *);
+    void bla_c_div(bla_scomplex *, bla_scomplex *, bla_scomplex *), bla_r_cnjg(bla_scomplex *, bla_scomplex *);
 
     /* Local variables */
-    integer info;
-    singlecomplex temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_scomplex temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -534,19 +534,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(d,tpsv)(character *uplo, character *trans, character *diag, integer *n, doublereal *ap, doublereal *x, integer *incx)
+/* Subroutine */ int PASTEF77(d,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_double *ap, bla_double *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    doublereal temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_double temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -885,19 +885,19 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(s,tpsv)(character *uplo, character *trans, character *diag, integer *n, real *ap, real *x, integer *incx)
+/* Subroutine */ int PASTEF77(s,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_real *ap, bla_real *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    bla_integer i__1, i__2;
 
     /* Local variables */
-    integer info;
-    real temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical nounit;
+    bla_integer info;
+    bla_real temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1236,24 +1236,24 @@
 	-lf2c -lm   (in that order)
 */
 
-/* Subroutine */ int PASTEF77(z,tpsv)(character *uplo, character *trans, character *diag, integer *n, doublecomplex *ap, doublecomplex *x, integer *incx)
+/* Subroutine */ int PASTEF77(z,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_dcomplex *ap, bla_dcomplex *x, bla_integer *incx)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4, i__5;
-    doublecomplex z__1, z__2, z__3;
+    bla_integer i__1, i__2, i__3, i__4, i__5;
+    bla_dcomplex z__1, z__2, z__3;
 
     /* Builtin functions */
-    void bla_z_div(doublecomplex *, doublecomplex *, doublecomplex *), bla_d_cnjg(
-	    doublecomplex *, doublecomplex *);
+    void bla_z_div(bla_dcomplex *, bla_dcomplex *, bla_dcomplex *), bla_d_cnjg(
+	    bla_dcomplex *, bla_dcomplex *);
 
     /* Local variables */
-    integer info;
-    doublecomplex temp;
-    integer i__, j, k;
-    extern logical PASTEF770(lsame)(character *, character *, ftnlen, ftnlen);
-    integer kk, ix, jx, kx = 0;
-    extern /* Subroutine */ int PASTEF770(xerbla)(character *, integer *, ftnlen);
-    logical noconj, nounit;
+    bla_integer info;
+    bla_dcomplex temp;
+    bla_integer i__, j, k;
+    extern bla_logical PASTEF770(lsame)(bla_character *, bla_character *, ftnlen, ftnlen);
+    bla_integer kk, ix, jx, kx = 0;
+    extern /* Subroutine */ int PASTEF770(xerbla)(bla_character *, bla_integer *, ftnlen);
+    bla_logical noconj, nounit;
 
 /*     .. Scalar Arguments .. */
 /*     .. Array Arguments .. */
@@ -1416,22 +1416,22 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			if (nounit) {
 			    i__1 = j;
 			    bla_z_div(&z__1, &x[j], &ap[kk]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = j;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 			k = kk - 1;
 			for (i__ = j - 1; i__ >= 1; --i__) {
 			    i__1 = i__;
 			    i__2 = i__;
 			    i__3 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__3]) - bli_zimag(temp) * bli_zimag(ap[i__3])), (bli_zreal(temp) * bli_zimag(ap[i__3]) + bli_zimag(temp) * bli_zreal(ap[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__2]) - bli_zreal(z__2)), (bli_zimag(x[i__2]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__3]) - bli_zimag(temp) * bli_zimag(ap[i__3])), (bli_zbla_real(temp) * bli_zimag(ap[i__3]) + bli_zimag(temp) * bli_zbla_real(ap[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__2]) - bli_zbla_real(z__2)), (bli_zimag(x[i__2]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			    --k;
 /* L10: */
 			}
@@ -1443,14 +1443,14 @@
 		jx = kx + (*n - 1) * *incx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			if (nounit) {
 			    i__1 = jx;
 			    bla_z_div(&z__1, &x[jx], &ap[kk]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = jx;
-			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 			ix = jx;
 			i__1 = kk - j + 1;
 			for (k = kk - 1; k >= i__1; --k) {
@@ -1458,9 +1458,9 @@
 			    i__2 = ix;
 			    i__3 = ix;
 			    i__4 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zreal(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zreal(ap[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__3]) - bli_zreal(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zbla_real(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zbla_real(ap[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__3]) - bli_zbla_real(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 /* L30: */
 			}
 		    }
@@ -1475,23 +1475,23 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			if (nounit) {
 			    i__2 = j;
 			    bla_z_div(&z__1, &x[j], &ap[kk]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = j;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 			k = kk + 1;
 			i__2 = *n;
 			for (i__ = j + 1; i__ <= i__2; ++i__) {
 			    i__3 = i__;
 			    i__4 = i__;
 			    i__5 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ++k;
 /* L50: */
 			}
@@ -1504,14 +1504,14 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			if (nounit) {
 			    i__2 = jx;
 			    bla_z_div(&z__1, &x[jx], &ap[kk]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = jx;
-			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 			ix = jx;
 			i__2 = kk + *n - j;
 			for (k = kk + 1; k <= i__2; ++k) {
@@ -1519,9 +1519,9 @@
 			    i__3 = ix;
 			    i__4 = ix;
 			    i__5 = k;
-			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
 /* L70: */
 			}
 		    }
@@ -1541,42 +1541,42 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    k = kk;
 		    if (noconj) {
 			i__2 = j - 1;
 			for (i__ = 1; i__ <= i__2; ++i__) {
 			    i__3 = k;
 			    i__4 = i__;
-			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L90: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk + j - 1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__2 = j - 1;
 			for (i__ = 1; i__ <= i__2; ++i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L100: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk + j - 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__2 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
 		    kk += j;
 /* L110: */
 		}
@@ -1585,42 +1585,42 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    ix = kx;
 		    if (noconj) {
 			i__2 = kk + j - 2;
 			for (k = kk; k <= i__2; ++k) {
 			    i__3 = k;
 			    i__4 = ix;
-			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L120: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk + j - 1]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__2 = kk + j - 2;
 			for (k = kk; k <= i__2; ++k) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L130: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk + j - 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__2 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
 		    jx += *incx;
 		    kk += j;
 /* L140: */
@@ -1631,42 +1631,42 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    k = kk;
 		    if (noconj) {
 			i__1 = j + 1;
 			for (i__ = *n; i__ >= i__1; --i__) {
 			    i__2 = k;
 			    i__3 = i__;
-			    bli_zsets( (bli_zreal(ap[i__2]) * bli_zreal(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zreal(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L150: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk - *n + j]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__1 = j + 1;
 			for (i__ = *n; i__ >= i__1; --i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__2 = i__;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L160: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk - *n + j]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__1 = j;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
 		    kk -= *n - j + 1;
 /* L170: */
 		}
@@ -1675,42 +1675,42 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    ix = kx;
 		    if (noconj) {
 			i__1 = kk - (*n - (j + 1));
 			for (k = kk; k >= i__1; --k) {
 			    i__2 = k;
 			    i__3 = ix;
-			    bli_zsets( (bli_zreal(ap[i__2]) * bli_zreal(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zreal(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zreal(x[i__3])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(ap[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zbla_real(x[i__3])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L180: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk - *n + j]);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__1 = kk - (*n - (j + 1));
 			for (k = kk; k >= i__1; --k) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__2 = ix;
-			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
-			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
+			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L190: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk - *n + j]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__1 = jx;
-		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
 		    jx -= *incx;
 		    kk -= *n - j + 1;
 /* L200: */

--- a/frame/compat/f2c/bla_tpsv.c
+++ b/frame/compat/f2c/bla_tpsv.c
@@ -1416,22 +1416,22 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			if (nounit) {
 			    i__1 = j;
 			    bla_z_div(&z__1, &x[j], &ap[kk]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = j;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 			k = kk - 1;
 			for (i__ = j - 1; i__ >= 1; --i__) {
 			    i__1 = i__;
 			    i__2 = i__;
 			    i__3 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__3]) - bli_zimag(temp) * bli_zimag(ap[i__3])), (bli_zbla_real(temp) * bli_zimag(ap[i__3]) + bli_zimag(temp) * bli_zbla_real(ap[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__2]) - bli_zbla_real(z__2)), (bli_zimag(x[i__2]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__3]) - bli_zimag(temp) * bli_zimag(ap[i__3])), (bli_zreal(temp) * bli_zimag(ap[i__3]) + bli_zimag(temp) * bli_zreal(ap[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__2]) - bli_zreal(z__2)), (bli_zimag(x[i__2]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			    --k;
 /* L10: */
 			}
@@ -1443,14 +1443,14 @@
 		jx = kx + (*n - 1) * *incx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    if (bli_zbla_real(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
+		    if (bli_zreal(x[i__1]) != 0. || bli_zimag(x[i__1]) != 0.) {
 			if (nounit) {
 			    i__1 = jx;
 			    bla_z_div(&z__1, &x[jx], &ap[kk]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__1] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__1] );
 			}
 			i__1 = jx;
-			bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+			bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 			ix = jx;
 			i__1 = kk - j + 1;
 			for (k = kk - 1; k >= i__1; --k) {
@@ -1458,9 +1458,9 @@
 			    i__2 = ix;
 			    i__3 = ix;
 			    i__4 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zbla_real(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zbla_real(ap[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__3]) - bli_zbla_real(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__4]) - bli_zimag(temp) * bli_zimag(ap[i__4])), (bli_zreal(temp) * bli_zimag(ap[i__4]) + bli_zimag(temp) * bli_zreal(ap[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__3]) - bli_zreal(z__2)), (bli_zimag(x[i__3]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 /* L30: */
 			}
 		    }
@@ -1475,23 +1475,23 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			if (nounit) {
 			    i__2 = j;
 			    bla_z_div(&z__1, &x[j], &ap[kk]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = j;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 			k = kk + 1;
 			i__2 = *n;
 			for (i__ = j + 1; i__ <= i__2; ++i__) {
 			    i__3 = i__;
 			    i__4 = i__;
 			    i__5 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 			    ++k;
 /* L50: */
 			}
@@ -1504,14 +1504,14 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    if (bli_zbla_real(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
+		    if (bli_zreal(x[i__2]) != 0. || bli_zimag(x[i__2]) != 0.) {
 			if (nounit) {
 			    i__2 = jx;
 			    bla_z_div(&z__1, &x[jx], &ap[kk]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__2] );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__2] );
 			}
 			i__2 = jx;
-			bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+			bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 			ix = jx;
 			i__2 = kk + *n - j;
 			for (k = kk + 1; k <= i__2; ++k) {
@@ -1519,9 +1519,9 @@
 			    i__3 = ix;
 			    i__4 = ix;
 			    i__5 = k;
-			    bli_zsets( (bli_zbla_real(temp) * bli_zbla_real(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zbla_real(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zbla_real(ap[i__5])), z__2 );
-			    bli_zsets( (bli_zbla_real(x[i__4]) - bli_zbla_real(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), x[i__3] );
+			    bli_zsets( (bli_zreal(temp) * bli_zreal(ap[i__5]) - bli_zimag(temp) * bli_zimag(ap[i__5])), (bli_zreal(temp) * bli_zimag(ap[i__5]) + bli_zimag(temp) * bli_zreal(ap[i__5])), z__2 );
+			    bli_zsets( (bli_zreal(x[i__4]) - bli_zreal(z__2)), (bli_zimag(x[i__4]) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), x[i__3] );
 /* L70: */
 			}
 		    }
@@ -1541,42 +1541,42 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    k = kk;
 		    if (noconj) {
 			i__2 = j - 1;
 			for (i__ = 1; i__ <= i__2; ++i__) {
 			    i__3 = k;
 			    i__4 = i__;
-			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L90: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk + j - 1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__2 = j - 1;
 			for (i__ = 1; i__ <= i__2; ++i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ++k;
 /* L100: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk + j - 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__2 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
 		    kk += j;
 /* L110: */
 		}
@@ -1585,42 +1585,42 @@
 		i__1 = *n;
 		for (j = 1; j <= i__1; ++j) {
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__2])), (bli_zimag(x[i__2])), temp );
+		    bli_zsets( (bli_zreal(x[i__2])), (bli_zimag(x[i__2])), temp );
 		    ix = kx;
 		    if (noconj) {
 			i__2 = kk + j - 2;
 			for (k = kk; k <= i__2; ++k) {
 			    i__3 = k;
 			    i__4 = ix;
-			    bli_zsets( (bli_zbla_real(ap[i__3]) * bli_zbla_real(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zbla_real(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zbla_real(x[i__4])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__3]) * bli_zreal(x[i__4]) - bli_zimag(ap[i__3]) * bli_zimag(x[i__4])), (bli_zreal(ap[i__3]) * bli_zimag(x[i__4]) + bli_zimag(ap[i__3]) * bli_zreal(x[i__4])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L120: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk + j - 1]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__2 = kk + j - 2;
 			for (k = kk; k <= i__2; ++k) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__3 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zbla_real(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__3]) - bli_zimag(z__3) * bli_zimag(x[i__3])), (bli_zreal(z__3) * bli_zimag(x[i__3]) + bli_zimag(z__3) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix += *incx;
 /* L130: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk + j - 1]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__2 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__2] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__2] );
 		    jx += *incx;
 		    kk += j;
 /* L140: */
@@ -1631,42 +1631,42 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    i__1 = j;
-		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    k = kk;
 		    if (noconj) {
 			i__1 = j + 1;
 			for (i__ = *n; i__ >= i__1; --i__) {
 			    i__2 = k;
 			    i__3 = i__;
-			    bli_zsets( (bli_zbla_real(ap[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__2]) * bli_zreal(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zreal(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L150: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk - *n + j]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__1 = j + 1;
 			for (i__ = *n; i__ >= i__1; --i__) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__2 = i__;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    --k;
 /* L160: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk - *n + j]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__1 = j;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
 		    kk -= *n - j + 1;
 /* L170: */
 		}
@@ -1675,42 +1675,42 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    i__1 = jx;
-		    bli_zsets( (bli_zbla_real(x[i__1])), (bli_zimag(x[i__1])), temp );
+		    bli_zsets( (bli_zreal(x[i__1])), (bli_zimag(x[i__1])), temp );
 		    ix = kx;
 		    if (noconj) {
 			i__1 = kk - (*n - (j + 1));
 			for (k = kk; k >= i__1; --k) {
 			    i__2 = k;
 			    i__3 = ix;
-			    bli_zsets( (bli_zbla_real(ap[i__2]) * bli_zbla_real(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zbla_real(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zbla_real(x[i__3])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(ap[i__2]) * bli_zreal(x[i__3]) - bli_zimag(ap[i__2]) * bli_zimag(x[i__3])), (bli_zreal(ap[i__2]) * bli_zimag(x[i__3]) + bli_zimag(ap[i__2]) * bli_zreal(x[i__3])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L180: */
 			}
 			if (nounit) {
 			    bla_z_div(&z__1, &temp, &ap[kk - *n + j]);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    } else {
 			i__1 = kk - (*n - (j + 1));
 			for (k = kk; k >= i__1; --k) {
 			    bla_d_cnjg(&z__3, &ap[k]);
 			    i__2 = ix;
-			    bli_zsets( (bli_zbla_real(z__3) * bli_zbla_real(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zbla_real(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zbla_real(x[i__2])), z__2 );
-			    bli_zsets( (bli_zbla_real(temp) - bli_zbla_real(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__3) * bli_zreal(x[i__2]) - bli_zimag(z__3) * bli_zimag(x[i__2])), (bli_zreal(z__3) * bli_zimag(x[i__2]) + bli_zimag(z__3) * bli_zreal(x[i__2])), z__2 );
+			    bli_zsets( (bli_zreal(temp) - bli_zreal(z__2)), (bli_zimag(temp) - bli_zimag(z__2)), z__1 );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			    ix -= *incx;
 /* L190: */
 			}
 			if (nounit) {
 			    bla_d_cnjg(&z__2, &ap[kk - *n + j]);
 			    bla_z_div(&z__1, &temp, &z__2);
-			    bli_zsets( (bli_zbla_real(z__1)), (bli_zimag(z__1)), temp );
+			    bli_zsets( (bli_zreal(z__1)), (bli_zimag(z__1)), temp );
 			}
 		    }
 		    i__1 = jx;
-		    bli_zsets( (bli_zbla_real(temp)), (bli_zimag(temp)), x[i__1] );
+		    bli_zsets( (bli_zreal(temp)), (bli_zimag(temp)), x[i__1] );
 		    jx -= *incx;
 		    kk -= *n - j + 1;
 /* L200: */

--- a/frame/compat/f2c/bla_tpsv.h
+++ b/frame/compat/f2c/bla_tpsv.h
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF77(c,tpsv)(character *uplo, character *trans, character *diag, integer *n, singlecomplex *ap, singlecomplex *x, integer *incx);
-int PASTEF77(d,tpsv)(character *uplo, character *trans, character *diag, integer *n, doublereal *ap, doublereal *x, integer *incx);
-int PASTEF77(s,tpsv)(character *uplo, character *trans, character *diag, integer *n, real *ap, real *x, integer *incx);
-int PASTEF77(z,tpsv)(character *uplo, character *trans, character *diag, integer *n, doublecomplex *ap, doublecomplex *x, integer *incx);
+int PASTEF77(c,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_scomplex *ap, bla_scomplex *x, bla_integer *incx);
+int PASTEF77(d,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_double *ap, bla_double *x, bla_integer *incx);
+int PASTEF77(s,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_real *ap, bla_real *x, bla_integer *incx);
+int PASTEF77(z,tpsv)(bla_character *uplo, bla_character *trans, bla_character *diag, bla_integer *n, bla_dcomplex *ap, bla_dcomplex *x, bla_integer *incx);
 
 #endif

--- a/frame/compat/f2c/bla_xerbla.c
+++ b/frame/compat/f2c/bla_xerbla.c
@@ -43,7 +43,7 @@
 
 /* Table of constant values */
 
-/* Subroutine */ int PASTEF770(xerbla)(character *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ int PASTEF770(xerbla)(bla_character *srname, bla_integer *info, ftnlen srname_len)
 {
 /*  -- LAPACK auxiliary routine (preliminary version) -- */
 /*     Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd., */

--- a/frame/compat/f2c/bla_xerbla.h
+++ b/frame/compat/f2c/bla_xerbla.h
@@ -36,6 +36,6 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-int PASTEF770(xerbla)(character *srname, integer *info, ftnlen srname_len);
+int PASTEF770(xerbla)(bla_character *srname, bla_integer *info, ftnlen srname_len);
 
 #endif

--- a/frame/compat/f2c/util/bla_c_abs.c
+++ b/frame/compat/f2c/util/bla_c_abs.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_c_abs(singlecomplex *z)
+double bla_c_abs(bla_scomplex *z)
 {
 	return( bla_f__cabs( bli_creal( *z ),
 	                     bli_cimag( *z ) ) );

--- a/frame/compat/f2c/util/bla_c_abs.h
+++ b/frame/compat/f2c/util/bla_c_abs.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_c_abs(singlecomplex *z);
+double bla_c_abs(bla_scomplex *z);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_c_div.c
+++ b/frame/compat/f2c/util/bla_c_div.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_c_div(singlecomplex *cp, singlecomplex *ap, singlecomplex *bp)
+void bla_c_div(bla_scomplex *cp, bla_scomplex *ap, bla_scomplex *bp)
 {
 	bli_ccopys( *ap, *cp );
 	bli_cinvscals( *bp, *cp );

--- a/frame/compat/f2c/util/bla_c_div.h
+++ b/frame/compat/f2c/util/bla_c_div.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_c_div(singlecomplex *cp, singlecomplex *ap, singlecomplex *bp);
+void bla_c_div(bla_scomplex *cp, bla_scomplex *ap, bla_scomplex *bp);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_d_abs.c
+++ b/frame/compat/f2c/util/bla_d_abs.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_d_abs(doublereal *x)
+double bla_d_abs(bla_double *x)
 {
 	if(*x >= 0.0)
 		return(*x);

--- a/frame/compat/f2c/util/bla_d_abs.h
+++ b/frame/compat/f2c/util/bla_d_abs.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_d_abs(doublereal *x);
+double bla_d_abs(bla_double *x);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_d_cnjg.c
+++ b/frame/compat/f2c/util/bla_d_cnjg.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_d_cnjg(doublecomplex *dest, doublecomplex *src)
+void bla_d_cnjg(bla_dcomplex *dest, bla_dcomplex *src)
 {
 	bli_zcopyjs( *src, *dest );
 }

--- a/frame/compat/f2c/util/bla_d_cnjg.h
+++ b/frame/compat/f2c/util/bla_d_cnjg.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_d_cnjg(doublecomplex *dest, doublecomplex *src);
+void bla_d_cnjg(bla_dcomplex *dest, bla_dcomplex *src);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_d_imag.c
+++ b/frame/compat/f2c/util/bla_d_imag.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_d_imag(doublecomplex *z)
+double bla_d_imag(bla_dcomplex *z)
 {
 	return bli_zimag( *z );
 }

--- a/frame/compat/f2c/util/bla_d_imag.h
+++ b/frame/compat/f2c/util/bla_d_imag.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_d_imag(doublecomplex *z);
+double bla_d_imag(bla_dcomplex *z);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_d_sign.c
+++ b/frame/compat/f2c/util/bla_d_sign.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_d_sign(doublereal *a, doublereal *b)
+double bla_d_sign(bla_double *a, bla_double *b)
 {
 	double x = (*a >= 0.0 ? *a : - *a);
 

--- a/frame/compat/f2c/util/bla_d_sign.h
+++ b/frame/compat/f2c/util/bla_d_sign.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_d_sign(doublereal *a, doublereal *b);
+double bla_d_sign(bla_double *a, bla_double *b);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_f__cabs.c
+++ b/frame/compat/f2c/util/bla_f__cabs.c
@@ -36,26 +36,26 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_f__cabs(double real, double imag)
+double bla_f__cabs(double bla_real, double imag)
 {
 	double temp;
 
-	if(real < 0)
-		real = -real;
+	if(bla_real < 0)
+		bla_real = -bla_real;
 	if(imag < 0)
 		imag = -imag;
-	if(imag > real)
+	if(imag > bla_real)
 	{
-		temp = real;
-		real = imag;
+		temp = bla_real;
+		bla_real = imag;
 		imag = temp;
 	}
 
-	if((real+imag) == real)
-		return(real);
+	if((bla_real+imag) == bla_real)
+		return(bla_real);
 
-	temp = imag/real;
-	temp = real*sqrt(1.0 + temp*temp);
+	temp = imag/bla_real;
+	temp = bla_real*sqrt(1.0 + temp*temp);
 
 	return(temp);
 }

--- a/frame/compat/f2c/util/bla_f__cabs.h
+++ b/frame/compat/f2c/util/bla_f__cabs.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_f__cabs(double real, double imag);
+double bla_f__cabs(double bla_real, double imag);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_r_abs.c
+++ b/frame/compat/f2c/util/bla_r_abs.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_r_abs(real *x)
+double bla_r_abs(bla_real *x)
 {
 	if(*x >= 0.0)
 		return(*x);

--- a/frame/compat/f2c/util/bla_r_abs.h
+++ b/frame/compat/f2c/util/bla_r_abs.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_r_abs(real *x);
+double bla_r_abs(bla_real *x);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_r_cnjg.c
+++ b/frame/compat/f2c/util/bla_r_cnjg.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_r_cnjg(singlecomplex *dest, singlecomplex *src)
+void bla_r_cnjg(bla_scomplex *dest, bla_scomplex *src)
 {
 	bli_ccopyjs( *src, *dest );
 }

--- a/frame/compat/f2c/util/bla_r_cnjg.h
+++ b/frame/compat/f2c/util/bla_r_cnjg.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_r_cnjg(singlecomplex *dest, singlecomplex *src);
+void bla_r_cnjg(bla_scomplex *dest, bla_scomplex *src);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_r_imag.c
+++ b/frame/compat/f2c/util/bla_r_imag.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-real bla_r_imag(singlecomplex *z)
+bla_real bla_r_imag(bla_scomplex *z)
 {
 	return bli_cimag( *z );
 }

--- a/frame/compat/f2c/util/bla_r_imag.h
+++ b/frame/compat/f2c/util/bla_r_imag.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-real bla_r_imag(singlecomplex *z);
+bla_real bla_r_imag(bla_scomplex *z);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_r_sign.c
+++ b/frame/compat/f2c/util/bla_r_sign.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_r_sign(real *a, real *b)
+double bla_r_sign(bla_real *a, bla_real *b)
 {
 	double x = (*a >= 0.0 ? *a : - *a);
 

--- a/frame/compat/f2c/util/bla_r_sign.h
+++ b/frame/compat/f2c/util/bla_r_sign.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_r_sign(real *a, real *b);
+double bla_r_sign(bla_real *a, bla_real *b);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_z_abs.c
+++ b/frame/compat/f2c/util/bla_z_abs.c
@@ -36,9 +36,9 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_z_abs(doublecomplex *z)
+double bla_z_abs(bla_dcomplex *z)
 {
-	return( bla_f__cabs( bli_zreal( *z ),
+	return( bla_f__cabs( bli_zbla_real( *z ),
 	                     bli_zimag( *z ) ) );
 }
 

--- a/frame/compat/f2c/util/bla_z_abs.c
+++ b/frame/compat/f2c/util/bla_z_abs.c
@@ -38,7 +38,7 @@
 
 double bla_z_abs(bla_dcomplex *z)
 {
-	return( bla_f__cabs( bli_zbla_real( *z ),
+	return( bla_f__cabs( bli_zreal( *z ),
 	                     bli_zimag( *z ) ) );
 }
 

--- a/frame/compat/f2c/util/bla_z_abs.h
+++ b/frame/compat/f2c/util/bla_z_abs.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-double bla_z_abs(doublecomplex *z);
+double bla_z_abs(bla_dcomplex *z);
 
 #endif
 

--- a/frame/compat/f2c/util/bla_z_div.c
+++ b/frame/compat/f2c/util/bla_z_div.c
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_z_div(doublecomplex *cp, doublecomplex *ap, doublecomplex *bp)
+void bla_z_div(bla_dcomplex *cp, bla_dcomplex *ap, bla_dcomplex *bp)
 {
 	bli_zcopys( *ap, *cp );
 	bli_zinvscals( *bp, *cp );

--- a/frame/compat/f2c/util/bla_z_div.h
+++ b/frame/compat/f2c/util/bla_z_div.h
@@ -36,7 +36,7 @@
 
 #ifdef BLIS_ENABLE_BLAS2BLIS
 
-void bla_z_div(doublecomplex *cp, doublecomplex *ap, doublecomplex *bp);
+void bla_z_div(bla_dcomplex *cp, bla_dcomplex *ap, bla_dcomplex *bp);
 
 #endif
 

--- a/frame/include/bli_f2c.h
+++ b/frame/include/bli_f2c.h
@@ -5,18 +5,18 @@
 #ifndef F2C_INCLUDE
 #define F2C_INCLUDE
 
-typedef f77_int integer;
-typedef f77_char character;
-typedef char *address;
-typedef short int shortint;
-typedef float real;
-typedef double doublereal;
-typedef scomplex singlecomplex;
-typedef dcomplex doublecomplex;
-typedef f77_int logical;
-typedef short int shortlogical;
-typedef char logical1;
-typedef char integer1;
+typedef f77_int bla_integer;
+typedef f77_char bla_character;
+//typedef char *address;
+//typedef short int shortint;
+typedef float bla_real;
+typedef double bla_double;
+typedef scomplex bla_scomplex;
+typedef dcomplex bla_dcomplex;
+typedef f77_int bla_logical;
+//typedef short int shortlogical;
+//typedef char logical1;
+//typedef char integer1;
 #ifdef INTEGER_STAR_8	/* Adjust for integer*8. */
 typedef long long longint;		/* system-dependent */
 typedef unsigned long long ulongint;	/* system-dependent */
@@ -45,112 +45,7 @@ typedef long int ftnlen;
 typedef long int ftnint;
 #endif
 
-/*external read, write*/
-typedef struct
-{	flag cierr;
-	ftnint ciunit;
-	flag ciend;
-	char *cifmt;
-	ftnint cirec;
-} cilist;
-
-/*internal read, write*/
-typedef struct
-{	flag icierr;
-	char *iciunit;
-	flag iciend;
-	char *icifmt;
-	ftnint icirlen;
-	ftnint icirnum;
-} icilist;
-
-/*open*/
-typedef struct
-{	flag oerr;
-	ftnint ounit;
-	char *ofnm;
-	ftnlen ofnmlen;
-	char *osta;
-	char *oacc;
-	char *ofm;
-	ftnint orl;
-	char *oblnk;
-} olist;
-
-/*close*/
-typedef struct
-{	flag cerr;
-	ftnint cunit;
-	char *csta;
-} cllist;
-
-/*rewind, backspace, endfile*/
-typedef struct
-{	flag aerr;
-	ftnint aunit;
-} alist;
-
-/* inquire */
-typedef struct
-{	flag inerr;
-	ftnint inunit;
-	char *infile;
-	ftnlen infilen;
-	ftnint	*inex;	/*parameters in standard's order*/
-	ftnint	*inopen;
-	ftnint	*innum;
-	ftnint	*innamed;
-	char	*inname;
-	ftnlen	innamlen;
-	char	*inacc;
-	ftnlen	inacclen;
-	char	*inseq;
-	ftnlen	inseqlen;
-	char 	*indir;
-	ftnlen	indirlen;
-	char	*infmt;
-	ftnlen	infmtlen;
-	char	*inform;
-	ftnint	informlen;
-	char	*inunf;
-	ftnlen	inunflen;
-	ftnint	*inrecl;
-	ftnint	*innrec;
-	char	*inblank;
-	ftnlen	inblanklen;
-} inlist;
-
 #define VOID void
-
-union Multitype {	/* for multiple entry points */
-	integer1 g;
-	shortint h;
-	integer i;
-	/* longint j; */
-	real r;
-	doublereal d;
-	singlecomplex c;
-	doublecomplex z;
-	};
-
-typedef union Multitype Multitype;
-
-/*typedef long int Long;*/	/* No longer used; formerly in Namelist */
-
-struct Vardesc {	/* for Namelist */
-	char *name;
-	char *addr;
-	ftnlen *dims;
-	int  type;
-	};
-typedef struct Vardesc Vardesc;
-
-struct Namelist {
-	char *name;
-	Vardesc **vars;
-	int nvars;
-	};
-typedef struct Namelist Namelist;
 
 #ifndef f2c_abs
   #define f2c_abs(x) ((x) >= 0 ? (x) : -(x))
@@ -174,42 +69,6 @@ typedef struct Namelist Namelist;
 #define bit_test(a,b)	((a) >> (b) & 1)
 #define bit_clear(a,b)	((a) & ~((uinteger)1 << (b)))
 #define bit_set(a,b)	((a) |  ((uinteger)1 << (b)))
-
-/* procedure parameter types for -A and -C++ */
-
-#define F2C_proc_par_types 1
-#ifdef __cplusplus
-typedef int /* Unknown procedure type */ (*U_fp)(...);
-typedef shortint (*J_fp)(...);
-typedef integer (*I_fp)(...);
-typedef real (*R_fp)(...);
-typedef doublereal (*D_fp)(...);
-typedef doublereal (*E_fp)(...);
-typedef /* Complex */ VOID (*C_fp)(...);
-typedef /* Double Complex */ VOID (*Z_fp)(...);
-typedef logical (*L_fp)(...);
-typedef shortlogical (*K_fp)(...);
-typedef /* Character */ VOID (*H_fp)(...);
-typedef /* Subroutine */ int (*S_fp)(...);
-#else
-typedef int /* Unknown procedure type */ (*U_fp)();
-typedef shortint (*J_fp)();
-typedef integer (*I_fp)();
-typedef real (*R_fp)();
-typedef doublereal (*D_fp)();
-typedef doublereal (*E_fp)();
-typedef /* Complex */ VOID (*C_fp)();
-typedef /* Double Complex */ VOID (*Z_fp)();
-typedef logical (*L_fp)();
-typedef shortlogical (*K_fp)();
-typedef /* Character */ VOID (*H_fp)();
-typedef /* Subroutine */ int (*S_fp)();
-#endif
-/* E_fp is for real functions when -R is not specified */
-typedef VOID C_f;	/* single complex function */
-typedef VOID H_f;	/* character function */
-typedef VOID Z_f;	/* double complex function */
-typedef doublereal E_f;	/* real function with -R not specified */
 
 /* undef any lower-case symbols that your C compiler predefines, e.g.: */
 


### PR DESCRIPTION
This pull removes many typedefs from bli_f2c.h which actively or potentially conflict with user code, in particular `real` which conflicts with `std::real` in C++. Dependent code in frame/compat/f2c has been updated to use new bla_XXX typedefs, while unused types in f2c have been removed (the majority of the file actually).