### PR TITLE
Fix bgclang compilation on BGQ

### DIFF
--- a/config/bgq/make_defs.mk
+++ b/config/bgq/make_defs.mk
@@ -51,7 +51,13 @@ THIS_CONFIG    := bgq
 # general-purpose/configuration-agnostic flags in common.mk. You
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -I/bgsys/drivers/ppcfloor -I/bgsys/drivers/ppcfloor/spi/include/kernel/cnk
+ifeq ($(CC_VENDOR),ibm)
 CMISCFLAGS     := -qthreaded -qsmp=omp -qasm=gcc -qkeyword=asm # -qreport -qsource -qlistopt -qlist
+else ifeq ($(CC_VENDOR),clang)
+CMISCFLAGS     := -fopenmp
+else
+$(error xlc or bgclang is required for this configuration.)
+endif
 CPICFLAGS      :=
 CWARNFLAGS     := -w
 
@@ -69,8 +75,6 @@ endif
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),ibm)
 CKVECFLAGS     := -qarch=qp -qtune=qp -qsimd=auto -qhot=level=1 -qprefetch -qunroll=yes -qnoipa
-else
-$(error xlc is required for this configuration.)
 endif
 
 # Flags specific to reference kernels.
@@ -78,7 +82,11 @@ CROPTFLAGS     := $(CKOPTFLAGS)
 CRVECFLAGS     := $(CKVECFLAGS)
 
 # Override the default value for LDFLAGS.
+ifeq ($(CC_VENDOR),ibm)
 LDFLAGS        := -L/bgsys/drivers/ppcfloor/spi/lib -lSPI -lSPI_cnk -qthreaded -qsmp=omp
+else ifeq ($(CC_VENDOR),clang)
+LDFLAGS        := -L/bgsys/drivers/ppcfloor/spi/lib -lSPI -lSPI_cnk -fopenmp
+endif
 
 # Store all of the variables here to new variables containing the
 # configuration name.

--- a/config_registry
+++ b/config_registry
@@ -34,5 +34,8 @@ cortexa53:   cortexa53/armv8a
 cortexa15:   cortexa15/armv7a
 cortexa9:    cortexa9/armv7a
 
+# IBM architectures.
+bgq:         bgq
+
 # Generic architectures.
 generic:     generic

--- a/kernels/bgq/1/bli_dotv_bgq_int.c
+++ b/kernels/bgq/1/bli_dotv_bgq_int.c
@@ -49,7 +49,7 @@ void bli_ddotv_bgq_int
 
 	// If the vector lengths are zero, set rho to zero and return.
 	if ( bli_zero_dim1( n ) ) {
-		PASTEMAC(d,set0s)( rho ); 
+		PASTEMAC(d,set0s)( *rho ); 
 		return; 
 	} 
 	// If there is anything that would interfere with our use of aligned

--- a/kernels/bgq/3/bli_gemm_bgq_int_8x8.c
+++ b/kernels/bgq/3/bli_gemm_bgq_int_8x8.c
@@ -56,23 +56,16 @@
 
 void bli_dgemm_bgq_int_8x8
      (
-       dim_t               k0,
+       dim_t               k,
        double*    restrict alpha,
        double*    restrict a,
        double*    restrict b,
        double*    restrict beta,
-       double*    restrict c, inc_t rs_c0, inc_t cs_c0,
+       double*    restrict c, inc_t rs_c, inc_t cs_c,
        auxinfo_t* restrict data,
        cntx_t*    restrict cntx
      )
 {
-	// Typecast local copies of integers in case dim_t and inc_t are a
-	// different size than is expected by load instructions.
-	uint64_t k_iter = k0 / 4;
-	uint64_t k_left = k0 % 4;
-	uint64_t rs_c   = rs_c0;
-	uint64_t cs_c   = cs_c0;
-
     //Registers for storing C.
     //4 4x4 subblocks of C, c00, c01, c10, c11
     //4 registers per subblock: a, b, c, d


### PR DESCRIPTION
We are still operating BGQ at Argonne. So I'm experimenting the possibility of using BLIS as an alternative to ESSL which has a conflict with the llvm OpenMP runtime.

There are two commits. One fixes the flags for bgclang compiler and the other fixes some compilation error. The result of my app comes out correctly.