### PR TITLE
Add thread yield function for spin-loops.

### DIFF
--- a/config/dunnington/bli_kernel.h
+++ b/config/dunnington/bli_kernel.h
@@ -36,6 +36,9 @@
 #define BLIS_KERNEL_H
 
 
+#define BLIS_YIELD bli_intel_yield
+
+
 // -- LEVEL-3 MICRO-KERNEL CONSTANTS -------------------------------------------
 
 #undef  BLIS_SIMD_ALIGN_SIZE

--- a/config/haswell/bli_kernel.h
+++ b/config/haswell/bli_kernel.h
@@ -36,6 +36,9 @@
 #define BLIS_KERNEL_H
 
 
+#define BLIS_YIELD bli_intel_yield
+
+
 // -- LEVEL-3 MICRO-KERNEL CONSTANTS AND DEFINITIONS ---------------------------
 
 //

--- a/config/sandybridge/bli_kernel.h
+++ b/config/sandybridge/bli_kernel.h
@@ -36,6 +36,9 @@
 #define BLIS_KERNEL_H
 
 
+#define BLIS_YIELD bli_intel_yield
+
+
 // -- LEVEL-3 MICRO-KERNEL CONSTANTS AND DEFINITIONS ---------------------------
 
 //

--- a/frame/base/bli_threading.c
+++ b/frame/base/bli_threading.c
@@ -848,3 +848,5 @@ dim_t bli_lcm( dim_t x, dim_t y)
 {
     return x * y / bli_gcd( x, y );
 }
+
+void bli_default_yield( void ) {}

--- a/frame/base/bli_threading.h
+++ b/frame/base/bli_threading.h
@@ -223,4 +223,6 @@ void bli_level3_thread_decorator
 dim_t bli_gcd( dim_t x, dim_t y );
 dim_t bli_lcm( dim_t x, dim_t y );
 
+void bli_default_yield( void );
+
 #endif

--- a/frame/base/bli_threading_omp.c
+++ b/frame/base/bli_threading_omp.c
@@ -99,7 +99,7 @@ void bli_barrier( thread_comm_t* communicator, dim_t t_id )
     }
     else {
         volatile bool_t* listener = &communicator->barrier_sense;
-        while( *listener == my_sense ) {}
+        while( *listener == my_sense ) { BLIS_YIELD(); }
     }
 }
 
@@ -208,7 +208,7 @@ void tree_barrier( barrier_t* barack )
     }
     else {
         volatile int* listener = &barack->signal;
-        while( *listener == my_signal ) {}
+        while( *listener == my_signal ) { BLIS_YIELD(); }
     }
 }
 

--- a/frame/base/bli_threading_pthreads.c
+++ b/frame/base/bli_threading_pthreads.c
@@ -71,7 +71,7 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
     }
     else {
         volatile bool_t* listener = &barrier->sense;
-        while( *listener == my_sense ) {}
+        while( *listener == my_sense ) { BLIS_YIELD(); }
     }
     return 0;
 }

--- a/frame/include/bli_kernel_macro_defs.h
+++ b/frame/include/bli_kernel_macro_defs.h
@@ -36,6 +36,18 @@
 #define BLIS_KERNEL_MACRO_DEFS_H
 
 
+// -- THREAD YIELDING ----------------------------------------------------------
+
+// Thread yield function for spin-loops.
+//
+//   void BLIS_YIELD( void );
+//
+
+#ifndef BLIS_YIELD
+#define BLIS_YIELD                      bli_default_yield
+#endif
+
+
 // -- MEMORY ALLOCATION --------------------------------------------------------
 
 // Memory allocation functions. These macros define the three types of

--- a/frame/include/bli_kernel_prototypes.h
+++ b/frame/include/bli_kernel_prototypes.h
@@ -35,6 +35,10 @@
 #ifndef BLIS_KERNEL_PROTOTYPES_H
 #define BLIS_KERNEL_PROTOTYPES_H
 
+// Generate prototype for thread yield function.
+
+void BLIS_YIELD( void );
+
 // Generate prototypes for level-3 micro-kernels.
 
 //

--- a/kernels/x86_64/haswell/3/bli_gemm_asm_d6x8.c
+++ b/kernels/x86_64/haswell/3/bli_gemm_asm_d6x8.c
@@ -34,6 +34,12 @@
 
 #include "blis.h"
 
+void bli_intel_yield()
+{
+    //_mm_pause();
+    __asm__ __volatile__ ("pause");
+}
+
 
 #define SGEMM_INPUT_GS_BETA_NZ \
 	"vmovlps    (%%rcx        ),  %%xmm0,  %%xmm0  \n\t" \

--- a/kernels/x86_64/penryn/3/bli_gemm_asm_d4x4.c
+++ b/kernels/x86_64/penryn/3/bli_gemm_asm_d4x4.c
@@ -34,6 +34,12 @@
 
 #include "blis.h"
 
+void bli_intel_yield()
+{
+    //_mm_pause();
+    __asm__ __volatile__ ("pause");
+}
+
 void bli_sgemm_asm_8x4
      (
        dim_t               k,

--- a/kernels/x86_64/sandybridge/3/bli_gemm_asm_d8x4.c
+++ b/kernels/x86_64/sandybridge/3/bli_gemm_asm_d8x4.c
@@ -37,6 +37,12 @@
 
 #include "blis.h"
 
+void bli_intel_yield()
+{
+    //_mm_pause();
+    __asm__ __volatile__ ("pause");
+}
+
 void bli_sgemm_asm_8x8
      (
        dim_t               k,


### PR DESCRIPTION
I noticed that TBLIS outperforms BLIS by about 30 GFLOP/s (400 vs. 370) on 12 cores of Lonestar 5 (both using OMP). To try and fix this I added a `pause` instruction in the spin-loop for Intel architectures, but alas there is no improvement. In any case, the optional macro `BLIS_YIELD` that I added in `bli_kernel.h` might be useful.

@fgvanzee, @tlrmchlsmth we should go over the respective codes at some point and figure out why TBLIS is faster.
