### PR TITLE
Move default SIMD-related definitions to bli_kernel_macro_defs.h

### DIFF
--- a/frame/include/bli_config_macro_defs.h
+++ b/frame/include/bli_config_macro_defs.h
@@ -83,60 +83,6 @@
 #endif
 
 
-// -- MEMORY ALLOCATION --------------------------------------------------------
-
-// Size of a virtual memory page. This is used to align certain memory
-// buffers which are allocated and used internally.
-#ifndef BLIS_PAGE_SIZE
-#define BLIS_PAGE_SIZE                   4096
-#endif
-
-// Number of named SIMD vector registers available for use.
-#ifndef BLIS_SIMD_NUM_REGISTERS
-#define BLIS_SIMD_NUM_REGISTERS          16
-#endif
-
-// Size (in bytes) of each SIMD vector.
-#ifndef BLIS_SIMD_SIZE
-#define BLIS_SIMD_SIZE                   32
-#endif
-
-// Alignment size (in bytes) needed by the instruction set for aligned
-// SIMD/vector instructions.
-#ifndef BLIS_SIMD_ALIGN_SIZE
-#define BLIS_SIMD_ALIGN_SIZE             BLIS_SIMD_SIZE
-#endif
-
-// The maximum size in bytes of local stack buffers within macro-kernel
-// functions. These buffers are usually used to store a temporary copy
-// of a single microtile. The reason we multiply by 2 is to handle induced
-// methods, where we use real domain register blocksizes in units of
-// complex elements. Specifically, the macro-kernels will need this larger
-// micro-tile footprint, even though the virtual micro-kernels will only
-// ever be writing to half (real or imaginary part) at a time.
-#ifndef BLIS_STACK_BUF_MAX_SIZE
-#define BLIS_STACK_BUF_MAX_SIZE          ( BLIS_SIMD_NUM_REGISTERS * \
-                                           BLIS_SIMD_SIZE * 2 )
-#endif
-
-// Alignment size used to align local stack buffers within macro-kernel
-// functions.
-#define BLIS_STACK_BUF_ALIGN_SIZE        BLIS_SIMD_ALIGN_SIZE
-
-// Alignment size used when allocating memory dynamically from the operating
-// system (eg: posix_memalign()). To disable heap alignment and just use
-// malloc() instead, set this to 1.
-#define BLIS_HEAP_ADDR_ALIGN_SIZE        BLIS_SIMD_ALIGN_SIZE
-
-// Alignment size used when sizing leading dimensions of dynamically
-// allocated memory.
-#define BLIS_HEAP_STRIDE_ALIGN_SIZE      BLIS_SIMD_ALIGN_SIZE
-
-// Alignment size used when allocating blocks to the internal memory
-// pool (for packing buffers).
-#define BLIS_POOL_ADDR_ALIGN_SIZE        BLIS_PAGE_SIZE
-
-
 // -- MISCELLANEOUS OPTIONS ----------------------------------------------------
 
 // Stay initialized after auto-initialization, unless and until the user

--- a/frame/include/bli_kernel_macro_defs.h
+++ b/frame/include/bli_kernel_macro_defs.h
@@ -36,6 +36,60 @@
 #define BLIS_KERNEL_MACRO_DEFS_H
 
 
+// -- MEMORY ALLOCATION --------------------------------------------------------
+
+// Size of a virtual memory page. This is used to align certain memory
+// buffers which are allocated and used internally.
+#ifndef BLIS_PAGE_SIZE
+#define BLIS_PAGE_SIZE                   4096
+#endif
+
+// Number of named SIMD vector registers available for use.
+#ifndef BLIS_SIMD_NUM_REGISTERS
+#define BLIS_SIMD_NUM_REGISTERS          16
+#endif
+
+// Size (in bytes) of each SIMD vector.
+#ifndef BLIS_SIMD_SIZE
+#define BLIS_SIMD_SIZE                   32
+#endif
+
+// Alignment size (in bytes) needed by the instruction set for aligned
+// SIMD/vector instructions.
+#ifndef BLIS_SIMD_ALIGN_SIZE
+#define BLIS_SIMD_ALIGN_SIZE             BLIS_SIMD_SIZE
+#endif
+
+// The maximum size in bytes of local stack buffers within macro-kernel
+// functions. These buffers are usually used to store a temporary copy
+// of a single microtile. The reason we multiply by 2 is to handle induced
+// methods, where we use real domain register blocksizes in units of
+// complex elements. Specifically, the macro-kernels will need this larger
+// micro-tile footprint, even though the virtual micro-kernels will only
+// ever be writing to half (real or imaginary part) at a time.
+#ifndef BLIS_STACK_BUF_MAX_SIZE
+#define BLIS_STACK_BUF_MAX_SIZE          ( BLIS_SIMD_NUM_REGISTERS * \
+                                           BLIS_SIMD_SIZE * 2 )
+#endif
+
+// Alignment size used to align local stack buffers within macro-kernel
+// functions.
+#define BLIS_STACK_BUF_ALIGN_SIZE        BLIS_SIMD_ALIGN_SIZE
+
+// Alignment size used when allocating memory dynamically from the operating
+// system (eg: posix_memalign()). To disable heap alignment and just use
+// malloc() instead, set this to 1.
+#define BLIS_HEAP_ADDR_ALIGN_SIZE        BLIS_SIMD_ALIGN_SIZE
+
+// Alignment size used when sizing leading dimensions of dynamically
+// allocated memory.
+#define BLIS_HEAP_STRIDE_ALIGN_SIZE      BLIS_SIMD_ALIGN_SIZE
+
+// Alignment size used when allocating blocks to the internal memory
+// pool (for packing buffers).
+#define BLIS_POOL_ADDR_ALIGN_SIZE        BLIS_PAGE_SIZE
+
+
 // -- Define row access bools --------------------------------------------------
 
 // In this section we consider each datatype-specific "prefers contiguous rows"


### PR DESCRIPTION
Otherwise, configurations which customize these fail as these are now defined in bli_kernel.h.