### PR TITLE
allow KNL build without hbwmalloc (i.e. emulated)

### DIFF
--- a/config/knl/bli_kernel.h
+++ b/config/knl/bli_kernel.h
@@ -43,10 +43,21 @@
 #define BLIS_SIMD_SIZE                   64
 #define BLIS_SIMD_NUM_REGISTERS          32
 
+#ifdef BLIS_NO_HBWMALLOC
+
+#include <stdlib.h>
+
+#define BLIS_MALLOC_POOL malloc
+#define BLIS_FREE_POOL free
+
+#else
+
 #include <hbwmalloc.h>
 
 #define BLIS_MALLOC_POOL hbw_malloc
 #define BLIS_FREE_POOL hbw_free
+
+#endif
 
 //#define BLIS_MALLOC_INTL hbw_malloc
 //#define BLIS_FREE_INTL hbw_free

--- a/config/knl/make_defs.mk
+++ b/config/knl/make_defs.mk
@@ -65,6 +65,10 @@ else
 COPTFLAGS      := -O3
 endif
 
+ifeq ($(DEBUG_TYPE),sde)
+CPPROCFLAGS    += -DBLIS_NO_HBWMALLOC
+endif
+
 CKOPTFLAGS     := $(COPTFLAGS)
 
 ifeq ($(CC_VENDOR),gcc)
@@ -95,11 +99,16 @@ ARFLAGS        := cru
 # --- Determine the linker and related flags ---
 LINKER         := $(CC)
 SOFLAGS        := -shared
-ifeq ($(CC_VENDOR),icc)
+
+ifneq ($(DEBUG_TYPE),sde)
 LDFLAGS        := -lmemkind
 else
-LDFLAGS        := -lmemkind -lm
+LDFLAGS        :=
 endif
+
+ifneq ($(CC_VENDOR),icc)
+LDFLAGS        += -lm
+endif 
 
 
 

--- a/configure
+++ b/configure
@@ -458,6 +458,9 @@ main()
 	if [ -n "${debug_flag}" ]; then
 		if [ "x${debug_type}" = "xopt" ]; then
 			echo "${script_name}: enabling debug symbols with optimizations."
+                elif [ "x${debug_type}" = "xsde" ]; then
+			debug_type='sde'
+			echo "${script_name}: enabling SDE processor emulation."
 		else
 			debug_type='noopt'
 			echo "${script_name}: enabling debug symbols; optimizations disabled."


### PR DESCRIPTION
we want to be able to run BLIS KNL binaries on non-KNL machines via SDE.
although it is possible to install hbwmalloc implementation on such
systems, it is easier not to, since obviously the performance of SDE
execution is not representative so there is no reason to emulate HBW
allocation.