### PR TITLE
Add symlink from config/bulldozer/kernels to kernels/x86_64/bulldozer

### DIFF
--- a/config/bulldozer/kernels
+++ b/config/bulldozer/kernels
@@ -1,0 +1,1 @@
+../../kernels/x86_64/bulldozer


### PR DESCRIPTION
to fix linking issue mentioned in #37 and https://groups.google.com/forum/#!topic/blis-devel/iypwljcaeEI