### PR TITLE
Add AVX implementation for sdotxv, ddotxv, daxpy

### DIFF
--- a/config/sandybridge/bli_kernel.h
+++ b/config/sandybridge/bli_kernel.h
@@ -124,6 +124,7 @@
 
 // -- dotv --
 
+#define BLIS_SDOTV_KERNEL       bli_sdotv_opt_var1
 #define BLIS_DDOTV_KERNEL       bli_ddotv_opt_var1
 
 // -- dotxv --

--- a/config/sandybridge/bli_kernel.h
+++ b/config/sandybridge/bli_kernel.h
@@ -120,6 +120,8 @@
 
 // -- axpyv --
 
+#define BLIS_DAXPYV_KERNEL      bli_daxpyv_opt_var1
+
 // -- copyv --
 
 // -- dotv --

--- a/config/sandybridge/bli_kernel.h
+++ b/config/sandybridge/bli_kernel.h
@@ -124,6 +124,8 @@
 
 // -- dotv --
 
+#define BLIS_DDOTV_KERNEL       bli_ddotv_opt_var1
+
 // -- dotxv --
 
 // -- invertv --

--- a/config/sandybridge/bli_kernel.h
+++ b/config/sandybridge/bli_kernel.h
@@ -126,10 +126,10 @@
 
 // -- dotv --
 
-#define BLIS_SDOTV_KERNEL       bli_sdotv_opt_var1
-#define BLIS_DDOTV_KERNEL       bli_ddotv_opt_var1
-
 // -- dotxv --
+
+#define BLIS_SDOTXV_KERNEL       bli_sdotxv_opt_var1
+#define BLIS_DDOTXV_KERNEL       bli_ddotxv_opt_var1
 
 // -- invertv --
 

--- a/frame/1/dotv/bli_dotv_ref.c
+++ b/frame/1/dotv/bli_dotv_ref.c
@@ -96,7 +96,7 @@ void bli_dotv_ref( obj_t*  x,
 */
 
 #undef  GENTFUNC3
-#define GENTFUNC3( ctype_x, ctype_y, ctype_r, chx, chy, chr, varname ) \
+#define GENTFUNC3( ctype_x, ctype_y, ctype_r, chx, chy, chr, varname, kername ) \
 \
 void PASTEMAC3(chx,chy,chr,varname) \
      ( \
@@ -108,70 +108,27 @@ void PASTEMAC3(chx,chy,chr,varname) \
        ctype_r* restrict rho  \
      ) \
 { \
-	ctype_x* x_cast   = x; \
-	ctype_y* y_cast   = y; \
-	ctype_r* rho_cast = rho; \
-	ctype_x* chi1; \
-	ctype_y* psi1; \
-	ctype_r  dotxy; \
-	dim_t    i; \
-	conj_t   conjx_use; \
-\
-	if ( bli_zero_dim1( n ) ) \
-	{ \
-		PASTEMAC(chr,set0s)( *rho_cast ); \
-		return; \
-	} \
-\
-	PASTEMAC(chr,set0s)( dotxy ); \
-\
-	chi1 = x_cast; \
-	psi1 = y_cast; \
-\
-	conjx_use = conjx; \
-\
-	/* If y must be conjugated, we do so indirectly by first toggling the
-	   effective conjugation of x and then conjugating the resulting dot
-	   product. */ \
-	if ( bli_is_conj( conjy ) ) \
-		bli_toggle_conj( conjx_use ); \
-\
-	if ( bli_is_conj( conjx_use ) ) \
-	{ \
-		for ( i = 0; i < n; ++i ) \
-		{ \
-			PASTEMAC3(chx,chy,chr,dotjs)( *chi1, *psi1, dotxy ); \
-\
-			chi1 += incx; \
-			psi1 += incy; \
-		} \
-	} \
-	else \
-	{ \
-		for ( i = 0; i < n; ++i ) \
-		{ \
-			PASTEMAC3(chx,chy,chr,dots)( *chi1, *psi1, dotxy ); \
-\
-			chi1 += incx; \
-			psi1 += incy; \
-		} \
-	} \
-\
-	if ( bli_is_conj( conjy ) ) \
-		PASTEMAC(chr,conjs)( dotxy ); \
-\
-	PASTEMAC2(chr,chr,copys)( dotxy, *rho_cast ); \
+	ctype_r* one        = PASTEMAC(chr,1); \
+	ctype_r* zero       = PASTEMAC(chr,0); \
+	PASTEMAC3(chx,chy,chr,kername)( conjx, \
+	                                conjy, \
+	                                n, \
+	                                one, \
+	                                x, incx, \
+	                                y, incy, \
+	                                zero, \
+	                                rho ); \
 }
 
 // Define the basic set of functions unconditionally, and then also some
 // mixed datatype functions if requested.
-INSERT_GENTFUNC3_BASIC0( dotv_ref )
+INSERT_GENTFUNC3_BASIC( dotv_ref, DOTXV_KERNEL )
 
 #ifdef BLIS_ENABLE_MIXED_DOMAIN_SUPPORT
-INSERT_GENTFUNC3_MIX_D0( dotv_ref )
+INSERT_GENTFUNC3_MIX_D( dotv_ref, DOTXV_KERNEL )
 #endif
 
 #ifdef BLIS_ENABLE_MIXED_PRECISION_SUPPORT
-INSERT_GENTFUNC3_MIX_P0( dotv_ref )
+INSERT_GENTFUNC3_MIX_P( dotv_ref, DOTXV_KERNEL )
 #endif
 

--- a/kernels/x86_64/avx/1/bli_axpyv_opt_var1.c
+++ b/kernels/x86_64/avx/1/bli_axpyv_opt_var1.c
@@ -1,0 +1,165 @@
+/*
+
+   BLIS   
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name of The University of Texas at Austin nor the names
+      of its contributors may be used to endorse or promote products
+      derived derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+#include <immintrin.h> 
+
+typedef union
+{
+	__m256d v;
+	double  d[4];
+} v4df_t;
+
+void bli_daxpyv_opt_var1(
+			 conj_t           conjx,
+			 dim_t            n,
+			 double* restrict alpha,
+			 double* restrict x, inc_t incx,
+			 double* restrict y, inc_t incy
+		       )
+{
+	double*  restrict x_cast   = x;
+	double*  restrict y_cast   = y;
+
+	double*  restrict x1;
+	double*  restrict y1;
+	gint_t            i;
+	double            alphad;
+	v4df_t            alphav;
+	v4df_t            x0v, x1v, x2v, x3v;
+	v4df_t            y0v, y1v, y2v, y3v;
+	gint_t            n_run, n_pre, n_left;
+
+	const dim_t       n_elem_per_reg = 4;
+	const dim_t       n_iter_unroll  = 4;
+
+	bool_t            use_ref = FALSE;
+
+	// If the vector lengths are zero, return.
+	if ( bli_zero_dim1( n ) )
+	{
+		return;
+	}
+
+        alphad = *alpha;
+
+	// If there is anything that would interfere with our use of aligned
+	// vector loads/stores, call the reference implementation.
+	if ( incx != 1 || incy != 1 )
+	{
+		use_ref = TRUE;
+	}
+
+	n_pre = 0;
+	if ( bli_is_unaligned_to( x, 32 ) ||
+	     bli_is_unaligned_to( y, 32 ) )
+	{
+		guint_t x_offset = bli_offset_from_alignment( x, 32 );
+		guint_t y_offset = bli_offset_from_alignment( y, 32 );
+
+		if ( x_offset % 8 != 0 ||
+		     x_offset != y_offset )
+		{
+			use_ref = TRUE;
+		}
+		else
+		{
+			n_pre = ( 32 - x_offset ) / 8;
+		}
+	}
+
+
+	// Call the reference implementation if needed.
+	if ( use_ref == TRUE )
+	{
+		BLIS_DAXPYV_KERNEL_REF( conjx,
+					n,
+					alpha,
+					x, incx,
+					y, incy );
+		return;
+	}
+
+	x1 = x_cast;
+	y1 = y_cast;
+
+	n_run       = ( n - n_pre ) / ( n_elem_per_reg * n_iter_unroll );
+	n_left      = ( n - n_pre ) % ( n_elem_per_reg * n_iter_unroll );
+
+	while ( n_pre-- > 0 )
+	{
+		*(y1++) += alphad * *(x1++);
+	}
+
+	alphav.v = _mm256_set_pd(alphad, alphad, alphad, alphad);
+	x0v.v = _mm256_setzero_pd();
+	x1v.v = _mm256_setzero_pd();
+	x2v.v = _mm256_setzero_pd();
+	x3v.v = _mm256_setzero_pd();
+	y0v.v = _mm256_setzero_pd();
+	y1v.v = _mm256_setzero_pd();
+	y2v.v = _mm256_setzero_pd();
+	y3v.v = _mm256_setzero_pd();
+
+	for ( i = 0; i < n_run; i++ )
+	{
+		x0v.v = _mm256_load_pd( ( double* )(x1 + 0*n_elem_per_reg) );
+		x1v.v = _mm256_load_pd( ( double* )(x1 + 1*n_elem_per_reg) );
+		x2v.v = _mm256_load_pd( ( double* )(x1 + 2*n_elem_per_reg) );
+		x3v.v = _mm256_load_pd( ( double* )(x1 + 3*n_elem_per_reg) );
+
+		y0v.v = _mm256_load_pd( ( double* )(y1 + 0*n_elem_per_reg) );
+		y1v.v = _mm256_load_pd( ( double* )(y1 + 1*n_elem_per_reg) );
+		y2v.v = _mm256_load_pd( ( double* )(y1 + 2*n_elem_per_reg) );
+		y3v.v = _mm256_load_pd( ( double* )(y1 + 3*n_elem_per_reg) );
+
+		y0v.v += x0v.v * alphav.v;
+		y1v.v += x1v.v * alphav.v;
+		y2v.v += x2v.v * alphav.v;
+		y3v.v += x3v.v * alphav.v;
+
+		_mm256_store_pd( ( double* )(y1 + 0*n_elem_per_reg), y0v.v );
+		_mm256_store_pd( ( double* )(y1 + 1*n_elem_per_reg), y1v.v );
+		_mm256_store_pd( ( double* )(y1 + 2*n_elem_per_reg), y2v.v );
+		_mm256_store_pd( ( double* )(y1 + 3*n_elem_per_reg), y3v.v );
+
+		x1 += n_iter_unroll * n_elem_per_reg;
+		y1 += n_iter_unroll * n_elem_per_reg;
+	}
+
+	while ( n_left-- > 0 )
+	{
+		*(y1++) += alphad * *(x1++);
+	}
+}

--- a/kernels/x86_64/avx/1/bli_dotv_opt_var1.c
+++ b/kernels/x86_64/avx/1/bli_dotv_opt_var1.c
@@ -1,0 +1,176 @@
+/*
+
+   BLIS   
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name of The University of Texas at Austin nor the names
+      of its contributors may be used to endorse or promote products
+      derived derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+#include <immintrin.h> 
+
+typedef union
+{
+	__m256d v;
+	double  d[4];
+} v4df_t;
+
+
+void bli_ddotv_opt_var1(
+			 conj_t           conjx,
+			 conj_t           conjy,
+			 dim_t            n,
+			 double* restrict x, inc_t incx,
+			 double* restrict y, inc_t incy,
+			 double* restrict rho
+		       )
+{
+	double*  restrict x_cast   = x;
+	double*  restrict y_cast   = y;
+	double*  restrict rho_cast = rho;
+
+	double*  restrict x1;
+	double*  restrict y1;
+	gint_t            i;
+	double            rho1;
+	v4df_t            rho0v, rho1v, rho2v, rho3v;
+	v4df_t            x0v, x1v, x2v, x3v;
+	v4df_t            y0v, y1v, y2v, y3v;
+	gint_t            n_run, n_pre, n_left;
+
+	const dim_t       n_elem_per_reg = 4;
+	const dim_t       n_iter_unroll  = 4;
+
+	bool_t            use_ref = FALSE;
+
+	// If the vector lengths are zero, set rho to zero and return.
+	if ( bli_zero_dim1( n ) )
+	{
+		PASTEMAC(d,set0s)( *rho_cast );
+		return;
+	}
+
+	// If there is anything that would interfere with our use of aligned
+	// vector loads/stores, call the reference implementation.
+	if ( incx != 1 || incy != 1 )
+	{
+		use_ref = TRUE;
+	}
+
+	n_pre = 0;
+	if ( bli_is_unaligned_to( x, 32 ) ||
+	     bli_is_unaligned_to( y, 32 ) )
+	{
+		guint_t x_offset = bli_offset_from_alignment( x, 32 );
+		guint_t y_offset = bli_offset_from_alignment( y, 32 );
+
+		if ( x_offset % 8 != 0 ||
+		     x_offset != y_offset )
+		{
+			use_ref = TRUE;
+		}
+		else
+		{
+			n_pre = ( 32 - x_offset ) / 8;
+		}
+	}
+
+
+	// Call the reference implementation if needed.
+	if ( use_ref == TRUE )
+	{
+		BLIS_DDOTV_KERNEL_REF( conjx,
+				       conjy,
+				       n,
+				       x, incx,
+				       y, incy,
+				       rho );
+		return;
+	}
+
+	x1 = x_cast;
+	y1 = y_cast;
+
+	n_run       = ( n - n_pre ) / ( n_elem_per_reg * n_iter_unroll );
+	n_left      = ( n - n_pre ) % ( n_elem_per_reg * n_iter_unroll );
+
+	PASTEMAC(d,set0s)( rho1 );
+
+	while ( n_pre-- > 0 )
+	{
+		rho1 += *(x1++) * *(y1++);
+	}
+
+	rho0v.v = _mm256_setzero_pd();
+	rho1v.v = _mm256_setzero_pd();
+	rho2v.v = _mm256_setzero_pd();
+	rho3v.v = _mm256_setzero_pd();
+	x0v.v = _mm256_setzero_pd();
+	x1v.v = _mm256_setzero_pd();
+	x2v.v = _mm256_setzero_pd();
+	x3v.v = _mm256_setzero_pd();
+	y0v.v = _mm256_setzero_pd();
+	y1v.v = _mm256_setzero_pd();
+	y2v.v = _mm256_setzero_pd();
+	y3v.v = _mm256_setzero_pd();
+
+	for ( i = 0; i < n_run; i++ )
+	{
+		x0v.v = _mm256_load_pd( ( double* )(x1 + 0*n_elem_per_reg) );
+		x1v.v = _mm256_load_pd( ( double* )(x1 + 1*n_elem_per_reg) );
+		x2v.v = _mm256_load_pd( ( double* )(x1 + 2*n_elem_per_reg) );
+		x3v.v = _mm256_load_pd( ( double* )(x1 + 3*n_elem_per_reg) );
+
+		y0v.v = _mm256_load_pd( ( double* )(y1 + 0*n_elem_per_reg) );
+		y1v.v = _mm256_load_pd( ( double* )(y1 + 1*n_elem_per_reg) );
+		y2v.v = _mm256_load_pd( ( double* )(y1 + 2*n_elem_per_reg) );
+		y3v.v = _mm256_load_pd( ( double* )(y1 + 3*n_elem_per_reg) );
+
+		rho0v.v += x0v.v * y0v.v;
+		rho1v.v += x1v.v * y1v.v;
+		rho2v.v += x2v.v * y2v.v;
+		rho3v.v += x3v.v * y3v.v;
+
+		x1 += n_iter_unroll * n_elem_per_reg;
+		y1 += n_iter_unroll * n_elem_per_reg;
+	}
+
+	rho0v.v += rho2v.v;
+	rho1v.v += rho3v.v;
+	rho0v.v += rho1v.v;
+
+	rho1 += rho0v.d[0] + rho0v.d[1] + rho0v.d[2] + rho0v.d[3];
+
+	while ( n_left-- > 0 )
+	{
+		rho1 += *(x1++) * *(y1++);
+	}
+
+	PASTEMAC(d,copys)( rho1, *rho_cast );
+}


### PR DESCRIPTION
Relatively simple dotv impls. These improve dotv especially when the data already fits in cache.

Is this a good approach? Is there a more general strategy that can be used to write these?

At least, this impl should be included into other configurations, at least haswell. What's the best way to have them share it? Right now they link kernel to avx and avx2 respectively.

Is pseudonymous authorship ok, and is there anything about contributing that I have missed? Thank you.

----

Edits: PR has been updated to focus on dotxv since first posting.