### PR TITLE
Default-initialize all extern global variables to avoid generating common symbols.

### DIFF
--- a/frame/1/packv/bli_packv_cntl.c
+++ b/frame/1/packv/bli_packv_cntl.c
@@ -34,7 +34,7 @@
 
 #include "blis.h"
 
-packv_t* packv_cntl;
+packv_t* packv_cntl = NULL;
 
 void bli_packv_cntl_init( void )
 {

--- a/frame/1/scalv/bli_scalv_cntl.c
+++ b/frame/1/scalv/bli_scalv_cntl.c
@@ -34,7 +34,7 @@
 
 #include "blis.h"
 
-scalv_t* scalv_cntl;
+scalv_t* scalv_cntl = NULL;
 
 void bli_scalv_cntl_init()
 {

--- a/frame/1/unpackv/bli_unpackv_cntl.c
+++ b/frame/1/unpackv/bli_unpackv_cntl.c
@@ -34,7 +34,7 @@
 
 #include "blis.h"
 
-unpackv_t* unpackv_cntl;
+unpackv_t* unpackv_cntl = NULL;
 
 void bli_unpackv_cntl_init()
 {

--- a/frame/1m/packm/bli_packm_cntl.c
+++ b/frame/1m/packm/bli_packm_cntl.c
@@ -34,10 +34,10 @@
 
 #include "blis.h"
 
-packm_t* packm_cntl_row;
-packm_t* packm_cntl_col;
+packm_t* packm_cntl_row = NULL;
+packm_t* packm_cntl_col = NULL;
 
-packm_t* packm_cntl;
+packm_t* packm_cntl = NULL;
 
 void bli_packm_cntl_init()
 {

--- a/frame/1m/scalm/bli_scalm_cntl.c
+++ b/frame/1m/scalm/bli_scalm_cntl.c
@@ -34,7 +34,7 @@
 
 #include "blis.h"
 
-scalm_t* scalm_cntl;
+scalm_t* scalm_cntl = NULL;
 
 void bli_scalm_cntl_init()
 {

--- a/frame/1m/unpackm/bli_unpackm_cntl.c
+++ b/frame/1m/unpackm/bli_unpackm_cntl.c
@@ -34,7 +34,7 @@
 
 #include "blis.h"
 
-unpackm_t* unpackm_cntl;
+unpackm_t* unpackm_cntl = NULL;
 
 void bli_unpackm_cntl_init()
 {

--- a/frame/2/gemv/bli_gemv_cntl.c
+++ b/frame/2/gemv/bli_gemv_cntl.c
@@ -39,17 +39,17 @@ extern packm_t*   packm_cntl;
 extern packv_t*   packv_cntl;
 extern unpackv_t* unpackv_cntl;
 
-gemv_t*           gemv_cntl_bs_ke_dot;
-gemv_t*           gemv_cntl_bs_ke_axpy;
+gemv_t*           gemv_cntl_bs_ke_dot = NULL;
+gemv_t*           gemv_cntl_bs_ke_axpy = NULL;
 
-gemv_t*           gemv_cntl_rp_bs_dot;
-gemv_t*           gemv_cntl_rp_bs_axpy;
+gemv_t*           gemv_cntl_rp_bs_dot = NULL;
+gemv_t*           gemv_cntl_rp_bs_axpy = NULL;
 
-gemv_t*           gemv_cntl_cp_bs_dot;
-gemv_t*           gemv_cntl_cp_bs_axpy;
+gemv_t*           gemv_cntl_cp_bs_dot = NULL;
+gemv_t*           gemv_cntl_cp_bs_axpy = NULL;
 
-gemv_t*           gemv_cntl_ge_dot;
-gemv_t*           gemv_cntl_ge_axpy;
+gemv_t*           gemv_cntl_ge_dot = NULL;
+gemv_t*           gemv_cntl_ge_axpy = NULL;
 
 
 void bli_gemv_cntl_init()

--- a/frame/2/ger/bli_ger_cntl.c
+++ b/frame/2/ger/bli_ger_cntl.c
@@ -38,17 +38,17 @@ extern packm_t*   packm_cntl;
 extern packv_t*   packv_cntl;
 extern unpackm_t* unpackm_cntl;
 
-ger_t*            ger_cntl_bs_ke_row;
-ger_t*            ger_cntl_bs_ke_col;
+ger_t*            ger_cntl_bs_ke_row = NULL;
+ger_t*            ger_cntl_bs_ke_col = NULL;
 
-ger_t*            ger_cntl_rp_bs_row;
-ger_t*            ger_cntl_rp_bs_col;
+ger_t*            ger_cntl_rp_bs_row = NULL;
+ger_t*            ger_cntl_rp_bs_col = NULL;
 
-ger_t*            ger_cntl_cp_bs_row;
-ger_t*            ger_cntl_cp_bs_col;
+ger_t*            ger_cntl_cp_bs_row = NULL;
+ger_t*            ger_cntl_cp_bs_col = NULL;
 
-ger_t*            ger_cntl_ge_row;
-ger_t*            ger_cntl_ge_col;
+ger_t*            ger_cntl_ge_row = NULL;
+ger_t*            ger_cntl_ge_col = NULL;
 
 
 void bli_ger_cntl_init()

--- a/frame/2/hemv/bli_hemv_cntl.c
+++ b/frame/2/hemv/bli_hemv_cntl.c
@@ -44,10 +44,10 @@ extern gemv_t*    gemv_cntl_rp_bs_axpy;
 extern gemv_t*    gemv_cntl_cp_bs_dot;
 extern gemv_t*    gemv_cntl_cp_bs_axpy;
 
-hemv_t*           hemv_cntl_bs_ke_lrow_ucol;
-hemv_t*           hemv_cntl_bs_ke_lcol_urow;
-hemv_t*           hemv_cntl_ge_lrow_ucol;
-hemv_t*           hemv_cntl_ge_lcol_urow;
+hemv_t*           hemv_cntl_bs_ke_lrow_ucol = NULL;
+hemv_t*           hemv_cntl_bs_ke_lcol_urow = NULL;
+hemv_t*           hemv_cntl_ge_lrow_ucol = NULL;
+hemv_t*           hemv_cntl_ge_lcol_urow = NULL;
 
 
 void bli_hemv_cntl_init()

--- a/frame/2/her/bli_her_cntl.c
+++ b/frame/2/her/bli_her_cntl.c
@@ -43,11 +43,11 @@ extern ger_t*     ger_cntl_cp_bs_col;
 extern ger_t*     ger_cntl_bs_ke_row;
 extern ger_t*     ger_cntl_bs_ke_col;
 
-her_t*            her_cntl_bs_ke_lrow_ucol;
-her_t*            her_cntl_bs_ke_lcol_urow;
+her_t*            her_cntl_bs_ke_lrow_ucol = NULL;
+her_t*            her_cntl_bs_ke_lcol_urow = NULL;
 
-her_t*            her_cntl_ge_lrow_ucol;
-her_t*            her_cntl_ge_lcol_urow;
+her_t*            her_cntl_ge_lrow_ucol = NULL;
+her_t*            her_cntl_ge_lcol_urow = NULL;
 
 
 void bli_her_cntl_init()

--- a/frame/2/her2/bli_her2_cntl.c
+++ b/frame/2/her2/bli_her2_cntl.c
@@ -41,11 +41,11 @@ extern unpackm_t* unpackm_cntl;
 extern ger_t*     ger_cntl_rp_bs_row;
 extern ger_t*     ger_cntl_cp_bs_col;
 
-her2_t*           her2_cntl_bs_ke_lrow_ucol;
-her2_t*           her2_cntl_bs_ke_lcol_urow;
+her2_t*           her2_cntl_bs_ke_lrow_ucol = NULL;
+her2_t*           her2_cntl_bs_ke_lcol_urow = NULL;
 
-her2_t*           her2_cntl_ge_lrow_ucol;
-her2_t*           her2_cntl_ge_lcol_urow;
+her2_t*           her2_cntl_ge_lrow_ucol = NULL;
+her2_t*           her2_cntl_ge_lcol_urow = NULL;
 
 
 void bli_her2_cntl_init()

--- a/frame/2/trmv/bli_trmv_cntl.c
+++ b/frame/2/trmv/bli_trmv_cntl.c
@@ -43,10 +43,10 @@ extern gemv_t*    gemv_cntl_rp_bs_axpy;
 extern gemv_t*    gemv_cntl_cp_bs_dot;
 extern gemv_t*    gemv_cntl_cp_bs_axpy;
 
-trmv_t*           trmv_cntl_bs_ke_nrow_tcol;
-trmv_t*           trmv_cntl_bs_ke_ncol_trow;
-trmv_t*           trmv_cntl_ge_nrow_tcol;
-trmv_t*           trmv_cntl_ge_ncol_trow;
+trmv_t*           trmv_cntl_bs_ke_nrow_tcol = NULL;
+trmv_t*           trmv_cntl_bs_ke_ncol_trow = NULL;
+trmv_t*           trmv_cntl_ge_nrow_tcol = NULL;
+trmv_t*           trmv_cntl_ge_ncol_trow = NULL;
 
 
 void bli_trmv_cntl_init()

--- a/frame/2/trsv/bli_trsv_cntl.c
+++ b/frame/2/trsv/bli_trsv_cntl.c
@@ -44,10 +44,10 @@ extern gemv_t*    gemv_cntl_rp_bs_axpy;
 extern gemv_t*    gemv_cntl_cp_bs_dot;
 extern gemv_t*    gemv_cntl_cp_bs_axpy;
 
-trsv_t*           trsv_cntl_bs_ke_nrow_tcol;
-trsv_t*           trsv_cntl_bs_ke_ncol_trow;
-trsv_t*           trsv_cntl_ge_nrow_tcol;
-trsv_t*           trsv_cntl_ge_ncol_trow;
+trsv_t*           trsv_cntl_bs_ke_nrow_tcol = NULL;
+trsv_t*           trsv_cntl_bs_ke_ncol_trow = NULL;
+trsv_t*           trsv_cntl_ge_nrow_tcol = NULL;
+trsv_t*           trsv_cntl_ge_ncol_trow = NULL;
 
 
 void bli_trsv_cntl_init()

--- a/frame/3/gemm/bli_gemm_cntl.c
+++ b/frame/3/gemm/bli_gemm_cntl.c
@@ -36,15 +36,15 @@
 
 extern scalm_t*   scalm_cntl;
 
-packm_t*          gemm_packa_cntl;
-packm_t*          gemm_packb_cntl;
+packm_t*          gemm_packa_cntl = NULL;
+packm_t*          gemm_packb_cntl = NULL;
 
-gemm_t*           gemm_cntl_bp_ke;
-gemm_t*           gemm_cntl_op_bp;
-gemm_t*           gemm_cntl_mm_op;
-gemm_t*           gemm_cntl_vl_mm;
+gemm_t*           gemm_cntl_bp_ke = NULL;
+gemm_t*           gemm_cntl_op_bp = NULL;
+gemm_t*           gemm_cntl_mm_op = NULL;
+gemm_t*           gemm_cntl_vl_mm = NULL;
 
-gemm_t*           gemm_cntl;
+gemm_t*           gemm_cntl = NULL;
 
 void bli_gemm_cntl_init()
 {

--- a/frame/3/trsm/bli_trsm_cntl.c
+++ b/frame/3/trsm/bli_trsm_cntl.c
@@ -38,24 +38,24 @@ extern scalm_t*   scalm_cntl;
 
 extern gemm_t*    gemm_cntl_bp_ke;
 
-packm_t*          trsm_l_packa_cntl;
-packm_t*          trsm_l_packb_cntl;
+packm_t*          trsm_l_packa_cntl = NULL;
+packm_t*          trsm_l_packb_cntl = NULL;
 
-packm_t*          trsm_r_packa_cntl;
-packm_t*          trsm_r_packb_cntl;
+packm_t*          trsm_r_packa_cntl = NULL;
+packm_t*          trsm_r_packb_cntl = NULL;
 
-trsm_t*           trsm_cntl_bp_ke;
+trsm_t*           trsm_cntl_bp_ke = NULL;
 
-trsm_t*           trsm_l_cntl_op_bp;
-trsm_t*           trsm_l_cntl_mm_op;
-trsm_t*           trsm_l_cntl_vl_mm;
+trsm_t*           trsm_l_cntl_op_bp = NULL;
+trsm_t*           trsm_l_cntl_mm_op = NULL;
+trsm_t*           trsm_l_cntl_vl_mm = NULL;
 
-trsm_t*           trsm_r_cntl_op_bp;
-trsm_t*           trsm_r_cntl_mm_op;
-trsm_t*           trsm_r_cntl_vl_mm;
+trsm_t*           trsm_r_cntl_op_bp = NULL;
+trsm_t*           trsm_r_cntl_mm_op = NULL;
+trsm_t*           trsm_r_cntl_vl_mm = NULL;
 
-trsm_t*           trsm_l_cntl;
-trsm_t*           trsm_r_cntl;
+trsm_t*           trsm_l_cntl = NULL;
+trsm_t*           trsm_r_cntl = NULL;
 
 
 void bli_trsm_cntl_init()

--- a/frame/base/bli_const.c
+++ b/frame/base/bli_const.c
@@ -34,13 +34,13 @@
 
 #include "blis.h"
 
-obj_t BLIS_TWO;
-obj_t BLIS_ONE;
-obj_t BLIS_ONE_HALF;
-obj_t BLIS_ZERO;
-obj_t BLIS_MINUS_ONE_HALF;
-obj_t BLIS_MINUS_ONE;
-obj_t BLIS_MINUS_TWO;
+obj_t BLIS_TWO = {};
+obj_t BLIS_ONE = {};
+obj_t BLIS_ONE_HALF = {};
+obj_t BLIS_ZERO = {};
+obj_t BLIS_MINUS_ONE_HALF = {};
+obj_t BLIS_MINUS_ONE = {};
+obj_t BLIS_MINUS_TWO = {};
 
 static bool_t bli_const_is_init = FALSE;
 

--- a/frame/base/bli_getopt.c
+++ b/frame/base/bli_getopt.c
@@ -35,11 +35,11 @@
 #include "blis.h"
 
 
-char       *bli_optarg;
+char       *bli_optarg = NULL;
 int         bli_optind = 1;
 
 int         bli_opterr = 0;
-int         bli_optopt;
+int         bli_optopt = 0;
 
 static char OPT_MARKER = '-';
 

--- a/frame/base/bli_threading.c
+++ b/frame/base/bli_threading.c
@@ -36,10 +36,10 @@
 
 static bool_t bli_thread_is_init = FALSE;
 
-packm_thrinfo_t BLIS_PACKM_SINGLE_THREADED;
-gemm_thrinfo_t BLIS_GEMM_SINGLE_THREADED;
-herk_thrinfo_t BLIS_HERK_SINGLE_THREADED;
-thread_comm_t BLIS_SINGLE_COMM;
+packm_thrinfo_t BLIS_PACKM_SINGLE_THREADED = {};
+gemm_thrinfo_t BLIS_GEMM_SINGLE_THREADED = {};
+herk_thrinfo_t BLIS_HERK_SINGLE_THREADED = {};
+thread_comm_t BLIS_SINGLE_COMM = {};
 
 void bli_thread_init( void )
 {


### PR DESCRIPTION
Fixes #73. The list of candidates was compiled with `nm -o lib/libblis.a 2>/dev/null | grep "C _"`.