### PR TITLE
Change .align to .p2align in Bulldozer ukernels

### DIFF
--- a/kernels/x86_64/bulldozer/3/bli_gemm_asm_d4x6_fma4.c
+++ b/kernels/x86_64/bulldozer/3/bli_gemm_asm_d4x6_fma4.c
@@ -763,7 +763,7 @@ void bli_sgemm_asm_8x8_fma4
 #undef KERNEL4x6_4
 
 #define KERNEL4x6_1(xx) \
-		".align 4											\n\t"\
+		".p2align 2											\n\t"\
 		"vmovddup -8 * 8(%%rax), %%xmm0						\n\t"\
 		"vfmaddpd %%xmm4,  %%xmm1, %%xmm0, %%xmm4			\n\t"\
 		"vfmaddpd %%xmm5,  %%xmm2, %%xmm0, %%xmm5			\n\t"\
@@ -888,7 +888,7 @@ void bli_dgemm_asm_4x6_fma4
 		"testq  %%rsi, %%rsi            \n\t"
 		"je .CONSIDERKLEFT   		\n\t"
 		"                       	\n\t"
-		".align 32              	\n\t"
+		".p2align 5              	\n\t"
 		".LOOPKITER:                    \n\t" // MAIN LOOP
 		"                       	\n\t"
         KERNEL4x6_1(xx)


### PR DESCRIPTION
Apparently OSX doesn't allow .align directives for >16B, so I've changed these to their .p2align counterparts.