### PR TITLE
symbolic link for bulldozer configuration to kernels

### DIFF
--- a/config/bulldozer/kernels
+++ b/config/bulldozer/kernels
@@ -1,1 +1,1 @@
-../../kernels/x86_64/bulldozer
+../../kernels/x86_64/bulldozer/


### PR DESCRIPTION
The bulldozer configuration couldn't be linked to, due to the absence of the symlink to kernels.