### PR TITLE
use GCC intrinsic instead of pthread_mutex

### DIFF
--- a/frame/base/bli_threading_pthreads.h
+++ b/frame/base/bli_threading_pthreads.h
@@ -44,7 +44,9 @@ typedef int pthread_barrierattr_t;
 
 struct pthread_barrier_s
 {
+#ifdef BLIS_USE_PTHREAD_MUTEX
     pthread_mutex_t mutex;
+#endif
     bool_t  sense;
     dim_t   threads_arrived;
     dim_t   n_threads;


### PR DESCRIPTION
I'm not sure how necessary this is, but I was reading the thread barrier code and couldn't help but implement this.

I can port this to use C11 atomics as well with trivial effort.