### PR TITLE
Match default integer sizes to standard interfaces

### DIFF
--- a/frame/include/bli_config_macro_defs.h
+++ b/frame/include/bli_config_macro_defs.h
@@ -152,10 +152,10 @@
 // leading dimensions (ie: column strides) within the BLAS compatibility layer.
 // A value of 32 results in the compatibility layer using 32-bit signed integers
 // while 64 results in 64-bit integers. Any other value results in use of the
-// C99 type "long int". Note that this ONLY affects integers used within the
+// C99 type "int". Note that this ONLY affects integers used within the
 // BLAS compatibility layer.
 #ifndef BLIS_BLAS2BLIS_INT_TYPE_SIZE
-#define BLIS_BLAS2BLIS_INT_TYPE_SIZE     64
+#define BLIS_BLAS2BLIS_INT_TYPE_SIZE     32
 #endif
 
 

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -40,6 +40,8 @@
 // -- BLIS basic types ---------------------------------------------------------
 //
 
+#include <stddef.h>
+
 #ifdef __cplusplus
   // For C++, include stdint.h.
   #include <stdint.h>
@@ -68,8 +70,8 @@ typedef          uint32_t guint_t;
 typedef           int64_t  gint_t;
 typedef          uint64_t guint_t;
 #else
-typedef   signed long int  gint_t;
-typedef unsigned long int guint_t;
+typedef         ptrdiff_t  gint_t;
+typedef            size_t guint_t;
 #endif
 
 // -- Boolean type --

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -165,7 +165,7 @@ typedef int32_t   f77_int;
 #elif BLIS_BLAS2BLIS_INT_TYPE_SIZE == 64
 typedef int64_t   f77_int;
 #else
-typedef long int  f77_int;
+typedef      int  f77_int;
 #endif
 
 typedef char      f77_char;


### PR DESCRIPTION
This matches the default integers to `size_t` and `ptrdiff_t` so that they match the size of a pointer even on LLP64 platforms like Windows.
I also went ahead and changed the default `f77_int` definition from long to int to more closely match the Fortran and C blas interfaces. Though, to my knowledge, it's not standardized anywhere, Fortran compilers usually use 32 bit integers by default.

I'm in the process of testing this myself. Putting this here for discussion for now.
