### PR TITLE
Fix OMP nesting problem.

### DIFF
--- a/frame/thread/bli_thrcomm_openmp.c
+++ b/frame/thread/bli_thrcomm_openmp.c
@@ -237,9 +237,20 @@ void bli_l3_thread_decorator
 		{
 			if ( id == 0 )
 			{
-				n_threads = n_threads_real;
-				bli_thrcomm_init( gl_comm, n_threads );
+	            if ( n_threads_real != 1 )
+	            {
+	                bli_print_msg( "A different number of threads was "
+	                               "created than was requested.",
+	                               __FILE__, __LINE__ );
+	                bli_abort();
+	            }
+
+				n_threads = 1;
+				bli_thrcomm_init( gl_comm, 1 );
+				bli_rntm_set_num_threads_only( 1, rntm );
+				bli_rntm_set_ways_only( 1, 1, 1, 1, 1, rntm );
 			}
+
 			_Pragma( "omp barrier" )
 		}
 

--- a/frame/thread/bli_thrcomm_openmp.c
+++ b/frame/thread/bli_thrcomm_openmp.c
@@ -230,7 +230,18 @@ void bli_l3_thread_decorator
 
 	_Pragma( "omp parallel num_threads(n_threads)" )
 	{
+		dim_t      n_threads_real = omp_get_num_threads();
 		dim_t      id = omp_get_thread_num();
+		
+		if ( n_threads_real != n_threads )
+		{
+			if ( id == 0 )
+			{
+				n_threads = n_threads_real;
+				bli_thrcomm_init( gl_comm, n_threads );
+			}
+			_Pragma( "omp barrier" )
+		}
 
 		obj_t      a_t, b_t, c_t;
 		cntl_t*    cntl_use;


### PR DESCRIPTION
Detect when OpenMP uses fewer threads than requested and correct accordingly, so that we don't wait forever for nonexistent threads. Fixes #267.