### PR TITLE
Add automatic loop thread assignment.

### DIFF
--- a/frame/3/gemm/bli_gemm_front.c
+++ b/frame/3/gemm/bli_gemm_front.c
@@ -86,7 +86,10 @@ void bli_gemm_front
 	bli_cntx_set_family( BLIS_GEMM, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_GEMM, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_GEMM, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end via the thread handler.
 	bli_l3_thread_decorator

--- a/frame/3/gemm/old/bli_gemm_thread.c
+++ b/frame/3/gemm/old/bli_gemm_thread.c
@@ -40,12 +40,12 @@ thrinfo_t** bli_gemm_thrinfo_create_paths( void )
 {
 
 #ifdef BLIS_ENABLE_MULTITHREADING
-    dim_t jc_way = bli_env_read_nway( "BLIS_JC_NT" );
-//    dim_t kc_way = bli_env_read_nway( "BLIS_KC_NT" );
+    dim_t jc_way = bli_env_read_nway( "BLIS_JC_NT", 1 );
+//    dim_t kc_way = bli_env_read_nway( "BLIS_KC_NT", 1 );
     dim_t kc_way = 1;
-    dim_t ic_way = bli_env_read_nway( "BLIS_IC_NT" );
-    dim_t jr_way = bli_env_read_nway( "BLIS_JR_NT" );
-    dim_t ir_way = bli_env_read_nway( "BLIS_IR_NT" );
+    dim_t ic_way = bli_env_read_nway( "BLIS_IC_NT", 1 );
+    dim_t jr_way = bli_env_read_nway( "BLIS_JR_NT", 1 );
+    dim_t ir_way = bli_env_read_nway( "BLIS_IR_NT", 1 );
 #else
     dim_t jc_way = 1;
     dim_t kc_way = 1;

--- a/frame/3/hemm/bli_hemm_front.c
+++ b/frame/3/hemm/bli_hemm_front.c
@@ -93,7 +93,10 @@ void bli_hemm_front
 	bli_cntx_set_family( BLIS_GEMM, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_HEMM, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_HEMM, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/3/her2k/bli_her2k_front.c
+++ b/frame/3/her2k/bli_her2k_front.c
@@ -111,7 +111,10 @@ void bli_her2k_front
 	bli_cntx_set_family( BLIS_HERK, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_HER2K, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_HER2K, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke herk twice, using beta only the first time.
 

--- a/frame/3/herk/bli_herk_front.c
+++ b/frame/3/herk/bli_herk_front.c
@@ -91,7 +91,10 @@ void bli_herk_front
 	bli_cntx_set_family( BLIS_HERK, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_HERK, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_HERK, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/3/symm/bli_symm_front.c
+++ b/frame/3/symm/bli_symm_front.c
@@ -92,7 +92,10 @@ void bli_symm_front
 	bli_cntx_set_family( BLIS_GEMM, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_SYMM, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_SYMM, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/3/syr2k/bli_syr2k_front.c
+++ b/frame/3/syr2k/bli_syr2k_front.c
@@ -92,7 +92,10 @@ void bli_syr2k_front
 	bli_cntx_set_family( BLIS_HERK, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_SYR2K, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_SYR2K, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke herk twice, using beta only the first time.
 

--- a/frame/3/syrk/bli_syrk_front.c
+++ b/frame/3/syrk/bli_syrk_front.c
@@ -85,7 +85,10 @@ void bli_syrk_front
 	bli_cntx_set_family( BLIS_HERK, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_SYRK, BLIS_LEFT, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_SYRK, BLIS_LEFT, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/3/trmm/bli_trmm_front.c
+++ b/frame/3/trmm/bli_trmm_front.c
@@ -135,7 +135,10 @@ void bli_trmm_front
 	bli_cntx_set_family( BLIS_TRMM, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_TRMM, side, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_TRMM, side, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/3/trmm3/bli_trmm3_front.c
+++ b/frame/3/trmm3/bli_trmm3_front.c
@@ -134,7 +134,10 @@ void bli_trmm3_front
 	bli_cntx_set_family( BLIS_TRMM, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_TRMM3, side, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_TRMM3, side, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/3/trsm/bli_trsm_front.c
+++ b/frame/3/trsm/bli_trsm_front.c
@@ -124,7 +124,10 @@ void bli_trsm_front
 	bli_cntx_set_family( BLIS_TRSM, cntx );
 
 	// Record the threading for each level within the context.
-	bli_cntx_set_thrloop_from_env( BLIS_TRSM, side, cntx );
+	bli_cntx_set_thrloop_from_env( BLIS_TRSM, side, cntx,
+                                   bli_obj_length( c_local ),
+                                   bli_obj_width( c_local ),
+                                   bli_obj_width( a_local ) );
 
 	// Invoke the internal back-end.
 	bli_l3_thread_decorator

--- a/frame/base/bli_cntx.c
+++ b/frame/base/bli_cntx.c
@@ -694,23 +694,56 @@ void bli_cntx_set_pack_schema_c( pack_t  schema_c,
 	bli_cntx_set_schema_c( schema_c, cntx );
 }
 
-void bli_cntx_set_thrloop_from_env( opid_t l3_op, side_t side, cntx_t* cntx )
+void bli_cntx_set_thrloop_from_env( opid_t l3_op, side_t side, cntx_t* cntx,
+                                    dim_t m, dim_t n, dim_t k )
 {
 	dim_t jc, pc, ic, jr, ir;
 
 #ifdef BLIS_ENABLE_MULTITHREADING
-	jc = bli_env_read_nway( "BLIS_JC_NT" );
-	//pc = bli_env_read_nway( "BLIS_KC_NT" );
+
+	int nthread = bli_env_read_nway( "BLIS_NUM_THREADS", -1 );
+
+	if ( nthread == -1 )
+	    nthread = bli_env_read_nway( "OMP_NUM_THREADS", -1 );
+
+	if ( nthread < 1 ) nthread = 1;
+
+    bli_partition_2x2( nthread, m*BLIS_DEFAULT_M_THREAD_RATIO,
+                                n*BLIS_DEFAULT_N_THREAD_RATIO, &ic, &jc );
+
+    for ( ir = BLIS_DEFAULT_MR_THREAD_MAX ; ir > 1 ; ir-- )
+    {
+        if ( ic % ir == 0 )
+        {
+            ic /= ir;
+            break;
+        }
+    }
+
+    for ( jr = BLIS_DEFAULT_NR_THREAD_MAX ; jr > 1 ; jr-- )
+    {
+        if ( jc % jr == 0 )
+        {
+            jc /= jr;
+            break;
+        }
+    }
+
+	jc = bli_env_read_nway( "BLIS_JC_NT", jc );
+	//pc = bli_env_read_nway( "BLIS_KC_NT", 1 );
 	pc = 1;
-	ic = bli_env_read_nway( "BLIS_IC_NT" );
-	jr = bli_env_read_nway( "BLIS_JR_NT" );
-	ir = bli_env_read_nway( "BLIS_IR_NT" );
+	ic = bli_env_read_nway( "BLIS_IC_NT", ic );
+	jr = bli_env_read_nway( "BLIS_JR_NT", jr );
+	ir = bli_env_read_nway( "BLIS_IR_NT", ir );
+
 #else
+
 	jc = 1;
 	pc = 1;
 	ic = 1;
 	jr = 1;
 	ir = 1;
+
 #endif
 
 	if ( l3_op == BLIS_TRMM )
@@ -750,7 +783,7 @@ void bli_cntx_set_thrloop_from_env( opid_t l3_op, side_t side, cntx_t* cntx )
 			(
 			  1,
 			  1,
-			  jc * ic * jr,
+			  ic * pc * jc * ic * jr,
 			  1,
 			  1,
 			  cntx
@@ -763,7 +796,7 @@ void bli_cntx_set_thrloop_from_env( opid_t l3_op, side_t side, cntx_t* cntx )
 			  1,
 			  1,
 			  1,
-			  ic * jr * ir,
+			  ic * pc * jc * jr * ir,
 			  1,
 			  cntx
 			);

--- a/frame/base/bli_cntx.c
+++ b/frame/base/bli_cntx.c
@@ -783,7 +783,7 @@ void bli_cntx_set_thrloop_from_env( opid_t l3_op, side_t side, cntx_t* cntx,
 			(
 			  1,
 			  1,
-			  ic * pc * jc * ic * jr,
+			  ic * pc * jc * ir * jr,
 			  1,
 			  1,
 			  cntx

--- a/frame/base/bli_cntx.h
+++ b/frame/base/bli_cntx.h
@@ -436,7 +436,10 @@ void     bli_cntx_set_pack_schema_c( pack_t  schema_c,
                                      cntx_t* cntx );
 void     bli_cntx_set_thrloop_from_env( opid_t  l3_op,
                                         side_t  side,
-                                        cntx_t* cntx );
+                                        cntx_t* cntx,
+                                        dim_t m,
+                                        dim_t n,
+                                        dim_t k );
 
 // other query functions
 

--- a/frame/include/bli_kernel_macro_defs.h
+++ b/frame/include/bli_kernel_macro_defs.h
@@ -1347,6 +1347,26 @@
 #endif
 
 
+// -- Define default threading parameters --------------------------------------
+
+
+#ifndef BLIS_DEFAULT_M_THREAD_RATIO
+#define BLIS_DEFAULT_M_THREAD_RATIO 2
+#endif
+
+#ifndef BLIS_DEFAULT_N_THREAD_RATIO
+#define BLIS_DEFAULT_N_THREAD_RATIO 1
+#endif
+
+#ifndef BLIS_DEFAULT_MR_THREAD_MAX
+#define BLIS_DEFAULT_MR_THREAD_MAX 1
+#endif
+
+#ifndef BLIS_DEFAULT_NR_THREAD_MAX
+#define BLIS_DEFAULT_NR_THREAD_MAX 3
+#endif
+
+
 // -- Kernel blocksize checks --------------------------------------------------
 
 // Verify that cache blocksizes are whole multiples of register blocksizes.

--- a/frame/include/bli_kernel_macro_defs.h
+++ b/frame/include/bli_kernel_macro_defs.h
@@ -1363,7 +1363,7 @@
 #endif
 
 #ifndef BLIS_DEFAULT_NR_THREAD_MAX
-#define BLIS_DEFAULT_NR_THREAD_MAX 3
+#define BLIS_DEFAULT_NR_THREAD_MAX 4
 #endif
 
 

--- a/frame/thread/bli_thread.h
+++ b/frame/thread/bli_thread.h
@@ -164,10 +164,25 @@ void bli_l3_thread_decorator
        cntl_t* cntl
      );
 
+// Factorization and partitioning prototypes
+typedef struct
+{
+    dim_t n;
+    dim_t sqrt_n;
+    dim_t f;
+} bli_prime_factors_t;
+
+void bli_prime_factorization(dim_t n, bli_prime_factors_t* factors);
+
+dim_t bli_next_prime_factor(bli_prime_factors_t* factors);
+
+void bli_partition_2x2(dim_t nthread, dim_t work1, dim_t work2, dim_t* nt1, dim_t* nt2);
+
 // Miscellaneous prototypes
-dim_t bli_env_read_nway( const char* env );
+dim_t bli_env_read_nway( const char* env, dim_t fallback );
 dim_t bli_gcd( dim_t x, dim_t y );
 dim_t bli_lcm( dim_t x, dim_t y );
+dim_t bli_ipow( dim_t base, dim_t power );
 
 #endif
 


### PR DESCRIPTION
- Number of threads is determined by BLIS_NUM_THREADS or OMP_NUM_THREADS, but can be overridden by BLIS_XX_NT as before.
- Threads are assigned to loops (ic, jc, ir, and jc) automatically by weighted partitioning and heuristics, both of which are tunable via bli_kernel.h.
- All level-3 BLAS covered.