### PR TITLE
Change -openmp to -fopenmp for icc.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -170,8 +170,8 @@ ifeq ($(THREADING_MODEL),auto)
 THREADING_MODEL := omp
 endif
 ifeq ($(THREADING_MODEL),omp)
-CTHREADFLAGS := -openmp
-LDFLAGS      += -openmp
+CTHREADFLAGS := -fopenmp
+LDFLAGS      += -fopenmp
 endif
 ifeq ($(THREADING_MODEL),pthreads)
 CTHREADFLAGS := -pthread


### PR DESCRIPTION
Since Intel 15, the `-openmp` option is depracated in favor of `-qopenmp`, and recent versions complain loudly about it. However, `-fopenmp` was and is still supported on Linux and OS X, providing coverage back to Intel 12.1. If at some point Intel nixes that too, then we can always switch again to `-qopenmp`.