### PR TITLE
Travis CI SDE testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,18 @@ env:
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="auto"
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="reference"
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="dunnington"
-  - RUN_TEST=0 THREADING="none" BUILD_CONFIG="sandybridge"
-  - RUN_TEST=0 THREADING="none" BUILD_CONFIG="knl"
-  - RUN_TEST=0 THREADING="none" BUILD_CONFIG="haswell"
+  - RUN_TEST=1 THREADING="none" BUILD_CONFIG="sandybridge"
+  - RUN_TEST=1 THREADING="none" BUILD_CONFIG="knl"
+  - RUN_TEST=1 THREADING="none" BUILD_CONFIG="haswell"
   - RUN_TEST=0 THREADING="none" BUILD_CONFIG="bulldozer"
   - RUN_TEST=0 THREADING="none" BUILD_CONFIG="piledriver"
   - RUN_TEST=0 THREADING="none" BUILD_CONFIG="carrizo"
   - RUN_TEST=0 THREADING="openmp" BUILD_CONFIG="auto"
   - RUN_TEST=0 THREADING="pthreads" BUILD_CONFIG="auto"
-  
+
 matrix:
   allow_failures:
-    - env: RUN_TEST=0 THREADING="none" BUILD_CONFIG="knl"
+    - env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="knl"
   exclude:
     - os: linux
       compiler: clang
@@ -35,11 +35,11 @@ matrix:
     - os: osx
       env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="dunnington"
     - os: osx
-      env: RUN_TEST=0 THREADING="none" BUILD_CONFIG="sandybridge"
+      env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="sandybridge"
     - os: osx
-      env: RUN_TEST=0 THREADING="none" BUILD_CONFIG="knl"
+      env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="knl"
     - os: osx
-      env: RUN_TEST=0 THREADING="none" BUILD_CONFIG="haswell"
+      env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="haswell"
     - os: osx
       env: RUN_TEST=0 THREADING="none" BUILD_CONFIG="bulldozer"
     - os: osx
@@ -50,24 +50,18 @@ matrix:
       env: RUN_TEST=0 THREADING="openmp" BUILD_CONFIG="auto"
 
 install:
-  - if [ "$CC" = "gcc" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-5"; fi
+  - if [ "$CC" = "gcc" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; fi
 
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-5
+    - gcc-6
     - clang
-    
-script:
-  - ./configure -t $THREADING CC=$CC $BUILD_CONFIG
-  - $CC --version
-  - make -j 2
-  - export BLIS_IC_NT=2
-  - export BLIS_JC_NT=1
-  - export BLIS_IR_NT=1
-  - export BLIS_JR_NT=1
-  - if [ $RUN_TEST -eq 1 ]; then make BLIS_ENABLE_TEST_OUTPUT=yes test; fi
-  - if [ $RUN_TEST -eq 1 ]; then ./build/check-test.sh ./output.testsuite; fi
 
+script:
+  - $CC --version
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then grep -m1 flags /proc/cpuinfo ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] ; then sysctl -a | grep machdep.cpu.features ; fi
+  - ./build/travis_driver.sh $CC $THREADING $BUILD_CONFIG $RUN_TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="reference"
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="dunnington"
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="sandybridge"
-  - RUN_TEST=1 THREADING="none" BUILD_CONFIG="knl"
   - RUN_TEST=1 THREADING="none" BUILD_CONFIG="haswell"
+  - RUN_TEST=1 THREADING="none" BUILD_CONFIG="knl"
   - RUN_TEST=0 THREADING="none" BUILD_CONFIG="bulldozer"
   - RUN_TEST=0 THREADING="none" BUILD_CONFIG="piledriver"
   - RUN_TEST=0 THREADING="none" BUILD_CONFIG="carrizo"
@@ -24,6 +24,7 @@ env:
 
 matrix:
   allow_failures:
+    - env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="haswell"
     - env: RUN_TEST=1 THREADING="none" BUILD_CONFIG="knl"
   exclude:
     - os: linux

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -47,6 +47,15 @@ case "$TARGET" in
 esac
 
 if [ "x$TARGET" == "xknl" ] ; then
+    # older binutils do not support AVX-512 (need at least 2.25)
+    wget https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2
+    tar -xaf binutils-2.28.tar.bz2
+    cd binutils-2.28
+    ./configure --prefix=/tmp/binutils-2.28 && make install
+    export PATH=/tmp/binutils-2.28/bin:$PATH
+    export LD_LIBRARY_PATH=/tmp/binutils-2.28/bin:$LD_LIBRARY_PATH
+    which ld
+    # now configure
     ./configure -d sde -t $THREADING CC=$CC $TARGET
 else
     ./configure        -t $THREADING CC=$CC $TARGET

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -72,7 +72,10 @@ if [ "x${RUN_TEST}" == "x1" ] ; then
     make testsuite-bin
     # We make no attempt to run SDE_OPTIONS on Mac.  It is supported but requires elevated permissions.
     if [ "x${HARDWARE}" != "x1" ] && [ "${TRAVIS_OS_NAME}" == "linux" ] ; then
+        set +x
+        echo wget -q SDE_LOCATION
         wget -q ${SDE_LOCATION}
+        set -x
         tar -xaf sde-external-7.58.0-2017-01-23-lin.tar.bz2
         export PATH=${PWD}/sde-external-7.58.0-2017-01-23-lin:${PATH}
         if [ `uname -m` = x86_64 ] ; then SDE_BIN=sde64 ; else SDE_BIN=sde ; fi

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -17,23 +17,42 @@ HARDWARE=0
 SDE_OPTIONS="false"
 case "$TARGET" in
     knl)
-        if $(grep avx512f -q /proc/cpuinfo) && $(grep avx512pf -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
+            if $(grep avx512f -q /proc/cpuinfo) && $(grep avx512pf -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        fi
         SDE_OPTIONS="-knl"
         ;;
     skx)
-        if $(grep avx512f -q /proc/cpuinfo) && $(grep avx512vl -q /proc/cpuinfo) && $(grep avx512dq -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
+            if $(grep avx512f -q /proc/cpuinfo) && $(grep avx512vl -q /proc/cpuinfo) && $(grep avx512dq -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        fi
         SDE_OPTIONS="-skx"
         ;;
     haswell)
-        if $(grep avx2 -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
+            if $(grep avx2 -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        elif [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+            #if $(sysctl -a | grep machdep.cpu.leaf7_features | grep -q AVX2) ; then HARDWARE=1 ; fi
+            if [ $(sysctl -n hw.optional.avx2_0) -eq 1 ] ; then HARDWARE=1 ; fi
+        fi
         SDE_OPTIONS="-hsw"
         ;;
     sandybridge)
-        if $(grep avx -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
+            if $(grep avx -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        elif [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+            #if $(sysctl -a | grep machdep.cpu.features | grep -q AVX1) ; then HARDWARE=1 ; fi
+            if [ $(sysctl -n hw.optional.avx1_0) -eq 1 ] ; then HARDWARE=1 ; fi
+        fi
         SDE_OPTIONS="-snb"
         ;;
     dunnington)
-        if $(grep ssse3 -q /proc/cpuinfo) && $(grep sse4_1 -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        if [ "$TRAVIS_OS_NAME" = "linux" ] ; then
+            if $(grep ssse3 -q /proc/cpuinfo) && $(grep sse4_1 -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        elif [ "$TRAVIS_OS_NAME" = "osx" ] ; then
+            #if $(sysctl -a | grep machdep.cpu.features | grep -q "SSE4.1") ; then HARDWARE=1 ; fi
+            if [ $(sysctl -n hw.optional.sse4_1) -eq 1 ] ; then HARDWARE=1 ; fi
+        fi
         SDE_OPTIONS="-pnr"
         ;;
     auto)

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -92,7 +92,6 @@ if [ "x${RUN_TEST}" == "x1" ] ; then
     # We make no attempt to run SDE_OPTIONS on Mac.  It is supported but requires elevated permissions.
     if [ "x${HARDWARE}" != "x1" ] && [ "${TRAVIS_OS_NAME}" == "linux" ] ; then
         set +x
-        echo wget -q SDE_LOCATION
         wget -q ${SDE_LOCATION}
         set -x
         tar -xaf sde-external-7.58.0-2017-01-23-lin.tar.bz2

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -51,7 +51,9 @@ if [ "x$TARGET" == "xknl" ] ; then
     wget https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2
     tar -xaf binutils-2.28.tar.bz2
     cd binutils-2.28
-    ./configure --prefix=/tmp/binutils-2.28 && make install
+    ./configure --prefix=/tmp/binutils-2.28
+    make
+    make install
     export PATH=/tmp/binutils-2.28/bin:$PATH
     export LD_LIBRARY_PATH=/tmp/binutils-2.28/bin:$LD_LIBRARY_PATH
     which ld

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -47,17 +47,20 @@ case "$TARGET" in
 esac
 
 if [ "x$TARGET" == "xknl" ] ; then
+    pushd /tmp
     # older binutils do not support AVX-512 (need at least 2.25)
     wget https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2
     tar -xaf binutils-2.28.tar.bz2
     cd binutils-2.28
-    ./configure --prefix=/tmp/binutils-2.28
+    export BINUTILS_PATH=/tmp/mybinutils
+    ./configure --prefix=$BINUTILS_PATH
     make
     make install
-    export PATH=/tmp/binutils-2.28/bin:$PATH
-    export LD_LIBRARY_PATH=/tmp/binutils-2.28/bin:$LD_LIBRARY_PATH
+    export PATH=$BINUTILS_PATH/bin:$PATH
+    export LD_LIBRARY_PATH=$BINUTILS_PATH/lib:$LD_LIBRARY_PATH
+    popd
     which ld
-    # now configure
+    # now configure BLIS
     ./configure -d sde -t $THREADING CC=$CC $TARGET
 else
     ./configure        -t $THREADING CC=$CC $TARGET

--- a/build/travis_driver.sh
+++ b/build/travis_driver.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+CC="$1"
+THREADING="$2"
+TARGET="$3"
+RUN_TEST="$4"
+
+export BLIS_IC_NT=2
+export BLIS_JC_NT=1
+export BLIS_IR_NT=1
+export BLIS_JR_NT=1
+
+HARDWARE=0
+SDE_OPTIONS="false"
+case "$TARGET" in
+    knl)
+        if $(grep avx512f -q /proc/cpuinfo) && $(grep avx512pf -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        SDE_OPTIONS="-knl"
+        ;;
+    skx)
+        if $(grep avx512f -q /proc/cpuinfo) && $(grep avx512vl -q /proc/cpuinfo) && $(grep avx512dq -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        SDE_OPTIONS="-skx"
+        ;;
+    haswell)
+        if $(grep avx2 -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        SDE_OPTIONS="-hsw"
+        ;;
+    sandybridge)
+        if $(grep avx -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        SDE_OPTIONS="-snb"
+        ;;
+    dunnington)
+        if $(grep ssse3 -q /proc/cpuinfo) && $(grep sse4_1 -q /proc/cpuinfo) ; then HARDWARE=1 ; fi
+        SDE_OPTIONS="-pnr"
+        ;;
+    auto)
+        HARDWARE=1
+        ;;
+    reference)
+        HARDWARE=1
+        ;;
+    *)
+        ;;
+esac
+
+if [ "x$TARGET" == "xknl" ] ; then
+    ./configure -d sde -t $THREADING CC=$CC $TARGET
+else
+    ./configure        -t $THREADING CC=$CC $TARGET
+fi
+
+make
+
+if [ "x${RUN_TEST}" == "x1" ] ; then
+    make testsuite-bin
+    # We make no attempt to run SDE_OPTIONS on Mac.  It is supported but requires elevated permissions.
+    if [ "x${HARDWARE}" != "x1" ] && [ "${TRAVIS_OS_NAME}" == "linux" ] ; then
+        wget -q ${SDE_LOCATION}
+        tar -xaf sde-external-7.58.0-2017-01-23-lin.tar.bz2
+        export PATH=${PWD}/sde-external-7.58.0-2017-01-23-lin:${PATH}
+        if [ `uname -m` = x86_64 ] ; then SDE_BIN=sde64 ; else SDE_BIN=sde ; fi
+        ${PWD}/sde-external-7.58.0-2017-01-23-lin/${SDE_BIN} ${SDE_OPTIONS} -- make BLIS_ENABLE_TEST_OUTPUT=yes testsuite-run
+    else
+        make BLIS_ENABLE_TEST_OUTPUT=yes testsuite-run
+    fi
+fi


### PR DESCRIPTION
This pull request implements https://github.com/flame/blis/issues/122.

This overhauls most of the Travis CI stuff.  In particular:
- I moved most of the interesting stuff into https://github.com/jeffhammond/blis/blob/travis-ci-sde-knl-testing/build/travis_driver.sh because it makes it a lot easier to script sensibly there.
- I determine what the native architecture is (https://github.com/jeffhammond/blis/blob/travis-ci-sde-knl-testing/build/travis_driver.sh#L18) and run tests natively if possible.  _This may be redundant with `BUILD_CONFIG=auto`._
- I run the tests in SDE if native execution isn't possible but emulation is (https://github.com/jeffhammond/blis/blob/travis-ci-sde-knl-testing/build/travis_driver.sh#L65).

As noted by @devinamatthews, performance with SDE is ~0.02 GF/s, so we probably need to prune the tests if we want them to finish in under an hour.