### PR TITLE
Add several changes to the build system.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,20 @@ endif
 
 
 #
+# --- Adjust verbosity level manually using make V=[0,1] -----------------------
+#
+
+ifeq ($(V),1)
+BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := yes
+endif
+
+ifeq ($(V),0)
+BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
+endif
+
+
+
+#
 # --- Append OS-specific libraries to LDFLAGS ----------------------------------
 #
 

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -44,6 +44,13 @@ OS_NAME        := $(shell uname -s)
 
 # The directory path to the top level of the source distribution.
 DIST_PATH      := @dist_path@
+
+# The level of debugging info to generate.
+DEBUG_TYPE     := @debug_type@
+
+# The C compiler.
+CC             := @CC@
+CC_VENDOR      := @cc_vendor@
 
 # The install prefix tell us where to install the libraries and header file
 # directory. Notice that we support the use of DESTDIR so that advanced users

--- a/config/cortex-a15/make_defs.mk
+++ b/config/cortex-a15/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -mfloat-abi=hard -mfpu=neon 
+CMISCFLAGS     := -std=c99 -mfloat-abi=hard -mfpu=neon
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := -g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -march=armv7-a -mfpu=neon -O2
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/cortex-a9/make_defs.mk
+++ b/config/cortex-a9/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -mfloat-abi=hard -mfpu=neon 
+CMISCFLAGS     := -std=c99 -mfloat-abi=hard -mfpu=neon
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := -g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -march=armv7-a -mfpu=neon -O2 -mfloat-abi=hard
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/dunnington/make_defs.mk
+++ b/config/dunnington/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 # -fopenmp -pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := #-g
 CWARNFLAGS     := -Wall
-COPTFLAGS      := -O2 -mfpmath=sse -fomit-frame-pointer
-CKOPTFLAGS     := -O2 -mfpmath=sse -fomit-frame-pointer
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
+COPTFLAGS     := -O2 -mfpmath=sse -fomit-frame-pointer
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := -msse3 -march=native
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/haswell/make_defs.mk
+++ b/config/haswell/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 -m64 -fopenmp  # -fopenmp -pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := #-g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O3 -march=native
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := -mavx2 -mfma -mfpmath=sse #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/loongson3a/make_defs.mk
+++ b/config/loongson3a/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L -mabi=64
 CMISCFLAGS     := -std=c99 -fopenmp #-pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := -g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O3  -march=loongson3a -mtune=loongson3a
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/mic/make_defs.mk
+++ b/config/mic/make_defs.mk
@@ -76,15 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := icc
-CPPROCFLAGS    :=
+CC_VENDOR      := icc
+endif
+ifneq ($(CC_VENDOR),icc)
+$(error icc is required for this configuration.)
+endif
+# Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
+# NOTE: This is needed to enable posix_memalign().
+CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -mmic -fasm-blocks -std=c99 -openmp
 CPICFLAGS      := -fPIC
-CDBGFLAGS      :=
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O3
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
+CVECFLAGS      := 
+endif
+
 CKOPTFLAGS     := $(COPTFLAGS)
-CVECFLAGS      :=
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/piledriver/make_defs.mk
+++ b/config/piledriver/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 -fopenmp
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := #-g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O2 -mfpmath=sse -fomit-frame-pointer
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := -mavx -mfma -march=native
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/power7/make_defs.mk
+++ b/config/power7/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 -m64 -mcpu=power7 #-fopenmp -pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := -g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O3 -mtune=power7
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := -mvsx
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/reference/make_defs.mk
+++ b/config/reference/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 # -fopenmp -pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := #-g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O2
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/sandybridge/make_defs.mk
+++ b/config/sandybridge/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 -m64 -fopenmp  # -fopenmp -pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := #-g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O3 -march=native
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := -mavx -mfpmath=sse #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/config/template/make_defs.mk
+++ b/config/template/make_defs.mk
@@ -76,17 +76,35 @@ GIT_LOG    := $(GIT) log --decorate
 #
 
 # --- Determine the C compiler and related flags ---
+ifeq ($(CC),)
 CC             := gcc
+CC_VENDOR      := gcc
+endif
+ifneq ($(CC_VENDOR),gcc)
+$(error gcc is required for this configuration.)
+endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99 # -fopenmp -pg
 CPICFLAGS      := -fPIC
-CDBGFLAGS      := -g
 CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
 COPTFLAGS      := -O2
-CKOPTFLAGS     := $(COPTFLAGS)
+endif
+
+ifneq ($(DEBUG_TYPE),noopt)
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+endif
+
+CKOPTFLAGS     := $(COPTFLAGS)
 
 # Aggregate all of the flags into multiple groups: one for standard
 # compilation, and one for each of the supported "special" compilation

--- a/configure
+++ b/configure
@@ -47,30 +47,48 @@ print_usage()
 	echo " "
 	echo " Usage:"
 	echo " "
-	echo "   ${script_name} [options] confname"
+	echo "   ${script_name} [options] [env. vars.] confname"
 	echo " "
 	echo " Arguments:"
 	echo " "
-	echo "   confname    The name of the sub-directory inside of the 'config'"
-	echo "               directory containing the desired BLIS configuration."
-	echo "               Note that confname MUST be specified; if it is not,"
-	echo "               configure will complain. To build a reference"
-	echo "               implementation, use the 'reference' configuration"
+	echo "   confname      The name of the sub-directory inside of the 'config'"
+	echo "                 directory containing the desired BLIS configuration."
+	echo "                 Note that confname MUST be specified; if it is not,"
+	echo "                 configure will complain. To build a reference"
+	echo "                 implementation, use the 'reference' configuration"
 	echo " "
 	echo " Options:"
 	echo " "
-	echo "   -p PREFIX   install prefix"
+	echo "   -p PREFIX, --prefix=PREFIX"
+	echo " "
 	echo "                 The path to which make will install buid products."
 	echo "                 If not given, PREFIX defaults to \$(HOME)/blis. If"
 	echo "                 the path refers to a directory that does not exist,"
 	echo "                 it will be created."
 	echo " "
-	echo "   -q          quiet"
-	echo "                 Suppress informational output. By default, configure"
+	echo "   -d DEBUG, --enable-debug[=DEBUG]"
+	echo " "
+	echo "                 Enable debugging symbols in the library. If argument"
+	echo "                 DEBUG is given as 'opt', then optimization flags are"
+	echo "                 kept in the framework, otherwise optimization is"
+	echo "                 turned off."
+	echo " "
+	echo "   -q, --quiet   Suppress informational output. By default, configure"
 	echo "                 is verbose. (NOTE: -q is not yet implemented)"
 	echo " "
-	echo "   -h          help"
-	echo "                 Output this information."
+	echo "   -h, --help    Output this information and quit."
+	echo " "
+	echo " Environment Variables:"
+	echo " "
+	echo "   CC            Specifies the C compiler to use."
+	echo " "
+	echo "   Environment variables may also be specified as command line"
+	echo "   options, e.g.:"
+	echo " "
+	echo "     ./configure CC=gcc sandybridge"
+	echo " "
+	echo "   Note that not all compilers are compatible with a given"
+	echo "   configuration."
 	echo " "
 
 	# Exit with non-zero exit status
@@ -142,6 +160,10 @@ main()
 	install_prefix=''
 	prefix_flag=''
 
+	# The debug flag.
+	debug_type=''
+	debug_flag=''
+
 	# Option variables.
 	quiet_flag=''
 
@@ -168,16 +190,68 @@ main()
 
 
 	# Process our command line options.
-	while getopts ":hp:q" opt; do
+	while getopts ":hp:d:q-:" opt; do
 		case $opt in
-			h  ) print_usage ;;
-			p  ) prefix_flag=1
-			     install_prefix=$OPTARG ;;
-			q  ) quiet_flag=1 ;;
-			\? ) print_usage
+			-)
+				case "$OPTARG" in
+					help)
+						print_usage
+						;;
+					quiet)
+						quiet_flag=1
+						;;
+					prefix=*)
+						prefix_flag=1
+						install_prefix=${OPTARG#*=}
+						;;
+					enable-debug)
+						debug_flag=1
+						;;
+					enable-debug=*)
+						debug_flag=1
+						debug_type=${OPTARG#*=}
+						;;
+					*)
+						print_usage
+						;;
+				esac;;
+			h)
+				print_usage
+				;;
+			p)
+				prefix_flag=1
+				install_prefix=$OPTARG
+				;;
+			d)
+				debug_flag=1
+				debug_type=$OPTARG
+				;;
+			q)
+				quiet_flag=1
+				;;
+			\?)
+				print_usage
+				;;
 		esac
 	done
 	shift $(($OPTIND - 1))
+	
+	
+	# Parse environment variables
+	while [ $# -gt 0 ]; do
+		case $1 in
+			CC=*)
+				CC=${1#*=}
+				shift
+				;;
+			*=*)
+				print_usage
+				;;
+			*)
+				break
+				;;
+		esac
+	done
 
 
 	# Initial message.
@@ -219,7 +293,7 @@ main()
 
 	elif [ $# = "1" ]; then
 
-        if [ $1 = "auto" ]; then
+		if [ $1 = "auto" ]; then
 
 			echo "${script_name}: automatic configuration requested."
 			config_name=`${build_dirpath}/auto-detect/auto-detect.sh`
@@ -244,16 +318,49 @@ main()
 	# Set the install prefix if it was not already set when parsing the install
 	# prefix flag.
 	if [ -n "${prefix_flag}" ]; then
-		echo "${script_name}: detected -p option; using install prefix '${install_prefix}'."
+		echo "${script_name}: using install prefix '${install_prefix}'."
 	else
 		install_prefix="${install_prefix_def}"
 		echo "${script_name}: no install prefix given; defaulting to '${install_prefix}'."
 	fi
 
 
+	# Check if the debug flag was specified.
+	if [ -n "${debug_flag}" ]; then
+		if [ ${debug_type} = 'opt' ]; then
+			echo "${script_name}: enabling debug symbols with optimizations."
+		else
+			debug_type='noopt'
+			echo "${script_name}: enabling debug symbols; optimizations disabled."
+		fi
+	else
+		debug_type='off'
+		echo "${script_name}: debug symbols disabled."
+	fi
+	
+	
+	# Determine the compiler vendor if CC was specified.
+	if [ -n "$CC" ]; then
+		if $CC --version 2>/dev/null | grep -q 'pnacl-version'; then
+			cc_vendor='pnacl-clang'
+		else
+			cc_vendor=`$CC --version 2>/dev/null | grep -Eo 'icc|gcc|clang|emcc'`
+		fi
+		if [ -z "$cc_vendor" ]; then
+			cc_vendor=`$CC -qversion 2>/dev/null | grep -o 'IBM'`
+		fi
+		if [ -z "$cc_vendor" ]; then
+			echo Unable to determine compiler vendor.
+			exit 1
+		fi
+		cc_vendor=`echo $cc_vendor | { read first rest; echo $first; }`
+	fi
+
+
 	# Insert escape characters into the paths used in the sed command below.
 	install_prefix_esc=$(echo "${install_prefix}" | sed 's/\//\\\//g')
 	dist_path_esc=$(echo "${dist_path}"           | sed 's/\//\\\//g')
+	cc_esc=$(echo "${CC}" | sed 's/\//\\\//g')
 	#echo "${install_prefix_esc}"
 	#exit 1
 
@@ -262,10 +369,13 @@ main()
 	# to config_mk_out.
 	echo "${script_name}: creating ${config_mk_out_path} from ${config_mk_in_path}"
 	cat "${config_mk_in_path}" \
-	    | sed "s/@config_name@/${config_name}/g" \
-	    | sed "s/@dist_path@/${dist_path_esc}/g" \
-	    | sed "s/@install_prefix@/${install_prefix_esc}/g" \
-	    > "${config_mk_out_path}"
+		| sed "s/@config_name@/${config_name}/g" \
+		| sed "s/@dist_path@/${dist_path_esc}/g" \
+		| sed "s/@CC@/${cc_esc}/g" \
+		| sed "s/@cc_vendor@/${cc_vendor}/g" \
+		| sed "s/@debug_type@/${debug_type}/g" \
+		| sed "s/@install_prefix@/${install_prefix_esc}/g" \
+		> "${config_mk_out_path}"
 
 
 	# Create obj sub-directories (if they do not already exist).
@@ -308,25 +418,25 @@ main()
 
 	# Generate makefile fragments in the chosen configuration directory.
 	${gen_make_frags_sh} \
-	         -h -r -v1 \
-	         -o ${script_name} \
-	         -p 'CONFIG' \
-	         ${configname_dirpath} \
-	         ${gen_make_frags_dirpath}/fragment.mk \
-	         ${gen_make_frags_dirpath}/suffix_list \
-	         ${gen_make_frags_dirpath}/ignore_list \
-	         ${gen_make_frags_dirpath}/special_list
+			 -h -r -v1 \
+			 -o ${script_name} \
+			 -p 'CONFIG' \
+			 ${configname_dirpath} \
+			 ${gen_make_frags_dirpath}/fragment.mk \
+			 ${gen_make_frags_dirpath}/suffix_list \
+			 ${gen_make_frags_dirpath}/ignore_list \
+			 ${gen_make_frags_dirpath}/special_list
 
 	# Generate makefile fragments in the framework directory.
 	${gen_make_frags_sh} \
-	         -h -r -v1 \
-	         -o ${script_name} \
-	         -p 'FRAME' \
-	         ${frame_dirpath} \
-	         ${gen_make_frags_dirpath}/fragment.mk \
-	         ${gen_make_frags_dirpath}/suffix_list \
-	         ${gen_make_frags_dirpath}/ignore_list \
-	         ${gen_make_frags_dirpath}/special_list
+			 -h -r -v1 \
+			 -o ${script_name} \
+			 -p 'FRAME' \
+			 ${frame_dirpath} \
+			 ${gen_make_frags_dirpath}/fragment.mk \
+			 ${gen_make_frags_dirpath}/suffix_list \
+			 ${gen_make_frags_dirpath}/ignore_list \
+			 ${gen_make_frags_dirpath}/special_list
 
 
 	# Under some circumstances, we need to create a symbolic link to the


### PR DESCRIPTION
1. Add -- options. *Technically* POSIX doesn't allow this style with getopts (e.g. '--foo' must be '-- foo' which is something different), but all extant bash versions work with it.
2. Add -d/--enable-debug option to enable debugging symbols with and without optimization.
3. Allow user to specify CC at configure time, and determine vendor (gcc/icc/etc.). For now configurations enforce a particular vendor. Practically, this means no change right now, but you can at least do ./configure CC=gcc-5 instead of make CC=gcc-5 etc.
4. Add make V=[0,1] option to control build verbosity.