### PR TITLE
Set missing free_fp in bli_membrk_init for free-ing GEN_USE buffers

### DIFF
--- a/frame/base/bli_membrk.c
+++ b/frame/base/bli_membrk.c
@@ -44,6 +44,7 @@ void bli_membrk_init
 	bli_mutex_init( bli_membrk_mutex( membrk ) );
 	bli_membrk_init_pools( cntx, membrk );
 	bli_membrk_set_malloc_fp( bli_malloc_pool, membrk );
+	bli_membrk_set_free_fp( bli_free_pool, membrk );
 }
 
 void bli_membrk_finalize


### PR DESCRIPTION
The membrk's free_fp is called when releasing GEN_USE buffers, but this free_fp is
not set in bli_membrk_init