### PR TITLE
never use libm with Intel compilers

### DIFF
--- a/config/armv7a/make_defs.mk
+++ b/config/armv7a/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/armv8a/make_defs.mk
+++ b/config/armv8a/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/bulldozer/make_defs.mk
+++ b/config/bulldozer/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/carrizo/make_defs.mk
+++ b/config/carrizo/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/cortex-a15/make_defs.mk
+++ b/config/cortex-a15/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/cortex-a9/make_defs.mk
+++ b/config/cortex-a9/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/dunnington/make_defs.mk
+++ b/config/dunnington/make_defs.mk
@@ -88,7 +88,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/haswell/make_defs.mk
+++ b/config/haswell/make_defs.mk
@@ -88,7 +88,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/knl/make_defs.mk
+++ b/config/knl/make_defs.mk
@@ -95,7 +95,11 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-LDFLAGS        := -lm -lmemkind
+ifeq ($(CC_VENDOR),icc)
+LDFLAGS        := -lmemkind
+else
+LDFLAGS        := -lmemkind -lm
+endif
 
 
 

--- a/config/loongson3a/make_defs.mk
+++ b/config/loongson3a/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/mic/make_defs.mk
+++ b/config/mic/make_defs.mk
@@ -77,7 +77,11 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifeq ($(CC_VENDOR),icc)
+LDFLAGS        := -mmic
+else
 LDFLAGS        := -mmic -lm
+endif
 
 
 

--- a/config/piledriver/make_defs.mk
+++ b/config/piledriver/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/pnacl/make_defs.mk
+++ b/config/pnacl/make_defs.mk
@@ -63,7 +63,9 @@ ARFLAGS        := rcs
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := 
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 # --- Determine the finalizer and related flags ---
 FINALIZER      := pnacl-finalize

--- a/config/power7/make_defs.mk
+++ b/config/power7/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/reference/make_defs.mk
+++ b/config/reference/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/sandybridge/make_defs.mk
+++ b/config/sandybridge/make_defs.mk
@@ -88,7 +88,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 

--- a/config/template/make_defs.mk
+++ b/config/template/make_defs.mk
@@ -77,7 +77,9 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
+ifneq ($(CC_VENDOR),icc)
 LDFLAGS        := -lm
+endif
 
 
 


### PR DESCRIPTION
Intel compilers include a highly optimized math library (libimf) that
should be used instead of GNU libm.

yes, this change is for ALL targets, including those that are not
supported by the Intel compiler.  there is no harm in doing this, and it
is future-proof in the event that the Intel compilers support other
architectures.

this has not been tested.  it should not be merged until that happens.
