### PR TITLE
[WIP] Add x86 and x86_64 processor families.

### DIFF
--- a/config_registry
+++ b/config_registry
@@ -6,11 +6,10 @@
 #
 
 # Processor families.
-intel64:     haswell sandybridge penryn
-amd64:       zen excavator steamroller piledriver bulldozer
-arm32:       cortexa9 cortexa15
-x86:         reference
-x86_64:      haswell sandybridge penryn zen excavator steamroller piledriver bulldozer reference
+intel64:     haswell sandybridge penryn generic
+amd64:       zen excavator steamroller piledriver bulldozer generic
+arm32:       cortexa9 cortexa15 generic
+x86_64:      haswell sandybridge penryn zen excavator steamroller piledriver bulldozer generic
 
 # Intel architectures.
 haswell:     haswell

--- a/config_registry
+++ b/config_registry
@@ -9,6 +9,8 @@
 intel64:     haswell sandybridge penryn
 amd64:       zen excavator steamroller piledriver bulldozer
 arm32:       cortexa9 cortexa15
+x86:         reference
+x86_64:      haswell sandybridge penryn zen excavator steamroller piledriver bulldozer reference
 
 # Intel architectures.
 haswell:     haswell


### PR DESCRIPTION
As a suggestion: would such two meta-families be OK? And would the x86_64 correctly fall back to reference if no fitting specialized kernel is found for a given architecture?