### PR TITLE
Disabling parallelism in Gemm using OMP_NUM_THREADS

### DIFF
--- a/frame/3/gemm/bli_gemm_threading.c
+++ b/frame/3/gemm/bli_gemm_threading.c
@@ -112,13 +112,27 @@ void bli_gemm_thrinfo_free_paths( gemm_thrinfo_t** threads, dim_t num )
 gemm_thrinfo_t** bli_create_gemm_thrinfo_paths( )
 {
 
-#ifdef BLIS_ENABLE_MULTITHREADING 
+#ifdef BLIS_ENABLE_MULTITHREADING
     dim_t jc_way = bli_read_nway_from_env( "BLIS_JC_NT" );
-//    dim_t kc_way = bli_read_nway_from_env( "BLIS_KC_NT" );
+    // dim_t kc_way = bli_read_nway_from_env( "BLIS_KC_NT" );
     dim_t kc_way = 1;
     dim_t ic_way = bli_read_nway_from_env( "BLIS_IC_NT" );
     dim_t jr_way = bli_read_nway_from_env( "BLIS_JR_NT" );
     dim_t ir_way = bli_read_nway_from_env( "BLIS_IR_NT" );
+    char* str = getenv( "OMP_NUM_THREADS" );
+    if( str != NULL )
+    {
+       int max_threads = strtol( str, NULL, 10 );
+       max_threads = max( max_threads, 1 );
+       if( max_threads == 1 )
+       {
+          jc_way = kc_way = ic_way = jr_way = ir_way = 1;   
+       }
+       else
+       {
+          // TODO: Graceful degradation; this might be complicated   
+       }
+    }
 #else
     dim_t jc_way = 1;
     dim_t kc_way = 1;

--- a/frame/base/bli_threading.c
+++ b/frame/base/bli_threading.c
@@ -816,10 +816,10 @@ dim_t bli_read_nway_from_env( char* env )
     dim_t number = 1;
     char* str = getenv( env );
     if( str != NULL )
-    {   
+    {
         number = strtol( str, NULL, 10 );
         number = max( number, 1 );
-    }   
+    }
     return number;
 }
 

--- a/frame/base/bli_threading.c
+++ b/frame/base/bli_threading.c
@@ -818,7 +818,7 @@ dim_t bli_read_nway_from_env( char* env )
     if( str != NULL )
     {
         number = strtol( str, NULL, 10 );
-        number = max( number, 1 );
+        number = (number>1) ? number : 1;
     }
     return number;
 }

--- a/frame/base/bli_threading.c
+++ b/frame/base/bli_threading.c
@@ -818,6 +818,7 @@ dim_t bli_read_nway_from_env( char* env )
     if( str != NULL )
     {   
         number = strtol( str, NULL, 10 );
+        number = max( number, 1 );
     }   
     return number;
 }


### PR DESCRIPTION
I hacked this PR together in my browser (so the formatting isn't so great), but this code could practically be copy and pasted for TRSM and any other multithreaded level 3 routines. Notice that I also modified `blis_read_nway_from_env` to ensure that the read variable is at least one.
