### PR TITLE
cortexa9 and cortexa53 travis build + qemu test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,25 @@ matrix:
   - os: osx
     compiler: clang
     env: OOT=0 TEST=0 SDE=0 THR="none" CONF="auto"
+  # cortexa15 build and test (qemu)
+  - os: linux
+    compiler: arm-linux-gnueabihf-gcc
+    env: OOT=0 TEST=FAST SDE=0 THR="none" CONF="cortexa15" \
+      PACKAGES="gcc-arm-linux-gnueabihf qemu-system-arm qemu-user" \
+      TESTSUITE_WRAPPER="qemu-arm -cpu cortex-a15 -L /usr/arm-linux-gnueabihf/"
+  # cortexa57 build and test (qemu)
+  - os: linux
+    compiler: aarch64-linux-gnu-gcc
+    env: OOT=0 TEST=FAST SDE=0 THR="none" CONF="cortexa57" \
+      PACKAGES="gcc-aarch64-linux-gnu qemu-system-arm qemu-user" \
+      TESTSUITE_WRAPPER="qemu-aarch64 -L /usr/aarch64-linux-gnu/"
 install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo rm -f /usr/bin/as; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/lib/binutils-2.26/bin/as /usr/bin/as; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo rm -f /usr/bin/ld; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/lib/binutils-2.26/bin/ld /usr/bin/ld; fi
 - if [ "$CC" = "gcc" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; fi
+- if [ -n "$PACKAGES" ]; then sudo apt-get install -y $PACKAGES; fi
 addons:
   apt:
     sources:
@@ -58,5 +71,5 @@ script:
 - ls -l
 - $CC --version
 - make -j 2
-- if [ $TEST -eq 1 ]; then travis_wait 30 $DIST_PATH/travis/do_testsuite.sh; fi
+- if [ "$TEST" != "0" ]; then travis_wait 30 $DIST_PATH/travis/do_testsuite.sh; fi
 - if [ $SDE -eq 1 ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] ; then travis_wait 30 $DIST_PATH/travis/do_sde.sh; fi

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ MK_TESTSUITE_OBJS       := $(sort \
 
 # The test suite binary executable filename.
 TESTSUITE_BIN           := test_$(LIBBLIS).x
+TESTSUITE_WRAPPER       ?=
 
 # The location of the script that checks the BLIS testsuite output.
 TESTSUITE_CHECK_PATH    := $(DIST_PATH)/$(TESTSUITE_DIR)/$(TESTSUITE_CHECK)
@@ -703,10 +704,10 @@ $(foreach name, $(BLASTEST_DRV_BASES), $(eval $(call make-blat-rule,$(name))))
 define make-run-blat1-rule
 run-$(1): $(BASE_OBJ_BLASTEST_PATH)/$(1).x
 ifeq ($(ENABLE_VERBOSE),yes)
-	$(BASE_OBJ_BLASTEST_PATH)/$(1).x > out.$(1)
+	$(TESTSUITE_WRAPPER) $(BASE_OBJ_BLASTEST_PATH)/$(1).x > out.$(1)
 else
 	@echo "Running $(1).x > 'out.$(1)'"
-	@$(BASE_OBJ_BLASTEST_PATH)/$(1).x > out.$(1)
+	@$(TESTSUITE_WRAPPER) $(BASE_OBJ_BLASTEST_PATH)/$(1).x > out.$(1)
 endif
 endef
 
@@ -717,10 +718,10 @@ $(foreach name, $(BLASTEST_DRV1_BASES), $(eval $(call make-run-blat1-rule,$(name
 define make-run-blat23-rule
 run-$(1): $(BASE_OBJ_BLASTEST_PATH)/$(1).x
 ifeq ($(ENABLE_VERBOSE),yes)
-	$(BASE_OBJ_BLASTEST_PATH)/$(1).x < $(BLASTEST_INPUT_PATH)/$(1).in
+	$(TESTSUITE_WRAPPER) $(BASE_OBJ_BLASTEST_PATH)/$(1).x < $(BLASTEST_INPUT_PATH)/$(1).in
 else
 	@echo "Running $(1).x < '$(BLASTEST_INPUT_PATH)/$(1).in' (output to 'out.$(1)')"
-	@$(BASE_OBJ_BLASTEST_PATH)/$(1).x < $(BLASTEST_INPUT_PATH)/$(1).in
+	@$(TESTSUITE_WRAPPER) $(BASE_OBJ_BLASTEST_PATH)/$(1).x < $(BLASTEST_INPUT_PATH)/$(1).in
 endif
 endef
 
@@ -769,13 +770,13 @@ endif
 # A rule to run the testsuite using the normal input.* files.
 testsuite-run: testsuite-bin
 ifeq ($(ENABLE_VERBOSE),yes)
-	./$(TESTSUITE_BIN) -g $(TESTSUITE_CONF_GEN_PATH) \
+	$(TESTSUITE_WRAPPER) ./$(TESTSUITE_BIN) -g $(TESTSUITE_CONF_GEN_PATH) \
 	                   -o $(TESTSUITE_CONF_OPS_PATH) \
 	                    > $(TESTSUITE_OUT_FILE)
 
 else
 	@echo "Running $(TESTSUITE_BIN) with output redirected to '$(TESTSUITE_OUT_FILE)'"
-	@./$(TESTSUITE_BIN) -g $(TESTSUITE_CONF_GEN_PATH) \
+	@$(TESTSUITE_WRAPPER) ./$(TESTSUITE_BIN) -g $(TESTSUITE_CONF_GEN_PATH) \
 	                    -o $(TESTSUITE_CONF_OPS_PATH) \
 	                     > $(TESTSUITE_OUT_FILE)
 endif
@@ -784,13 +785,13 @@ endif
 # run a set of tests designed to finish much more quickly.
 testsuite-run-fast: testsuite-bin
 ifeq ($(ENABLE_VERBOSE),yes)
-	./$(TESTSUITE_BIN) -g $(TESTSUITE_FAST_GEN_PATH) \
+	$(TESTSUITE_WRAPPER) ./$(TESTSUITE_BIN) -g $(TESTSUITE_FAST_GEN_PATH) \
 	                   -o $(TESTSUITE_FAST_OPS_PATH) \
 	                    > $(TESTSUITE_OUT_FILE)
 
 else
 	@echo "Running $(TESTSUITE_BIN) (fast) with output redirected to '$(TESTSUITE_OUT_FILE)'"
-	@./$(TESTSUITE_BIN) -g $(TESTSUITE_FAST_GEN_PATH) \
+	@$(TESTSUITE_WRAPPER) ./$(TESTSUITE_BIN) -g $(TESTSUITE_FAST_GEN_PATH) \
 	                    -o $(TESTSUITE_FAST_OPS_PATH) \
 	                     > $(TESTSUITE_OUT_FILE)
 endif

--- a/blastest/Makefile
+++ b/blastest/Makefile
@@ -141,7 +141,7 @@ LIBBLIS_LINK   := $(LIB_PATH)/$(LIBBLIS_L)
 # Override the location of the check-blastest.sh script.
 #BLASTEST_CHECK := ./check-blastest.sh
 
-
+TESTSUITE_WRAPPER       ?=
 
 #
 # --- Targets/rules ------------------------------------------------------------
@@ -213,10 +213,10 @@ run: $(DRIVER_BINS_R)
 define make-run-blat1-rule
 run-$(1): $(1).x
 ifeq ($(ENABLE_VERBOSE),yes)
-	./$(1).x > out.$(1)
+	$(TESTSUITE_WRAPPER) ./$(1).x > out.$(1)
 else
 	@echo "Running $(1).x > 'out.$(1)'"
-	@./$(1).x > out.$(1)
+	@$(TESTSUITE_WRAPPER) ./$(1).x > out.$(1)
 endif
 endef
 
@@ -227,10 +227,10 @@ $(foreach name, $(DRIVER1_BASES), $(eval $(call make-run-blat1-rule,$(name))))
 define make-run-blat23-rule
 run-$(1): $(1).x
 ifeq ($(ENABLE_VERBOSE),yes)
-	./$(1).x < $(INPUT_DIR)/$(1).in
+	$(TESTSUITE_WRAPPER) ./$(1).x < $(INPUT_DIR)/$(1).in
 else
 	@echo "Running $(1).x < '$(INPUT_DIR)/$(1).in' (output to 'out.$(1)')"
-	@./$(1).x < $(INPUT_DIR)/$(1).in
+	@$(TESTSUITE_WRAPPER) ./$(1).x < $(INPUT_DIR)/$(1).in
 endif
 endef
 

--- a/config/cortexa57/make_defs.mk
+++ b/config/cortexa57/make_defs.mk
@@ -57,13 +57,13 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -ftree-vectorize -mtune=cortex-a57.cortex-a53
+COPTFLAGS      := -O3 -ftree-vectorize -mtune=cortex-a57
 endif
 
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -march=armv8-a+fp+simd -mcpu=cortex-a57.cortex-a53
+CKVECFLAGS     := -march=armv8-a+fp+simd -mcpu=cortex-a57
 else
 $(error gcc is required for this configuration.)
 endif

--- a/travis/do_testsuite.sh
+++ b/travis/do_testsuite.sh
@@ -8,7 +8,13 @@ export BLIS_JC_NT=1
 export BLIS_IR_NT=1
 export BLIS_JR_NT=1
 
-make testblis
+if [ "$TEST" = "FAST" ]
+then
+    make testblis-fast
+else
+    make testblis
+fi
+
 $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 make testblas
 $DIST_PATH/blastest/check-blastest.sh


### PR DESCRIPTION
Adds travis build and test for one arm32 target and one aarch64.

One sidenode: as ubuntu/trusty cross gcc is a bit ancient, i had to downgrade the mtune argument from a53.a57 to a57 only... I'm not sure if we should have two differenc configs just for that or if we can use a more recent ubuntu..