### PR TITLE
AMD specific optimizations for target 'zen'

### DIFF
--- a/config/zen/bli_cntx_init_zen.c
+++ b/config/zen/bli_cntx_init_zen.c
@@ -111,10 +111,14 @@ void bli_cntx_init_zen( cntx_t* cntx )
 	//                                           s      d      c      z
 	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     6,     6,     3,     3 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    16,     8,     8,     4 );
-	//bli_blksz_init_easy( &blkszs[ BLIS_MC ],   144,   510,   144,    72 );
-	//bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,  1024,   256,   256 );
+#ifdef BLIS_ENABLE_ZEN_BLOCK_SIZES
+	// Zen optmized level 3 cache block sizes
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   144,   510,   144,    72 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,  1024,   256,   256 );
+#else
 	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   144,    72,   144,    72 );
 	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   256,   256,   256,   256 );
+#endif
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4080,  4080,  4080,  4080 );
 	bli_blksz_init_easy( &blkszs[ BLIS_AF ],     8,     8,    -1,    -1 );
 	bli_blksz_init_easy( &blkszs[ BLIS_DF ],     8,     8,    -1,    -1 );

--- a/config/zen/bli_family_zen.h
+++ b/config/zen/bli_family_zen.h
@@ -42,7 +42,7 @@
 #define BLIS_DEFAULT_MR_THREAD_MAX 1
 #define BLIS_DEFAULT_NR_THREAD_MAX 1
 
-
+#define BLIS_ENABLE_ZEN_BLOCK_SIZES
 //#define BLIS_ENABLE_SMALL_MATRIX
 
 // This will select the threshold below which small matrix code will be called.

--- a/config/zen/bli_family_zen.h
+++ b/config/zen/bli_family_zen.h
@@ -43,12 +43,12 @@
 #define BLIS_DEFAULT_NR_THREAD_MAX 1
 
 #define BLIS_ENABLE_ZEN_BLOCK_SIZES
-//#define BLIS_ENABLE_SMALL_MATRIX
+#define BLIS_ENABLE_SMALL_MATRIX
 
 // This will select the threshold below which small matrix code will be called.
-//#define BLIS_SMALL_MATRIX_THRES        700
-//#define BLIS_SMALL_M_RECT_MATRIX_THRES 160
-//#define BLIS_SMALL_K_RECT_MATRIX_THRES 128
+#define BLIS_SMALL_MATRIX_THRES        700
+#define BLIS_SMALL_M_RECT_MATRIX_THRES 160
+#define BLIS_SMALL_K_RECT_MATRIX_THRES 128
 
 
 


### PR DESCRIPTION
Re-enabling the AMD specific optimizations for target 'zen', that were disabled while merging 'amd' branch to 'master' branch.