### PR TITLE
Initialize error messages at compile time

### DIFF
--- a/build/libblis-symbols.def
+++ b/build/libblis-symbols.def
@@ -976,9 +976,6 @@ bli_dzxpbym_md_unb_var1
 bli_error_checking_is_enabled
 bli_error_checking_level
 bli_error_checking_level_set
-bli_error_finalize
-bli_error_init
-bli_error_init_msgs
 bli_error_string_for_code
 bli_ffree_align
 bli_ffree_noalign
@@ -990,6 +987,7 @@ bli_find_area_trap_l
 bli_fmalloc_align
 bli_fmalloc_align_check
 bli_fmalloc_noalign
+bli_fmalloc_post_check
 bli_fprintm
 bli_fprintm_check
 bli_fprintm_ex

--- a/frame/base/bli_error.c
+++ b/frame/base/bli_error.c
@@ -47,141 +47,86 @@ void bli_error_finalize( void )
 // -----------------------------------------------------------------------------
 
 // Internal array to hold error strings.
-static char bli_error_string[BLIS_MAX_NUM_ERR_MSGS][BLIS_MAX_ERR_MSG_LENGTH];
+static char bli_error_string[BLIS_MAX_NUM_ERR_MSGS][BLIS_MAX_ERR_MSG_LENGTH] =
+{
+	[-BLIS_INVALID_ERROR_CHECKING_LEVEL]         = "Invalid error checking level.",
+	[-BLIS_UNDEFINED_ERROR_CODE]                 = "Undefined error code.",
+	[-BLIS_NULL_POINTER]                         = "Encountered unexpected null pointer.",
+	[-BLIS_NOT_YET_IMPLEMENTED]                  = "Requested functionality not yet implemented.",
+
+	[-BLIS_INVALID_SIDE]                         = "Invalid side parameter value.",
+	[-BLIS_INVALID_UPLO]                         = "Invalid uplo_t parameter value.",
+	[-BLIS_INVALID_TRANS]                        = "Invalid trans_t parameter value.",
+	[-BLIS_INVALID_CONJ]                         = "Invalid conj_t parameter value.",
+	[-BLIS_INVALID_DIAG]                         = "Invalid diag_t parameter value.",
+	[-BLIS_EXPECTED_NONUNIT_DIAG]                = "Expected object with non-unit diagonal.",
+
+	[-BLIS_INVALID_DATATYPE]                     = "Invalid datatype value.",
+	[-BLIS_EXPECTED_FLOATING_POINT_DATATYPE]     = "Expected floating-point datatype value.",
+	[-BLIS_EXPECTED_NONINTEGER_DATATYPE]         = "Expected non-integer datatype value.",
+	[-BLIS_EXPECTED_NONCONSTANT_DATATYPE]        = "Expected non-constant datatype value.",
+	[-BLIS_EXPECTED_REAL_DATATYPE]               = "Expected real datatype value.",
+	[-BLIS_EXPECTED_INTEGER_DATATYPE]            = "Expected integer datatype value.",
+	[-BLIS_INCONSISTENT_DATATYPES]               = "Expected consistent datatypes (equal, or one being constant).",
+	[-BLIS_EXPECTED_REAL_PROJ_OF]                = "Expected second datatype to be real projection of first.",
+	[-BLIS_EXPECTED_REAL_VALUED_OBJECT]          = "Expected real-valued object (ie: if complex, imaginary component equals zero).",
+	[-BLIS_INCONSISTENT_PRECISIONS]              = "Expected consistent precisions (both single or both double).",
+
+	[-BLIS_NONCONFORMAL_DIMENSIONS]              = "Encountered non-conformal dimensions between objects.",
+	[-BLIS_EXPECTED_SCALAR_OBJECT]               = "Expected scalar object.",
+	[-BLIS_EXPECTED_VECTOR_OBJECT]               = "Expected vector object.",
+	[-BLIS_UNEQUAL_VECTOR_LENGTHS]               = "Encountered unequal vector lengths.",
+	[-BLIS_EXPECTED_SQUARE_OBJECT]               = "Expected square object.",
+	[-BLIS_UNEXPECTED_OBJECT_LENGTH]             = "Unexpected object length.",
+	[-BLIS_UNEXPECTED_OBJECT_WIDTH]              = "Unexpected object width.",
+	[-BLIS_UNEXPECTED_VECTOR_DIM]                = "Unexpected vector dimension.",
+	[-BLIS_UNEXPECTED_DIAG_OFFSET]               = "Unexpected object diagonal offset.",
+	[-BLIS_NEGATIVE_DIMENSION]                   = "Encountered negative dimension.",
+
+	[-BLIS_INVALID_ROW_STRIDE]                   = "Encountered invalid row stride relative to n dimension.",
+	[-BLIS_INVALID_COL_STRIDE]                   = "Encountered invalid col stride relative to m dimension.",
+	[-BLIS_INVALID_DIM_STRIDE_COMBINATION]       = "Encountered invalid stride/dimension combination.",
+
+	[-BLIS_EXPECTED_GENERAL_OBJECT]              = "Expected general object.",
+	[-BLIS_EXPECTED_HERMITIAN_OBJECT]            = "Expected Hermitian object.",
+	[-BLIS_EXPECTED_SYMMETRIC_OBJECT]            = "Expected symmetric object.",
+	[-BLIS_EXPECTED_TRIANGULAR_OBJECT]           = "Expected triangular object.",
+
+	[-BLIS_EXPECTED_UPPER_OR_LOWER_OBJECT]       = "Expected upper or lower triangular object.",
+
+	[-BLIS_INVALID_3x1_SUBPART]                  = "Encountered invalid 3x1 (vertical) subpartition label.",
+	[-BLIS_INVALID_1x3_SUBPART]                  = "Encountered invalid 1x3 (horizontal) subpartition label.",
+	[-BLIS_INVALID_3x3_SUBPART]                  = "Encountered invalid 3x3 (diagonal) subpartition label.",
+
+	[-BLIS_UNEXPECTED_NULL_CONTROL_TREE]         = "Encountered unexpected null control tree node.",
+
+	[-BLIS_PACK_SCHEMA_NOT_SUPPORTED_FOR_UNPACK] = "Pack schema not yet supported/implemented for use with unpacking.",
+
+	[-BLIS_EXPECTED_NONNULL_OBJECT_BUFFER]       = "Encountered object with non-zero dimensions containing null buffer.",
+
+	[-BLIS_MALLOC_RETURNED_NULL]                 = "malloc() returned NULL; heap memory is likely exhausted.",
+
+	[-BLIS_INVALID_PACKBUF]                      = "Invalid packbuf_t value.",
+	[-BLIS_EXHAUSTED_CONTIG_MEMORY_POOL]         = "Attempted to allocate more memory from contiguous pool than is available.",
+	[-BLIS_INSUFFICIENT_STACK_BUF_SIZE]          = "Configured maximum stack buffer size is insufficient for register blocksizes currently in use.",
+	[-BLIS_ALIGNMENT_NOT_POWER_OF_TWO]           = "Encountered memory alignment value that is either zero or not a power of two.",
+	[-BLIS_ALIGNMENT_NOT_MULT_OF_PTR_SIZE]       = "Encountered memory alignment value that is not a multiple of sizeof(void*).",
+
+	[-BLIS_EXPECTED_OBJECT_ALIAS]                = "Expected object to be alias.",
+
+	[-BLIS_INVALID_ARCH_ID]                      = "Invalid architecture id value.",
+
+	[-BLIS_MC_DEF_NONMULTIPLE_OF_MR]             = "Default MC is non-multiple of MR for one or more datatypes.",
+	[-BLIS_MC_MAX_NONMULTIPLE_OF_MR]             = "Maximum MC is non-multiple of MR for one or more datatypes.",
+	[-BLIS_NC_DEF_NONMULTIPLE_OF_NR]             = "Default NC is non-multiple of NR for one or more datatypes.",
+	[-BLIS_NC_MAX_NONMULTIPLE_OF_NR]             = "Maximum NC is non-multiple of NR for one or more datatypes.",
+	[-BLIS_KC_DEF_NONMULTIPLE_OF_KR]             = "Default KC is non-multiple of KR for one or more datatypes.",
+	[-BLIS_KC_MAX_NONMULTIPLE_OF_KR]             = "Maximum KC is non-multiple of KR for one or more datatypes.",
+};
 
 void bli_error_init_msgs( void )
 {
-	sprintf( bli_error_string_for_code(BLIS_INVALID_ERROR_CHECKING_LEVEL),
-	         "Invalid error checking level." );
-	sprintf( bli_error_string_for_code(BLIS_UNDEFINED_ERROR_CODE),
-	         "Undefined error code." );
-	sprintf( bli_error_string_for_code(BLIS_NULL_POINTER),
-	         "Encountered unexpected null pointer." );
-	sprintf( bli_error_string_for_code(BLIS_NOT_YET_IMPLEMENTED),
-	         "Requested functionality not yet implemented." );
-
-	sprintf( bli_error_string_for_code(BLIS_INVALID_SIDE),
-	         "Invalid side parameter value." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_UPLO),
-	         "Invalid uplo_t parameter value." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_TRANS),
-	         "Invalid trans_t parameter value." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_CONJ),
-	         "Invalid conj_t parameter value." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_DIAG),
-	         "Invalid diag_t parameter value." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_NONUNIT_DIAG),
-	         "Expected object with non-unit diagonal." );
-
-	sprintf( bli_error_string_for_code(BLIS_INVALID_DATATYPE),
-	         "Invalid datatype value." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_FLOATING_POINT_DATATYPE),
-	         "Expected floating-point datatype value." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_NONINTEGER_DATATYPE),
-	         "Expected non-integer datatype value." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_NONCONSTANT_DATATYPE),
-	         "Expected non-constant datatype value." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_REAL_DATATYPE),
-	         "Expected real datatype value." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_INTEGER_DATATYPE),
-	         "Expected integer datatype value." );
-	sprintf( bli_error_string_for_code(BLIS_INCONSISTENT_DATATYPES),
-	         "Expected consistent datatypes (equal, or one being constant)." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_REAL_PROJ_OF),
-	         "Expected second datatype to be real projection of first." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_REAL_VALUED_OBJECT),
-	         "Expected real-valued object (ie: if complex, imaginary component equals zero)." );
-	sprintf( bli_error_string_for_code(BLIS_INCONSISTENT_PRECISIONS),
-	         "Expected consistent precisions (both single or both double)." );
-
-	sprintf( bli_error_string_for_code(BLIS_NONCONFORMAL_DIMENSIONS),
-	         "Encountered non-conformal dimensions between objects." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_SCALAR_OBJECT),
-	         "Expected scalar object." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_VECTOR_OBJECT),
-	         "Expected vector object." );
-	sprintf( bli_error_string_for_code(BLIS_UNEQUAL_VECTOR_LENGTHS),
-	         "Encountered unequal vector lengths." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_SQUARE_OBJECT),
-	         "Expected square object." );
-	sprintf( bli_error_string_for_code(BLIS_UNEXPECTED_OBJECT_LENGTH),
-	         "Unexpected object length." );
-	sprintf( bli_error_string_for_code(BLIS_UNEXPECTED_OBJECT_WIDTH),
-	         "Unexpected object width." );
-	sprintf( bli_error_string_for_code(BLIS_UNEXPECTED_VECTOR_DIM),
-	         "Unexpected vector dimension." );
-	sprintf( bli_error_string_for_code(BLIS_UNEXPECTED_DIAG_OFFSET),
-	         "Unexpected object diagonal offset." );
-	sprintf( bli_error_string_for_code(BLIS_NEGATIVE_DIMENSION),
-	         "Encountered negative dimension." );
-
-	sprintf( bli_error_string_for_code(BLIS_INVALID_ROW_STRIDE),
-	         "Encountered invalid row stride relative to n dimension." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_COL_STRIDE),
-	         "Encountered invalid col stride relative to m dimension." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_DIM_STRIDE_COMBINATION),
-	         "Encountered invalid stride/dimension combination." );
-
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_GENERAL_OBJECT),
-	         "Expected general object." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_HERMITIAN_OBJECT),
-	         "Expected Hermitian object." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_SYMMETRIC_OBJECT),
-	         "Expected symmetric object." );
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_TRIANGULAR_OBJECT),
-	         "Expected triangular object." );
-
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_UPPER_OR_LOWER_OBJECT),
-	         "Expected upper or lower triangular object." );
-
-	sprintf( bli_error_string_for_code(BLIS_INVALID_3x1_SUBPART),
-	         "Encountered invalid 3x1 (vertical) subpartition label." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_1x3_SUBPART),
-	         "Encountered invalid 1x3 (horizontal) subpartition label." );
-	sprintf( bli_error_string_for_code(BLIS_INVALID_3x3_SUBPART),
-	         "Encountered invalid 3x3 (diagonal) subpartition label." );
-
-	sprintf( bli_error_string_for_code(BLIS_UNEXPECTED_NULL_CONTROL_TREE),
-	         "Encountered unexpected null control tree node." );
-
-	sprintf( bli_error_string_for_code(BLIS_PACK_SCHEMA_NOT_SUPPORTED_FOR_UNPACK),
-	         "Pack schema not yet supported/implemented for use with unpacking." );
-
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_NONNULL_OBJECT_BUFFER),
-	         "Encountered object with non-zero dimensions containing null buffer." );
-
-	sprintf( bli_error_string_for_code(BLIS_MALLOC_RETURNED_NULL),
-	         "malloc() returned NULL; heap memory is likely exhausted." );
-
-	sprintf( bli_error_string_for_code(BLIS_INVALID_PACKBUF),
-	         "Invalid packbuf_t value." );
-	sprintf( bli_error_string_for_code(BLIS_EXHAUSTED_CONTIG_MEMORY_POOL),
-	         "Attempted to allocate more memory from contiguous pool than is available." );
-	sprintf( bli_error_string_for_code(BLIS_INSUFFICIENT_STACK_BUF_SIZE),
-	         "Configured maximum stack buffer size is insufficient for register blocksizes currently in use." );
-	sprintf( bli_error_string_for_code(BLIS_ALIGNMENT_NOT_POWER_OF_TWO),
-	         "Encountered memory alignment value that is either zero or not a power of two." );
-	sprintf( bli_error_string_for_code(BLIS_ALIGNMENT_NOT_MULT_OF_PTR_SIZE),
-	         "Encountered memory alignment value that is not a multiple of sizeof(void*)." );
-
-	sprintf( bli_error_string_for_code(BLIS_EXPECTED_OBJECT_ALIAS),
-	         "Expected object to be alias." );
-
-	sprintf( bli_error_string_for_code(BLIS_INVALID_ARCH_ID),
-	         "Invalid architecture id value." );
-
-	sprintf( bli_error_string_for_code(BLIS_MC_DEF_NONMULTIPLE_OF_MR),
-	         "Default MC is non-multiple of MR for one or more datatypes." );
-	sprintf( bli_error_string_for_code(BLIS_MC_MAX_NONMULTIPLE_OF_MR),
-	         "Maximum MC is non-multiple of MR for one or more datatypes." );
-	sprintf( bli_error_string_for_code(BLIS_NC_DEF_NONMULTIPLE_OF_NR),
-	         "Default NC is non-multiple of NR for one or more datatypes." );
-	sprintf( bli_error_string_for_code(BLIS_NC_MAX_NONMULTIPLE_OF_NR),
-	         "Maximum NC is non-multiple of NR for one or more datatypes." );
-	sprintf( bli_error_string_for_code(BLIS_KC_DEF_NONMULTIPLE_OF_KR),
-	         "Default KC is non-multiple of KR for one or more datatypes." );
-	sprintf( bli_error_string_for_code(BLIS_KC_MAX_NONMULTIPLE_OF_KR),
-	         "Maximum KC is non-multiple of KR for one or more datatypes." );
+	// Empty here. All error messages have been initialized above, at compile time.
 }
 
 void bli_print_msg( char* str, char* file, guint_t line )

--- a/frame/base/bli_error.c
+++ b/frame/base/bli_error.c
@@ -35,17 +35,6 @@
 
 #include "blis.h"
 
-void bli_error_init( void )
-{
-	bli_error_init_msgs();
-}
-
-void bli_error_finalize( void )
-{
-}
-
-// -----------------------------------------------------------------------------
-
 // Internal array to hold error strings.
 static char bli_error_string[BLIS_MAX_NUM_ERR_MSGS][BLIS_MAX_ERR_MSG_LENGTH] =
 {
@@ -124,10 +113,7 @@ static char bli_error_string[BLIS_MAX_NUM_ERR_MSGS][BLIS_MAX_ERR_MSG_LENGTH] =
 	[-BLIS_KC_MAX_NONMULTIPLE_OF_KR]             = "Maximum KC is non-multiple of KR for one or more datatypes.",
 };
 
-void bli_error_init_msgs( void )
-{
-	// Empty here. All error messages have been initialized above, at compile time.
-}
+// -----------------------------------------------------------------------------
 
 void bli_print_msg( char* str, char* file, guint_t line )
 {

--- a/frame/base/bli_error.h
+++ b/frame/base/bli_error.h
@@ -33,10 +33,6 @@
 */
 
 
-void     bli_error_init( void );
-void     bli_error_finalize( void );
-
-void     bli_error_init_msgs( void );
 void     bli_print_msg( char* str, char* file, guint_t line );
 void     bli_abort( void );
 
@@ -46,5 +42,4 @@ void     bli_error_checking_level_set( errlev_t new_level );
 bool_t   bli_error_checking_is_enabled( void );
 
 char*    bli_error_string_for_code( gint_t code );
-
 

--- a/frame/base/bli_init.c
+++ b/frame/base/bli_init.c
@@ -75,7 +75,6 @@ void bli_finalize_auto( void )
 void bli_init_apis( void )
 {
 	// Initialize various sub-APIs.
-	bli_error_init();
 	bli_gks_init();
 	bli_ind_init();
 	bli_thread_init();
@@ -89,7 +88,6 @@ void bli_finalize_apis( void )
 	bli_thread_finalize();
 	bli_gks_finalize();
 	bli_ind_finalize();
-	bli_error_finalize();
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Assigning strings directly to the bli_error_string array, instead of snprintf() at execution-time.

- From the programming point of view, this simplifies code and further adding of error code. 

- From the binary point of view, I believe this does not change the executable size, or even reduce it by some KB (all constant strings in `.data` section). The `bli_error_string`array will be moved from the `.bss` section to the `.data` one. And those constant hard-coded strings, which have always been in the `.data` section, instead of getting "duplicated" to the `bli_error_string` array at execution-time (function `bli_error_init_msgs()`), now should be directly put to the right place at compile time.

- From the performance point of view, we save dozens of sprintf.