### PR TITLE
Use clock_gettime(CLOCK_MONOTONIC) and mach_absolute_time instead of gettimeofday

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,16 @@ endif
 
 
 #
+# --- Append OS-specific libraries to LDFLAGS ----------------------------------
+#
+
+ifeq ($(OS_NAME),Linux)
+LDFLAGS += -lrt
+endif
+
+
+
+#
 # --- Main target variable definitions -----------------------------------------
 #
 

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -39,6 +39,9 @@ CONFIG_MK_INCLUDED := yes
 # The name of the configuration sub-directory.
 CONFIG_NAME    := @config_name@
 
+# The operating system name, which should be either 'Linux' or 'Darwin'.
+OS_NAME        := $(shell uname -s)
+
 # The directory path to the top level of the source distribution.
 DIST_PATH      := @dist_path@
 

--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -52,7 +52,7 @@
 #define BLIS_OS_BGQ 1
 #elif defined(__bg__)
 #define BLIS_OS_BGP 1
-#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) ||
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
       defined(__bsdi__) || defined(__DragonFly__)
 #define BLIS_OS_BSD 1
 #else

--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -40,9 +40,30 @@
 #include <math.h>
 #include <string.h>
 
-#ifdef BLIS_ENABLE_WINDOWS_BUILD
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define BLIS_OS_WINDOWS 1
+#elif defined(__APPLE__) || defined(__MACH__)
+#define BLIS_OS_OSX 1
+#elif defined(__ANDROID__)
+#define BLIS_OS_ANDROID 1
+#elif defined(__linux__)
+#define BLIS_OS_LINUX 1
+#elif defined(__bgq__)
+#define BLIS_OS_BGQ 1
+#elif defined(__bg__)
+#define BLIS_OS_BGP 1
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) ||
+      defined(__bsdi__) || defined(__DragonFly__)
+#define BLIS_OS_BSD 1
+#else
+#error "Cannot determine operating system"
+#endif
+
+#if BLIS_OS_WINDOWS
 
   // Include Windows header file.
+  #define WIN32_LEAN_AND_MEAN
+  #define VC_EXTRALEAN
   #include <windows.h>
 
   // Undefine attribute specifiers in Windows.
@@ -54,8 +75,10 @@
 #endif
 
 // gettimeofday() needs this.
-#ifdef BLIS_ENABLE_WINDOWS_BUILD
+#if BLIS_OS_WINDOWS
   #include <time.h>
+#elif BLIS_OS_OSX
+  #include <mach/mach_time.h>
 #else
   #include <sys/time.h>
   #include <time.h>


### PR DESCRIPTION
Since `gettimeofday` may or may not be high precision, is obsoleted by POSIX.1-2008, and is affected by NTP hijinks, I switched to `clock_gettime(CLOCK_MONOTONIC)` for Linux et al., and `mach_absolute_time` for OSX since `clock_gettime` is not supported there. I also updated the OS detection in bli_system.h using recommended preprocessor macros from [here](https://sourceforge.net/p/predef/wiki/OperatingSystems).