### PR TITLE
Also for the x86_64 family, select the proper kernel at runtime.

### DIFF
--- a/frame/base/bli_arch.c
+++ b/frame/base/bli_arch.c
@@ -48,6 +48,10 @@ arch_t bli_arch_query_id( void )
 	id = bli_cpuid_query_id();
 #endif
 
+#ifdef BLIS_FAMILY_X86_64
+        id = bli_cpuid_query_id();
+#endif
+
 	// Intel microarchitectures.
 #ifdef BLIS_FAMILY_KNL
 	id = BLIS_ARCH_KNL;


### PR DESCRIPTION
This partially addresses #156 