### PR TITLE
(Example) Add vectorization over n to Zen sdotxf kernel.

### DIFF
--- a/kernels/zen/1f/bli_dotxf_zen_int_8.c
+++ b/kernels/zen/1f/bli_dotxf_zen_int_8.c
@@ -94,7 +94,6 @@ void bli_sdotxf_zen_int_8
 	// operation as a loop over dotxv.
 	if ( b_n != fuse_fac )
 	{
-	    printf("n != 8\n");
 		sdotxv_ft f = bli_cntx_get_l1v_ker_dt( BLIS_FLOAT, BLIS_DOTXV_KER, cntx );
 
 		for ( dim_t i = 0; i < b_n; ++i )

--- a/kernels/zen/1f/bli_dotxf_zen_int_8.c
+++ b/kernels/zen/1f/bli_dotxf_zen_int_8.c
@@ -68,41 +68,7 @@ void bli_sdotxf_zen_int_8
      )
 {
 	const dim_t      fuse_fac       = 8;
-
 	const dim_t      n_elem_per_reg = 8;
-	const dim_t      n_iter_unroll  = 1;
-
-	dim_t            i;
-	dim_t            m_viter;
-	dim_t            m_left;
-
-	float*  restrict a0;
-	float*  restrict a1;
-	float*  restrict a2;
-	float*  restrict a3;
-	float*  restrict a4;
-	float*  restrict a5;
-	float*  restrict a6;
-	float*  restrict a7;
-
-	float*  restrict x0;
-
-	float            rho0, rho1, rho2, rho3;
-	float            rho4, rho5, rho6, rho7;
-
-	v8sf_t           a0v, a1v, a2v, a3v;
-	v8sf_t           a4v, a5v, a6v, a7v;
-
-	v8sf_t           x0v;
-
-	v8sf_t           rho0v, rho1v, rho2v, rho3v;
-	v8sf_t           rho4v, rho5v, rho6v, rho7v;
-
-	v8sf_t           alphav;
-	v8sf_t           betav;
-	v8sf_t           y0v;
-
-	v8sf_t           onev;
 
 	// If the b_n dimension is zero, y is empty and there is no computation.
 	if ( bli_zero_dim1( b_n ) ) return;
@@ -128,9 +94,10 @@ void bli_sdotxf_zen_int_8
 	// operation as a loop over dotxv.
 	if ( b_n != fuse_fac )
 	{
+	    printf("n != 8\n");
 		sdotxv_ft f = bli_cntx_get_l1v_ker_dt( BLIS_FLOAT, BLIS_DOTXV_KER, cntx );
 
-		for ( i = 0; i < b_n; ++i )
+		for ( dim_t i = 0; i < b_n; ++i )
 		{
 			float* a1   = a + (0  )*inca + (i  )*lda;
 			float* x1   = x + (0  )*incx;
@@ -152,138 +119,231 @@ void bli_sdotxf_zen_int_8
 		return;
 	}
 
-	// At this point, we know that b_n is exactly equal to the fusing factor.
-	// However, m may not be a multiple of the number of elements per vector.
+	// Intermediate variables to hold the completed dot products
+	float rho0 = 0, rho1 = 0, rho2 = 0, rho3 = 0,
+	      rho4 = 0, rho5 = 0, rho6 = 0, rho7 = 0;
 
-	// Use the unrolling factor and the number of elements per register
-	// to compute the number of vectorized and leftover iterations.
-	m_viter = ( m ) / ( n_elem_per_reg * n_iter_unroll );
-	m_left  = ( m ) % ( n_elem_per_reg * n_iter_unroll );
+	// Split the problem into two subproblems along the m dimension:
+	// 1) A vectorized part, starting at m=0 and ending at any 0<=m'<=m.
+	// 2) A scalar part, starting at m' and ending at m. If no vectorization
+	//    is possible then this is the entire problem. If m'>0, then the
+	//    a and x pointers and m variable shall be adjusted accordingly
+	//    for the second subproblem.
 
-	// If there is anything that would interfere with our use of contiguous
-	// vector loads/stores, override m_viter and m_left to use scalar code
-	// for all iterations. (NOTE: vector instructions can be used even if
-	// the increment of the output vector, incy, is nonunit.)
-	if ( inca != 1 || incx != 1 )
-	{
-		m_viter = 0;
-		m_left  = m;
-	}
+    // If there is anything that would interfere with our use of contiguous
+    // vector loads/stores, override m_viter and m_left to use scalar code
+    // for all iterations. (NOTE: vector instructions can be used even if
+    // the increment of the output vector, incy, is nonunit.)
+    if ( inca == 1 && incx == 1 )
+    {
+        // At this point, we know that b_n is exactly equal to the fusing factor.
+        // However, m may not be a multiple of the number of elements per vector.
 
-	// Set up pointers for x and the b_n columns of A (rows of A^T).
-	x0 = x;
-	a0 = a + 0*lda;
-	a1 = a + 1*lda;
-	a2 = a + 2*lda;
-	a3 = a + 3*lda;
-	a4 = a + 4*lda;
-	a5 = a + 5*lda;
-	a6 = a + 6*lda;
-	a7 = a + 7*lda;
+        const dim_t n_iter_unroll  = 1;
 
-	// Initialize b_n rho vector accumulators to zero.
-	rho0v.v = _mm256_setzero_ps();
-	rho1v.v = _mm256_setzero_ps();
-	rho2v.v = _mm256_setzero_ps();
-	rho3v.v = _mm256_setzero_ps();
-	rho4v.v = _mm256_setzero_ps();
-	rho5v.v = _mm256_setzero_ps();
-	rho6v.v = _mm256_setzero_ps();
-	rho7v.v = _mm256_setzero_ps();
+        // Use the unrolling factor and the number of elements per register
+        // to compute the number of vectorized and leftover iterations.
+        dim_t m_viter = ( m ) / ( n_elem_per_reg * n_iter_unroll );
 
-	// If there are vectorized iterations, perform them with vector
-	// instructions.
-	for ( i = 0; i < m_viter; ++i )
-	{
-		// Load the input values.
-		x0v.v = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+        // Set up pointers for x and the b_n columns of A (rows of A^T).
+        float * restrict x0 = x;
+        float * restrict a0 = a + 0*lda;
+        float * restrict a1 = a + 1*lda;
+        float * restrict a2 = a + 2*lda;
+        float * restrict a3 = a + 3*lda;
+        float * restrict a4 = a + 4*lda;
+        float * restrict a5 = a + 5*lda;
+        float * restrict a6 = a + 6*lda;
+        float * restrict a7 = a + 7*lda;
 
-		a0v.v = _mm256_loadu_ps( a0 + 0*n_elem_per_reg );
-		a1v.v = _mm256_loadu_ps( a1 + 0*n_elem_per_reg );
-		a2v.v = _mm256_loadu_ps( a2 + 0*n_elem_per_reg );
-		a3v.v = _mm256_loadu_ps( a3 + 0*n_elem_per_reg );
-		a4v.v = _mm256_loadu_ps( a4 + 0*n_elem_per_reg );
-		a5v.v = _mm256_loadu_ps( a5 + 0*n_elem_per_reg );
-		a6v.v = _mm256_loadu_ps( a6 + 0*n_elem_per_reg );
-		a7v.v = _mm256_loadu_ps( a7 + 0*n_elem_per_reg );
+        // Initialize b_n rho vector accumulators to zero.
+        v8sf_t rho0v; rho0v.v = _mm256_setzero_ps();
+        v8sf_t rho1v; rho1v.v = _mm256_setzero_ps();
+        v8sf_t rho2v; rho2v.v = _mm256_setzero_ps();
+        v8sf_t rho3v; rho3v.v = _mm256_setzero_ps();
+        v8sf_t rho4v; rho4v.v = _mm256_setzero_ps();
+        v8sf_t rho5v; rho5v.v = _mm256_setzero_ps();
+        v8sf_t rho6v; rho6v.v = _mm256_setzero_ps();
+        v8sf_t rho7v; rho7v.v = _mm256_setzero_ps();
 
-		// perform : rho?v += a?v * x0v;
-		rho0v.v = _mm256_fmadd_ps( a0v.v, x0v.v, rho0v.v );
-		rho1v.v = _mm256_fmadd_ps( a1v.v, x0v.v, rho1v.v );
-		rho2v.v = _mm256_fmadd_ps( a2v.v, x0v.v, rho2v.v );
-		rho3v.v = _mm256_fmadd_ps( a3v.v, x0v.v, rho3v.v );
-		rho4v.v = _mm256_fmadd_ps( a4v.v, x0v.v, rho4v.v );
-		rho5v.v = _mm256_fmadd_ps( a5v.v, x0v.v, rho5v.v );
-		rho6v.v = _mm256_fmadd_ps( a6v.v, x0v.v, rho6v.v );
-		rho7v.v = _mm256_fmadd_ps( a7v.v, x0v.v, rho7v.v );
+        v8sf_t x0v;
+        v8sf_t a0v, a1v, a2v, a3v, a4v, a5v, a6v, a7v;
 
-		x0 += n_elem_per_reg * n_iter_unroll;
-		a0 += n_elem_per_reg * n_iter_unroll;
-		a1 += n_elem_per_reg * n_iter_unroll;
-		a2 += n_elem_per_reg * n_iter_unroll;
-		a3 += n_elem_per_reg * n_iter_unroll;
-		a4 += n_elem_per_reg * n_iter_unroll;
-		a5 += n_elem_per_reg * n_iter_unroll;
-		a6 += n_elem_per_reg * n_iter_unroll;
-		a7 += n_elem_per_reg * n_iter_unroll;
-	}
+        // If there are vectorized iterations, perform them with vector
+        // instructions.
+        for ( dim_t i = 0; i < m_viter; ++i )
+        {
+            // Load the input values.
+            x0v.v = _mm256_loadu_ps( x0 + 0*n_elem_per_reg );
+
+            a0v.v = _mm256_loadu_ps( a0 + 0*n_elem_per_reg );
+            a1v.v = _mm256_loadu_ps( a1 + 0*n_elem_per_reg );
+            a2v.v = _mm256_loadu_ps( a2 + 0*n_elem_per_reg );
+            a3v.v = _mm256_loadu_ps( a3 + 0*n_elem_per_reg );
+            a4v.v = _mm256_loadu_ps( a4 + 0*n_elem_per_reg );
+            a5v.v = _mm256_loadu_ps( a5 + 0*n_elem_per_reg );
+            a6v.v = _mm256_loadu_ps( a6 + 0*n_elem_per_reg );
+            a7v.v = _mm256_loadu_ps( a7 + 0*n_elem_per_reg );
+
+            // perform : rho?v += a?v * x0v;
+            rho0v.v = _mm256_fmadd_ps( a0v.v, x0v.v, rho0v.v );
+            rho1v.v = _mm256_fmadd_ps( a1v.v, x0v.v, rho1v.v );
+            rho2v.v = _mm256_fmadd_ps( a2v.v, x0v.v, rho2v.v );
+            rho3v.v = _mm256_fmadd_ps( a3v.v, x0v.v, rho3v.v );
+            rho4v.v = _mm256_fmadd_ps( a4v.v, x0v.v, rho4v.v );
+            rho5v.v = _mm256_fmadd_ps( a5v.v, x0v.v, rho5v.v );
+            rho6v.v = _mm256_fmadd_ps( a6v.v, x0v.v, rho6v.v );
+            rho7v.v = _mm256_fmadd_ps( a7v.v, x0v.v, rho7v.v );
+
+            x0 += n_elem_per_reg * n_iter_unroll;
+            a0 += n_elem_per_reg * n_iter_unroll;
+            a1 += n_elem_per_reg * n_iter_unroll;
+            a2 += n_elem_per_reg * n_iter_unroll;
+            a3 += n_elem_per_reg * n_iter_unroll;
+            a4 += n_elem_per_reg * n_iter_unroll;
+            a5 += n_elem_per_reg * n_iter_unroll;
+            a6 += n_elem_per_reg * n_iter_unroll;
+            a7 += n_elem_per_reg * n_iter_unroll;
+        }
 
 #if 0
-	rho0 += rho0v.f[0] + rho0v.f[1] + rho0v.f[2] + rho0v.f[3] +
-	        rho0v.f[4] + rho0v.f[5] + rho0v.f[6] + rho0v.f[7];
-	rho1 += rho1v.f[0] + rho1v.f[1] + rho1v.f[2] + rho1v.f[3] +
-	        rho1v.f[4] + rho1v.f[5] + rho1v.f[6] + rho1v.f[7];
-	rho2 += rho2v.f[0] + rho2v.f[1] + rho2v.f[2] + rho2v.f[3] +
-	        rho2v.f[4] + rho2v.f[5] + rho2v.f[6] + rho2v.f[7];
-	rho3 += rho3v.f[0] + rho3v.f[1] + rho3v.f[2] + rho3v.f[3] +
-	        rho3v.f[4] + rho3v.f[5] + rho3v.f[6] + rho3v.f[7];
-	rho4 += rho4v.f[0] + rho4v.f[1] + rho4v.f[2] + rho4v.f[3] +
-	        rho4v.f[4] + rho4v.f[5] + rho4v.f[6] + rho4v.f[7];
-	rho5 += rho5v.f[0] + rho5v.f[1] + rho5v.f[2] + rho5v.f[3] +
-	        rho5v.f[4] + rho5v.f[5] + rho5v.f[6] + rho5v.f[7];
-	rho6 += rho6v.f[0] + rho6v.f[1] + rho6v.f[2] + rho6v.f[3] +
-	        rho6v.f[4] + rho6v.f[5] + rho6v.f[6] + rho6v.f[7];
-	rho7 += rho7v.f[0] + rho7v.f[1] + rho7v.f[2] + rho7v.f[3] +
-	        rho7v.f[4] + rho7v.f[5] + rho7v.f[6] + rho7v.f[7];
+        rho0 += rho0v.f[0] + rho0v.f[1] + rho0v.f[2] + rho0v.f[3] +
+                rho0v.f[4] + rho0v.f[5] + rho0v.f[6] + rho0v.f[7];
+        rho1 += rho1v.f[0] + rho1v.f[1] + rho1v.f[2] + rho1v.f[3] +
+                rho1v.f[4] + rho1v.f[5] + rho1v.f[6] + rho1v.f[7];
+        rho2 += rho2v.f[0] + rho2v.f[1] + rho2v.f[2] + rho2v.f[3] +
+                rho2v.f[4] + rho2v.f[5] + rho2v.f[6] + rho2v.f[7];
+        rho3 += rho3v.f[0] + rho3v.f[1] + rho3v.f[2] + rho3v.f[3] +
+                rho3v.f[4] + rho3v.f[5] + rho3v.f[6] + rho3v.f[7];
+        rho4 += rho4v.f[0] + rho4v.f[1] + rho4v.f[2] + rho4v.f[3] +
+                rho4v.f[4] + rho4v.f[5] + rho4v.f[6] + rho4v.f[7];
+        rho5 += rho5v.f[0] + rho5v.f[1] + rho5v.f[2] + rho5v.f[3] +
+                rho5v.f[4] + rho5v.f[5] + rho5v.f[6] + rho5v.f[7];
+        rho6 += rho6v.f[0] + rho6v.f[1] + rho6v.f[2] + rho6v.f[3] +
+                rho6v.f[4] + rho6v.f[5] + rho6v.f[6] + rho6v.f[7];
+        rho7 += rho7v.f[0] + rho7v.f[1] + rho7v.f[2] + rho7v.f[3] +
+                rho7v.f[4] + rho7v.f[5] + rho7v.f[6] + rho7v.f[7];
 #else
-	// Now we need to sum the elements within each vector.
+        // Now we need to sum the elements within each vector.
 
-	onev.v = _mm256_set1_ps( 1.0f );
+        v8sf_t onev; onev.v = _mm256_set1_ps( 1.0f );
 
-	// Sum the elements of a given rho?v by dotting it with 1. The '1' in
-	// '0xf1' stores the sum of the upper four and lower four values to
-	// the low elements of each lane: elements 4 and 0, respectively. (The
-	// 'f' in '0xf1' means include all four elements of each lane in the
-	// summation.)
-	rho0v.v = _mm256_dp_ps( rho0v.v, onev.v, 0xf1 );
-	rho1v.v = _mm256_dp_ps( rho1v.v, onev.v, 0xf1 );
-	rho2v.v = _mm256_dp_ps( rho2v.v, onev.v, 0xf1 );
-	rho3v.v = _mm256_dp_ps( rho3v.v, onev.v, 0xf1 );
-	rho4v.v = _mm256_dp_ps( rho4v.v, onev.v, 0xf1 );
-	rho5v.v = _mm256_dp_ps( rho5v.v, onev.v, 0xf1 );
-	rho6v.v = _mm256_dp_ps( rho6v.v, onev.v, 0xf1 );
-	rho7v.v = _mm256_dp_ps( rho7v.v, onev.v, 0xf1 );
+        // Sum the elements of a given rho?v by dotting it with 1. The '1' in
+        // '0xf1' stores the sum of the upper four and lower four values to
+        // the low elements of each lane: elements 4 and 0, respectively. (The
+        // 'f' in '0xf1' means include all four elements of each lane in the
+        // summation.)
+        rho0v.v = _mm256_dp_ps( rho0v.v, onev.v, 0xf1 );
+        rho1v.v = _mm256_dp_ps( rho1v.v, onev.v, 0xf1 );
+        rho2v.v = _mm256_dp_ps( rho2v.v, onev.v, 0xf1 );
+        rho3v.v = _mm256_dp_ps( rho3v.v, onev.v, 0xf1 );
+        rho4v.v = _mm256_dp_ps( rho4v.v, onev.v, 0xf1 );
+        rho5v.v = _mm256_dp_ps( rho5v.v, onev.v, 0xf1 );
+        rho6v.v = _mm256_dp_ps( rho6v.v, onev.v, 0xf1 );
+        rho7v.v = _mm256_dp_ps( rho7v.v, onev.v, 0xf1 );
 
-	// Issue vzeroupper instruction to clear upper lanes of ymm registers.
-	// This avoids a performance penalty caused by false dependencies when
-	// transitioning from from AVX to SSE instructions (which may occur
-	// as soon as the m_left cleanup loop below if BLIS is compiled with
-	// -mfpmath=sse).
-	_mm256_zeroupper();
-
-	// Manually add the results from above to finish the sum.
-	rho0    = rho0v.f[0] + rho0v.f[4];
-	rho1    = rho1v.f[0] + rho1v.f[4];
-	rho2    = rho2v.f[0] + rho2v.f[4];
-	rho3    = rho3v.f[0] + rho3v.f[4];
-	rho4    = rho4v.f[0] + rho4v.f[4];
-	rho5    = rho5v.f[0] + rho5v.f[4];
-	rho6    = rho6v.f[0] + rho6v.f[4];
-	rho7    = rho7v.f[0] + rho7v.f[4];
+        // Manually add the results from above to finish the sum.
+        rho0    = rho0v.f[0] + rho0v.f[4];
+        rho1    = rho1v.f[0] + rho1v.f[4];
+        rho2    = rho2v.f[0] + rho2v.f[4];
+        rho3    = rho3v.f[0] + rho3v.f[4];
+        rho4    = rho4v.f[0] + rho4v.f[4];
+        rho5    = rho5v.f[0] + rho5v.f[4];
+        rho6    = rho6v.f[0] + rho6v.f[4];
+        rho7    = rho7v.f[0] + rho7v.f[4];
 #endif
 
+        // Adjust for scalar subproblem
+        m -= n_elem_per_reg * n_iter_unroll * m_viter;
+        a += n_elem_per_reg * n_iter_unroll * m_viter;
+        x += n_elem_per_reg * n_iter_unroll * m_viter;
+    }
+    // If lda == 1 then vectorize over n with broadcast values from x
+    else if ( lda == 1 )
+    {
+        // At this point, we know that b_n is exactly equal to the fusing factor.
+        // Since this is also equal to the vector length we can vectorize over
+        // this dimension.
+
+        const dim_t n_iter_unroll = 4;
+
+        dim_t m_viter = ( m ) / ( n_iter_unroll );
+
+        // Set up pointers for x and A.
+        float * restrict x0 = x;
+        float * restrict a0 = a;
+
+        // Initialize rho vector accumulators to zero.
+        v8sf_t rho0v; rho0v.v = _mm256_setzero_ps();
+        v8sf_t rho1v; rho1v.v = _mm256_setzero_ps();
+        v8sf_t rho2v; rho2v.v = _mm256_setzero_ps();
+        v8sf_t rho3v; rho3v.v = _mm256_setzero_ps();
+
+        v8sf_t x0v, x1v, x2v, x3v;
+        v8sf_t a0v, a1v, a2v, a3v;
+
+        for ( dim_t i = 0; i < m_viter; ++i )
+        {
+            // Load the input values.
+            a0v.v = _mm256_loadu_ps( a0 + 0*inca );
+            a1v.v = _mm256_loadu_ps( a0 + 1*inca );
+            a2v.v = _mm256_loadu_ps( a0 + 2*inca );
+            a3v.v = _mm256_loadu_ps( a0 + 3*inca );
+
+            x0v.v = _mm256_broadcast_ss( x0 + 0*incx );
+            x1v.v = _mm256_broadcast_ss( x0 + 1*incx );
+            x2v.v = _mm256_broadcast_ss( x0 + 2*incx );
+            x3v.v = _mm256_broadcast_ss( x0 + 3*incx );
+
+            // perform : rhoXv += aXv * xXv;
+            rho0v.v = _mm256_fmadd_ps( a0v.v, x0v.v, rho0v.v );
+            rho1v.v = _mm256_fmadd_ps( a1v.v, x1v.v, rho1v.v );
+            rho2v.v = _mm256_fmadd_ps( a2v.v, x2v.v, rho2v.v );
+            rho3v.v = _mm256_fmadd_ps( a3v.v, x3v.v, rho3v.v );
+
+            x0 += incx * n_iter_unroll;
+            a0 += inca * n_iter_unroll;
+        }
+
+        // Combine the 8 accumulators into one register
+        rho0v.v = _mm256_add_ps( rho0v.v, rho1v.v );
+        rho2v.v = _mm256_add_ps( rho2v.v, rho3v.v );
+        rho0v.v = _mm256_add_ps( rho0v.v, rho2v.v );
+
+        // Write vector components to scalar values
+        rho0 = rho0v.f[0];
+        rho1 = rho0v.f[1];
+        rho2 = rho0v.f[2];
+        rho3 = rho0v.f[3];
+        rho4 = rho0v.f[4];
+        rho5 = rho0v.f[5];
+        rho6 = rho0v.f[6];
+        rho7 = rho0v.f[7];
+
+        // Adjust for scalar subproblem
+        m -= n_iter_unroll * m_viter;
+        a += inca * n_iter_unroll * m_viter;
+        x += incx * n_iter_unroll * m_viter;
+    }
+    // No vectorization possible; use scalar iterations for the entire problem
+    else
+    {
+        // Nothing to do here
+    }
+
+    // Set up pointers for x and the b_n columns of A (rows of A^T).
+    float * restrict x0 = x;
+    float * restrict a0 = a + 0*lda;
+    float * restrict a1 = a + 1*lda;
+    float * restrict a2 = a + 2*lda;
+    float * restrict a3 = a + 3*lda;
+    float * restrict a4 = a + 4*lda;
+    float * restrict a5 = a + 5*lda;
+    float * restrict a6 = a + 6*lda;
+    float * restrict a7 = a + 7*lda;
+
 	// If there are leftover iterations, perform them with scalar code.
-	for ( i = 0; i < m_left ; ++i )
+	for ( dim_t i = 0; i < m ; ++i )
 	{
 		const float x0c = *x0;
 
@@ -316,6 +376,8 @@ void bli_sdotxf_zen_int_8
 		a7 += inca;
 	}
 
+	v8sf_t rho0v, y0v;
+
 	// Insert the scalar rho values into a single vector.
 	rho0v.f[0] = rho0;
 	rho0v.f[1] = rho1;
@@ -327,7 +389,7 @@ void bli_sdotxf_zen_int_8
 	rho0v.f[7] = rho7;
 
 	// Broadcast the alpha scalar.
-	alphav.v = _mm256_broadcast_ss( alpha );
+	v8sf_t alphav; alphav.v = _mm256_broadcast_ss( alpha );
 
 	// We know at this point that alpha is nonzero; however, beta may still
 	// be zero. If beta is indeed zero, we must overwrite y rather than scale
@@ -341,7 +403,7 @@ void bli_sdotxf_zen_int_8
 	else
 	{
 		// Broadcast the beta scalar.
-		betav.v = _mm256_broadcast_ss( beta );
+	    v8sf_t betav; betav.v = _mm256_broadcast_ss( beta );
 
 		// Load y.
 		if ( incy == 1 )
@@ -374,11 +436,6 @@ void bli_sdotxf_zen_int_8
 		*(y + 4*incy) = y0v.f[4]; *(y + 5*incy) = y0v.f[5];
 		*(y + 6*incy) = y0v.f[6]; *(y + 7*incy) = y0v.f[7];
 	}
-
-	// Issue vzeroupper instruction to clear upper lanes of ymm registers.
-	// This avoids a performance penalty caused by false dependencies when
-	// transitioning from from AVX to SSE instructions.
-	_mm256_zeroupper();
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Performance improvement is ~3x for the specific case targeted vs. something like 5x measured for vectorization over the other direction.