### PR TITLE
More config opts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,11 +189,11 @@ THREADING_MODEL := omp
 endif
 ifeq ($(THREADING_MODEL),omp)
 CTHREADFLAGS := -fopenmp -DBLIS_ENABLE_OPENMP
-LD_FLAGS     += -fopenmp
+LDFLAGS      += -fopenmp
 endif
 ifeq ($(THREADING_MODEL),pthreads)
 CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
-LD_FLAGS     += -pthread
+LDFLAGS      += -pthread
 endif
 endif
 
@@ -203,11 +203,11 @@ THREADING_MODEL := omp
 endif
 ifeq ($(THREADING_MODEL),omp)
 CTHREADFLAGS := -openmp -DBLIS_ENABLE_OPENMP
-LD_FLAGS     += -openmp
+LDFLAGS      += -openmp
 endif
 ifeq ($(THREADING_MODEL),pthreads)
 CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
-LD_FLAGS     += -pthread
+LDFLAGS      += -pthread
 endif
 endif
 
@@ -220,7 +220,7 @@ $(error OpenMP is not supported with Clang.)
 endif
 ifeq ($(THREADING_MODEL),pthreads)
 CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
-LD_FLAGS     += -pthread
+LDFLAGS      += -pthread
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,29 @@ GIT_LOG    := $(GIT) log --decorate
 
 
 #
+# --- Determine the compiler vendor --------------------------------------------
+#
+
+ifneq ($(CC),)
+
+VENDOR_STRING := $(shell $(CC) --version 2>/dev/null)
+ifeq ($(VENDOR_STRING),)
+VENDOR_STRING := $(shell $(CC) -qversion 2>/dev/null)
+endif
+ifeq ($(VENDOR_STRING),)
+$(error Unable to determine compiler vendor.)
+endif
+
+CC_VENDOR := $(firstword $(shell echo '$(VENDOR_STRING)' | grep -Eo 'icc|gcc|clang|emcc|pnacl|IBM'))
+ifeq ($(CC_VENDOR),)
+$(error Unable to determine compiler vendor.)
+endif
+
+endif
+
+
+
+#
 # --- Include makefile definitions file ----------------------------------------
 #
 
@@ -179,9 +202,11 @@ else
 MAKE_DEFS_MK_PRESENT := no
 endif
 
-# Deal with threading flags and aggregate all of the flags into multiple groups:
-# one for standard compilation, and one for each of the supported "special"
-# compilation modes.
+
+
+#
+# --- Configuration-agnostic flags ---------------------------------------------
+#
 
 ifeq ($(CC_VENDOR),gcc)
 ifeq ($(THREADING_MODEL),auto)
@@ -223,6 +248,9 @@ CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
 LDFLAGS      += -pthread
 endif
 endif
+
+# Aggregate all of the flags into multiple groups: one for standard compilation,
+# and one for each of the supported "special" compilation modes.
 
 CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CTHREADFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
 CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,28 @@ BASE_LIB_PATH           := ./$(LIB_DIR)/$(CONFIG_NAME)
 
 
 #
+# --- Utility program definitions ----------------------------------------------
+#
+
+SH         := /bin/sh
+MV         := mv
+MKDIR      := mkdir -p
+RM_F       := rm -f
+RM_RF      := rm -rf
+SYMLINK    := ln -sf
+FIND       := find
+GREP       := grep
+XARGS      := xargs
+RANLIB     := ranlib
+INSTALL    := install -c
+
+# Used to refresh CHANGELOG.
+GIT        := git
+GIT_LOG    := $(GIT) log --decorate
+
+
+
+#
 # --- Include makefile definitions file ----------------------------------------
 #
 
@@ -156,6 +178,55 @@ MAKE_DEFS_MK_PRESENT := yes
 else
 MAKE_DEFS_MK_PRESENT := no
 endif
+
+# Deal with threading flags and aggregate all of the flags into multiple groups:
+# one for standard compilation, and one for each of the supported "special"
+# compilation modes.
+
+ifeq ($(CC_VENDOR),gcc)
+ifeq ($(THREADING_MODEL),auto)
+THREADING_MODEL := omp
+endif
+ifeq ($(THREADING_MODEL),omp)
+CTHREADFLAGS := -fopenmp -DBLIS_ENABLE_OPENMP
+LD_FLAGS     += -fopenmp
+endif
+ifeq ($(THREADING_MODEL),pthreads)
+CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
+LD_FLAGS     += -pthread
+endif
+endif
+
+ifeq ($(CC_VENDOR),icc)
+ifeq ($(THREADING_MODEL),auto)
+THREADING_MODEL := omp
+endif
+ifeq ($(THREADING_MODEL),omp)
+CTHREADFLAGS := -openmp -DBLIS_ENABLE_OPENMP
+LD_FLAGS     += -openmp
+endif
+ifeq ($(THREADING_MODEL),pthreads)
+CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
+LD_FLAGS     += -pthread
+endif
+endif
+
+ifeq ($(CC_VENDOR),clang)
+ifeq ($(THREADING_MODEL),auto)
+THREADING_MODEL := pthreads
+endif
+ifeq ($(THREADING_MODEL),omp)
+$(error OpenMP is not supported with Clang.)
+endif
+ifeq ($(THREADING_MODEL),pthreads)
+CTHREADFLAGS := -pthread -DBLIS_ENABLE_PTHREADS
+LD_FLAGS     += -pthread
+endif
+endif
+
+CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CTHREADFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
+CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
+CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 
 

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -57,6 +57,10 @@ CC_VENDOR      := @cc_vendor@
 # may install to a temporary location.
 INSTALL_PREFIX := $(DESTDIR)@install_prefix@
 
+# Variables corresponding to other configure-time options.
+BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := @enable_verbose@
+BLIS_ENABLE_STATIC_BUILD        := @enable_static@
+BLIS_ENABLE_DYNAMIC_BUILD       := @enable_dynamic@
 
 # end of ifndef CONFIG_MK_INCLUDED conditional block
 endif

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -50,7 +50,6 @@ DEBUG_TYPE      := @debug_type@
 
 # The C compiler.
 CC              := @CC@
-CC_VENDOR       := @cc_vendor@
 
 # The requested threading model.
 THREADING_MODEL := @threading_model@

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -37,20 +37,23 @@ ifndef CONFIG_MK_INCLUDED
 CONFIG_MK_INCLUDED := yes
 
 # The name of the configuration sub-directory.
-CONFIG_NAME    := @config_name@
+CONFIG_NAME     := @config_name@
 
-# The operating system name, which should be either 'Linux' or 'Darwin'.
-OS_NAME        := $(shell uname -s)
+# The operatin g system name, which should be either 'Linux' or 'Darwin'.
+OS_NAME         := $(shell uname -s)
 
 # The directory path to the top level of the source distribution.
-DIST_PATH      := @dist_path@
+DIST_PATH       := @dist_path@
 
 # The level of debugging info to generate.
-DEBUG_TYPE     := @debug_type@
+DEBUG_TYPE      := @debug_type@
 
 # The C compiler.
-CC             := @CC@
-CC_VENDOR      := @cc_vendor@
+CC              := @CC@
+CC_VENDOR       := @cc_vendor@
+
+# The requested threading model.
+THREADING_MODEL := @threading_model@
 
 # The install prefix tell us where to install the libraries and header file
 # directory. Notice that we support the use of DESTDIR so that advanced users

--- a/config/armv7a/make_defs.mk
+++ b/config/armv7a/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := yes
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -mfpu=vfpv3 -marm -march=armv7-a
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/armv8a/make_defs.mk
+++ b/config/armv8a/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := yes
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_GNU_SOURCE
-CMISCFLAGS     := -std=c99 -fopenmp
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -103,13 +70,6 @@ endif
 CVECFLAGS      := -march=armv8-a+fp+simd -mcpu=cortex-a57.cortex-a53
 CKOPTFLAGS     := $(COPTFLAGS)
 
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
-
 # --- Determine the archiver and related flags ---
 AR             := ar
 ARFLAGS        := cru
@@ -117,7 +77,7 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -lm -fopenmp
+LDFLAGS        := -lm
 
 
 

--- a/config/bgq/make_defs.mk
+++ b/config/bgq/make_defs.mk
@@ -39,44 +39,12 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
 # --- Determine the C compiler and related flags ---
 CC             := /bgsys/drivers/ppcfloor/comm/gcc.legacy/bin/mpixlc_r
+CC_VENDOR      := IBM
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L \
@@ -88,13 +56,6 @@ CWARNFLAGS     := -w
 COPTFLAGS      := -O3
 CKOPTFLAGS     := $(COPTFLAGS)
 CVECFLAGS      := -qarch=qp -qtune=qp -qsimd=auto -qhot=level=1 -qprefetch -qunroll=yes -qnoipa
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/bulldozer/make_defs.mk
+++ b/config/bulldozer/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -fopenmp
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -mavx -mfma -march=bdver2 -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/carrizo/bli_config.h
+++ b/config/carrizo/bli_config.h
@@ -36,9 +36,6 @@
 #define BLIS_CONFIG_H
 
 
-//#define BLIS_ENABLE_PTHREADS
-#define BLIS_ENABLE_OPENMP
-
 #define BLIS_SIMD_ALIGN_SIZE             16
 
 

--- a/config/carrizo/make_defs.mk
+++ b/config/carrizo/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -fopenmp
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -103,13 +70,6 @@ endif
 CVECFLAGS      := -mavx -mfma -march=native -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
-
 # --- Determine the archiver and related flags ---
 AR             := ar
 ARFLAGS        := cru
@@ -117,7 +77,7 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -lm -fopenmp
+LDFLAGS        := -lm
 
 
 

--- a/config/carrizo/make_defs.mk
+++ b/config/carrizo/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O2 -fomit-frame-pointer
 endif
 
-CVECFLAGS      := -mavx -mfma -march=native -mfpmath=sse
+CVECFLAGS      := -mavx -mfma -march=bdver4 -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/config/cortex-a15/make_defs.mk
+++ b/config/cortex-a15/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -march=armv7-a #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/cortex-a15/make_defs.mk
+++ b/config/cortex-a15/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O2
 endif
 
-CVECFLAGS      := -march=armv7-a #-msse3 -march=native # -mfpmath=sse
+CVECFLAGS      := -march=armv7-a
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/config/cortex-a9/make_defs.mk
+++ b/config/cortex-a9/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -march=armv7-a #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/cortex-a9/make_defs.mk
+++ b/config/cortex-a9/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O2
 endif
 
-CVECFLAGS      := -march=armv7-a #-msse3 -march=native # -mfpmath=sse
+CVECFLAGS      := -march=armv7-a
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/config/dunnington/make_defs.mk
+++ b/config/dunnington/make_defs.mk
@@ -47,9 +47,7 @@ ifeq ($(CC),)
 CC             := gcc
 CC_VENDOR      := gcc
 endif
-ifneq ($(CC_VENDOR),gcc)
-$(error gcc is required for this configuration.)
-endif
+
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
@@ -67,8 +65,17 @@ else
 COPTFLAGS      := -O2 -fomit-frame-pointer
 endif
 
-CVECFLAGS      := -msse3 -march=native -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
+
+ifeq ($(CC_VENDOR),gcc)
+CVECFLAGS      := -msse3 -march=nehalem -mfpmath=sse
+else
+ifeq ($(CC_VENDOR),icc)
+CVECFLAGS      := -xSSE4.2
+else
+$(error gcc or icc is required for this configuration.)
+endif
+endif
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/dunnington/make_defs.mk
+++ b/config/dunnington/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 # -fopenmp -pg
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -msse3 -march=native -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/dunnington/make_defs.mk
+++ b/config/dunnington/make_defs.mk
@@ -68,12 +68,16 @@ endif
 CKOPTFLAGS     := $(COPTFLAGS)
 
 ifeq ($(CC_VENDOR),gcc)
-CVECFLAGS      := -msse3 -march=nehalem -mfpmath=sse
+CVECFLAGS      := -msse3 -march=corei7 -mfpmath=sse
 else
 ifeq ($(CC_VENDOR),icc)
 CVECFLAGS      := -xSSE4.2
 else
-$(error gcc or icc is required for this configuration.)
+ifeq ($(CC_VENDOR),clang)
+CVECFLAGS      := -msse3 -mfpmath=sse -march=corei7
+else
+$(error gcc, icc, or clang is required for this configuration.)
+endif
 endif
 endif
 

--- a/config/emscripten/make_defs.mk
+++ b/config/emscripten/make_defs.mk
@@ -39,44 +39,12 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := emranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
 # --- Determine the C compiler and related flags ---
 CC             := emcc
+CC_VENDOR      := emcc
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
@@ -87,13 +55,6 @@ CWARNFLAGS     := -Wall
 COPTFLAGS      := -O2
 CKOPTFLAGS     := -O3
 CVECFLAGS      :=
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := emar

--- a/config/haswell/bli_config.h
+++ b/config/haswell/bli_config.h
@@ -35,11 +35,6 @@
 #ifndef BLIS_CONFIG_H
 #define BLIS_CONFIG_H
 
-// Enable multithreading via POSIX threads.
-//#define BLIS_ENABLE_PTHREADS
-
-// Enable multithreading via OpenMP.
-#define BLIS_ENABLE_OPENMP
 
 
 

--- a/config/haswell/make_defs.mk
+++ b/config/haswell/make_defs.mk
@@ -47,9 +47,7 @@ ifeq ($(CC),)
 CC             := gcc
 CC_VENDOR      := gcc
 endif
-ifneq ($(CC_VENDOR),gcc)
-$(error gcc is required for this configuration.)
-endif
+
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
@@ -67,8 +65,17 @@ else
 COPTFLAGS      := -O3
 endif
 
-CVECFLAGS      := -mavx2 -mfma -mfpmath=sse -march=native #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
+
+ifeq ($(CC_VENDOR),gcc)
+CVECFLAGS      := -mavx2 -mfma -mfpmath=sse -march=haswell
+else
+ifeq ($(CC_VENDOR),icc)
+CVECFLAGS      := -xCORE-AVX2
+else
+$(error gcc or icc is required for this configuration.)
+endif
+endif
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/haswell/make_defs.mk
+++ b/config/haswell/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -m64 -fopenmp  # -fopenmp -pg
+CMISCFLAGS     := -std=c99 -m64
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -103,13 +70,6 @@ endif
 CVECFLAGS      := -mavx2 -mfma -mfpmath=sse -march=native #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
-
 # --- Determine the archiver and related flags ---
 AR             := ar
 ARFLAGS        := cru
@@ -117,7 +77,7 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -lm -fopenmp -lpthread
+LDFLAGS        := -lm
 
 
 

--- a/config/haswell/make_defs.mk
+++ b/config/haswell/make_defs.mk
@@ -68,12 +68,16 @@ endif
 CKOPTFLAGS     := $(COPTFLAGS)
 
 ifeq ($(CC_VENDOR),gcc)
-CVECFLAGS      := -mavx2 -mfma -mfpmath=sse -march=haswell
+CVECFLAGS      := -mavx2 -mfma -mfpmath=sse -march=core-avx2
 else
 ifeq ($(CC_VENDOR),icc)
 CVECFLAGS      := -xCORE-AVX2
 else
-$(error gcc or icc is required for this configuration.)
+ifeq ($(CC_VENDOR),clang)
+CVECFLAGS      := -mavx2 -mfma -mfpmath=sse -march=core-avx2
+else
+$(error gcc, icc, or clang is required for this configuration.)
+endif
 endif
 endif
 

--- a/config/loongson3a/make_defs.mk
+++ b/config/loongson3a/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L -mabi=64
-CMISCFLAGS     := -std=c99 -fopenmp #-pg
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -march=loongson3a #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/loongson3a/make_defs.mk
+++ b/config/loongson3a/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O3 -mtune=loongson3a
 endif
 
-CVECFLAGS      := -march=loongson3a #-msse3 -march=native # -mfpmath=sse
+CVECFLAGS      := -march=loongson3a
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/config/mic/bli_config.h
+++ b/config/mic/bli_config.h
@@ -39,7 +39,6 @@
 #define BLIS_TREE_BARRIER
 #define BLIS_TREE_BARRIER_ARITY 4
 
-#define BLIS_ENABLE_OPENMP
 
 #define BLIS_SIMD_ALIGN_SIZE             32
 

--- a/config/mic/make_defs.mk
+++ b/config/mic/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -mmic -fasm-blocks -std=c99 -openmp
+CMISCFLAGS     := -mmic -fasm-blocks -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -103,13 +70,6 @@ endif
 CVECFLAGS      := 
 CKOPTFLAGS     := $(COPTFLAGS)
 
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
-
 # --- Determine the archiver and related flags ---
 AR             := ar
 ARFLAGS        := cru
@@ -117,7 +77,7 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -mmic -lm -openmp
+LDFLAGS        := -mmic -lm
 
 
 

--- a/config/piledriver/bli_config.h
+++ b/config/piledriver/bli_config.h
@@ -36,9 +36,6 @@
 #define BLIS_CONFIG_H
 
 
-//#define BLIS_ENABLE_PTHREADS
-
-#define BLIS_ENABLE_OPENMP
 
 #define BLIS_SIMD_ALIGN_SIZE 16
 

--- a/config/piledriver/make_defs.mk
+++ b/config/piledriver/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -fopenmp
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -103,13 +70,6 @@ endif
 CVECFLAGS      := -mavx -mfma -march=native -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
-
 # --- Determine the archiver and related flags ---
 AR             := ar
 ARFLAGS        := cru
@@ -117,7 +77,7 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -lm -fopenmp
+LDFLAGS        := -lm
 
 
 

--- a/config/piledriver/make_defs.mk
+++ b/config/piledriver/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O2 -fomit-frame-pointer
 endif
 
-CVECFLAGS      := -mavx -mfma -march=native -mfpmath=sse
+CVECFLAGS      := -mavx -mfma -march=bdver2 -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/config/pnacl/make_defs.mk
+++ b/config/pnacl/make_defs.mk
@@ -39,44 +39,12 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := pnacl-ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
 # --- Determine the C compiler and related flags ---
 CC             := pnacl-clang
+CC_VENDOR      := pnacl-clang
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
@@ -87,13 +55,6 @@ CWARNFLAGS     := -Wall
 COPTFLAGS      := -O3
 CKOPTFLAGS     := $(COPTFLAGS) -ffast-math
 CVECFLAGS      :=
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := pnacl-ar

--- a/config/power7/make_defs.mk
+++ b/config/power7/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -m64 -mcpu=power7 #-fopenmp -pg
+CMISCFLAGS     := -std=c99 -m64 -mcpu=power7
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := -mvsx
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/reference/make_defs.mk
+++ b/config/reference/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 # -fopenmp -pg
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/reference/make_defs.mk
+++ b/config/reference/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O2
 endif
 
-CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+CVECFLAGS      := 
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/config/sandybridge/bli_config.h
+++ b/config/sandybridge/bli_config.h
@@ -35,12 +35,6 @@
 #ifndef BLIS_CONFIG_H
 #define BLIS_CONFIG_H
 
-// Enable multithreading via POSIX threads.
-//#define BLIS_ENABLE_PTHREADS
-
-// Enable multithreading via OpenMP.
-#define BLIS_ENABLE_OPENMP
-
 
 
 #endif

--- a/config/sandybridge/make_defs.mk
+++ b/config/sandybridge/make_defs.mk
@@ -68,12 +68,16 @@ endif
 CKOPTFLAGS     := $(COPTFLAGS)
 
 ifeq ($(CC_VENDOR),gcc)
-CVECFLAGS      := -mavx -mfpmath=sse -march=sandybridge
+CVECFLAGS      := -mavx -mfpmath=sse -march=corei7-avx
 else
 ifeq ($(CC_VENDOR),icc)
 CVECFLAGS      := -xAVX
 else
-$(error gcc or icc is required for this configuration.)
+ifeq ($(CC_VENDOR),clang)
+CVECFLAGS      := -mavx -mfpmath=sse -march=corei7-avx
+else
+$(error gcc, icc, or clang is required for this configuration.)
+endif
 endif
 endif
 

--- a/config/sandybridge/make_defs.mk
+++ b/config/sandybridge/make_defs.mk
@@ -47,9 +47,7 @@ ifeq ($(CC),)
 CC             := gcc
 CC_VENDOR      := gcc
 endif
-ifneq ($(CC_VENDOR),gcc)
-$(error gcc is required for this configuration.)
-endif
+
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
@@ -67,8 +65,17 @@ else
 COPTFLAGS      := -O3
 endif
 
-CVECFLAGS      := -mavx -mfpmath=sse -march=native #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
+
+ifeq ($(CC_VENDOR),gcc)
+CVECFLAGS      := -mavx -mfpmath=sse -march=sandybridge
+else
+ifeq ($(CC_VENDOR),icc)
+CVECFLAGS      := -xAVX
+else
+$(error gcc or icc is required for this configuration.)
+endif
+endif
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/sandybridge/make_defs.mk
+++ b/config/sandybridge/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 -m64 -fopenmp  # -fopenmp -pg
+CMISCFLAGS     := -std=c99 -m64
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -103,13 +70,6 @@ endif
 CVECFLAGS      := -mavx -mfpmath=sse -march=native #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
-
 # --- Determine the archiver and related flags ---
 AR             := ar
 ARFLAGS        := cru
@@ -117,7 +77,7 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -lm -fopenmp -lpthread
+LDFLAGS        := -lm
 
 
 

--- a/config/template/make_defs.mk
+++ b/config/template/make_defs.mk
@@ -39,39 +39,6 @@ MAKE_DEFS_MK_INCLUDED := yes
 
 
 #
-# --- Build definitions --------------------------------------------------------
-#
-
-# Variables corresponding to other configure-time options.
-BLIS_ENABLE_VERBOSE_MAKE_OUTPUT := no
-BLIS_ENABLE_STATIC_BUILD        := yes
-BLIS_ENABLE_DYNAMIC_BUILD       := no
-
-
-
-#
-# --- Utility program definitions ----------------------------------------------
-#
-
-SH         := /bin/sh
-MV         := mv
-MKDIR      := mkdir -p
-RM_F       := rm -f
-RM_RF      := rm -rf
-SYMLINK    := ln -sf
-FIND       := find
-GREP       := grep
-XARGS      := xargs
-RANLIB     := ranlib
-INSTALL    := install -c
-
-# Used to refresh CHANGELOG.
-GIT        := git
-GIT_LOG    := $(GIT) log --decorate
-
-
-
-#
 # --- Development tools definitions --------------------------------------------
 #
 
@@ -86,7 +53,7 @@ endif
 # Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
-CMISCFLAGS     := -std=c99 # -fopenmp -pg
+CMISCFLAGS     := -std=c99
 CPICFLAGS      := -fPIC
 CWARNFLAGS     := -Wall
 
@@ -102,13 +69,6 @@ endif
 
 CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
-
-# Aggregate all of the flags into multiple groups: one for standard
-# compilation, and one for each of the supported "special" compilation
-# modes.
-CFLAGS_NOOPT   := $(CDBGFLAGS) $(CWARNFLAGS) $(CPICFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS)
-CFLAGS         := $(COPTFLAGS)  $(CVECFLAGS) $(CFLAGS_NOOPT)
-CFLAGS_KERNELS := $(CKOPTFLAGS) $(CVECFLAGS) $(CFLAGS_NOOPT)
 
 # --- Determine the archiver and related flags ---
 AR             := ar

--- a/config/template/make_defs.mk
+++ b/config/template/make_defs.mk
@@ -67,7 +67,7 @@ else
 COPTFLAGS      := -O2
 endif
 
-CVECFLAGS      := #-msse3 -march=native # -mfpmath=sse
+CVECFLAGS      := #-msse3 -march=core2 # -mfpmath=sse
 CKOPTFLAGS     := $(COPTFLAGS)
 
 # --- Determine the archiver and related flags ---

--- a/configure
+++ b/configure
@@ -73,6 +73,21 @@ print_usage()
 	echo "                 kept in the framework, otherwise optimization is"
 	echo "                 turned off."
 	echo " "
+	echo "   --enable-verbose-make, --disable-verbose-make"
+	echo " "
+	echo "                 Enable (disabled by default) verbose compilation"
+	echo "                 output during make."
+	echo " "
+	echo "   --disable-static, --enable-static"
+	echo " "
+	echo "                 Disable (enabled by default) building BLIS as a static"
+	echo "                 library. May be combined with --enable-shared."
+	echo " "
+	echo "   --enable-shared, --disable-static"
+	echo " "
+	echo "                 Enable (disabled by default) building BLIS as a shared"
+	echo "                 library. May be combined with --enable-static."
+	echo " "
 	echo "   -q, --quiet   Suppress informational output. By default, configure"
 	echo "                 is verbose. (NOTE: -q is not yet implemented)"
 	echo " "
@@ -85,7 +100,7 @@ print_usage()
 	echo "   Environment variables may also be specified as command line"
 	echo "   options, e.g.:"
 	echo " "
-	echo "     ./configure CC=gcc sandybridge"
+	echo "     ./configure [options] CC=gcc sandybridge"
 	echo " "
 	echo "   Note that not all compilers are compatible with a given"
 	echo "   configuration."
@@ -166,6 +181,11 @@ main()
 
 	# Option variables.
 	quiet_flag=''
+	
+	# Additional flags.
+	enable_verbose='yes'
+	enable_static='yes'
+	enable_shared='no'
 
 	# The path to the auto-detection script.
 	auto_detect_sh="${build_dirpath}/auto-detect/auto-detect.sh"
@@ -210,6 +230,24 @@ main()
 					enable-debug=*)
 						debug_flag=1
 						debug_type=${OPTARG#*=}
+						;;
+					enable-verbose-make)
+						enable_verbose='yes'
+						;;
+					disable-verbose-make)
+						enable_verbose='no'
+						;;
+					enable-static)
+						enable_static='yes'
+						;;
+					disable-static)
+						enable_static='no'
+						;;
+					enable-shared)
+						enable_shared='yes'
+						;;
+					disable-shared)
+						enable_shared='no'
 						;;
 					*)
 						print_usage
@@ -375,6 +413,9 @@ main()
 		| sed "s/@cc_vendor@/${cc_vendor}/g" \
 		| sed "s/@debug_type@/${debug_type}/g" \
 		| sed "s/@install_prefix@/${install_prefix_esc}/g" \
+		| sed "s/@enable_verbose@/${enable_verbose}/g" \
+		| sed "s/@enable_static@/${enable_static}/g" \
+		| sed "s/@enable_shared@/${enable_shared}/g" \
 		> "${config_mk_out_path}"
 
 

--- a/configure
+++ b/configure
@@ -442,24 +442,6 @@ main()
 		echo "Unsupported threading model: ${threading_model}."
 		exit 1
 	fi
-	
-	
-	# Determine the compiler vendor if CC was specified.
-	if [ -n "$CC" ]; then
-		if $CC --version 2>/dev/null | grep -q 'pnacl-version'; then
-			cc_vendor='pnacl-clang'
-		else
-			cc_vendor=`$CC --version 2>/dev/null | grep -Eo 'icc|gcc|clang|emcc'`
-		fi
-		if [ -z "$cc_vendor" ]; then
-			cc_vendor=`$CC -qversion 2>/dev/null | grep -o 'IBM'`
-		fi
-		if [ -z "$cc_vendor" ]; then
-			echo "Unable to determine compiler vendor."
-			exit 1
-		fi
-		cc_vendor=`echo $cc_vendor | { read first rest; echo $first; }`
-	fi
 
 
 	# Insert escape characters into the paths used in the sed command below.
@@ -477,7 +459,6 @@ main()
 		| sed "s/@config_name@/${config_name}/g" \
 		| sed "s/@dist_path@/${dist_path_esc}/g" \
 		| sed "s/@CC@/${cc_esc}/g" \
-		| sed "s/@cc_vendor@/${cc_vendor}/g" \
 		| sed "s/@debug_type@/${debug_type}/g" \
 		| sed "s/@install_prefix@/${install_prefix_esc}/g" \
 		| sed "s/@enable_verbose@/${enable_verbose}/g" \

--- a/configure
+++ b/configure
@@ -88,6 +88,14 @@ print_usage()
 	echo "                 Enable (disabled by default) building BLIS as a shared"
 	echo "                 library. May be combined with --enable-static."
 	echo " "
+	echo "   -t MODEL, --enable-threading[=MODEL], --disable-threading"
+	echo " "
+	echo "                 Enable threading in the library, using threading model"
+	echo "                 MODEL={auto,omp,pthreads,no}. If MODEL=no or "
+	echo "                 --disable-threading is specified, threading will be"
+	echo "                 disabled. If MODEL=auto or is unspecified, a model"
+	echo "                 will be chosen automatically. The default is 'auto'."
+	echo " "
 	echo "   -q, --quiet   Suppress informational output. By default, configure"
 	echo "                 is verbose. (NOTE: -q is not yet implemented)"
 	echo " "
@@ -179,11 +187,14 @@ main()
 	debug_type=''
 	debug_flag=''
 
+	# The threading flag.
+	threading_model='auto'
+
 	# Option variables.
 	quiet_flag=''
 	
 	# Additional flags.
-	enable_verbose='yes'
+	enable_verbose='no'
 	enable_static='yes'
 	enable_shared='no'
 
@@ -210,7 +221,7 @@ main()
 
 
 	# Process our command line options.
-	while getopts ":hp:d:q-:" opt; do
+	while getopts ":hp:d:t:q-:" opt; do
 		case $opt in
 			-)
 				case "$OPTARG" in
@@ -232,6 +243,9 @@ main()
 						debug_flag=1
 						debug_type=${OPTARG#*=}
 						;;
+					disable-debug)
+						debug_flag=0
+						;;
 					enable-verbose-make)
 						enable_verbose='yes'
 						;;
@@ -250,6 +264,15 @@ main()
 					disable-shared)
 						enable_shared='no'
 						;;
+					enable-threading)
+						threading_model='auto'
+						;;
+					enable-threading=*)
+						threading_model=${OPTARG#*=}
+						;;
+					disable-threading)
+						threading_model='no'
+						;;
 					*)
 						print_usage
 						;;
@@ -267,6 +290,9 @@ main()
 				;;
 			q)
 				quiet_flag=1
+				;;
+			t)
+				threading_model=$OPTARG
 				;;
 			\?)
 				print_usage
@@ -376,6 +402,46 @@ main()
 		debug_type='off'
 		echo "${script_name}: debug symbols disabled."
 	fi
+
+
+	# Check if the verbose make flag was specified.
+	if [ "x${enable_verbose}" = "xyes" ]; then
+		echo "${script_name}: enabling verbose make output, disable with 'make V=0'."
+	else
+		echo "${script_name}: disabling verbose make output, enable with 'make V=1'."
+	fi
+
+
+	# Check if the static lib flag was specified.
+	if [ "x${enable_static}" = "xyes" ]; then
+		echo "${script_name}: building BLIS as a static library."
+	fi
+	
+	# Check if the shared lib flag was specified.
+	if [ "x${enable_shared}" = "xyes" ]; then
+		echo "${script_name}: building BLIS as a shared library."
+	fi
+	
+	# Check if neither flag was specified.
+	if [ "x${enable_static}" = "xno" -a "x${enable_shared}" = "xno" ]; then
+		echo "Neither a shared nor static library build has been requested."
+		exit 1
+	fi
+	
+	
+	# Check the threading model flag.
+	if [ "x${threading_model}" = "xauto" ]; then
+		echo "${script_name}: determining the threading model automatically."
+	elif [ "x${threading_model}" = "xomp" ]; then
+		echo "${script_name}: using OpenMP for threading."
+	elif [ "x${threading_model}" = "xpthreads" ]; then
+		echo "${script_name}: using Pthreads for threading."
+	elif [ "x${threading_model}" = "xno" ]; then
+		echo "${script_name}: threading is disabled."
+	else
+		echo "Unsupported threading model: ${threading_model}."
+		exit 1
+	fi
 	
 	
 	# Determine the compiler vendor if CC was specified.
@@ -389,7 +455,7 @@ main()
 			cc_vendor=`$CC -qversion 2>/dev/null | grep -o 'IBM'`
 		fi
 		if [ -z "$cc_vendor" ]; then
-			echo Unable to determine compiler vendor.
+			echo "Unable to determine compiler vendor."
 			exit 1
 		fi
 		cc_vendor=`echo $cc_vendor | { read first rest; echo $first; }`
@@ -416,7 +482,8 @@ main()
 		| sed "s/@install_prefix@/${install_prefix_esc}/g" \
 		| sed "s/@enable_verbose@/${enable_verbose}/g" \
 		| sed "s/@enable_static@/${enable_static}/g" \
-		| sed "s/@enable_shared@/${enable_shared}/g" \
+		| sed "s/@enable_dynamic@/${enable_shared}/g" \
+		| sed "s/@threading_model@/${threading_model}/g" \
 		> "${config_mk_out_path}"
 
 


### PR DESCRIPTION
This pull request includes:

1. `configure` option to control threading model:

    - `-t <MODEL>`
    - `--enable-threading[=<MODEL>]` (default with MODEL=auto)
    - `--disable-threading` = `--enable-threading=no`
    
    where `MODEL = {auto,omp,pthreads,no}`.

2. An option to control verbose make ouput: `--enable-verbose-make` and `--disable-verbose-make` (default).

3. Options to control static/shared library generation: `--enable-static` (default), `--disable-static`, `--enable-shared`, and `--disable-shared` (default).

4. icc and clang support for Intel architectures through `./configure CC={icc,clang}` or `make CC={icc,clang}`. Note that 4mh methods for single-precision complex currently do not work with icc (see issue #51).