### PR TITLE
Port BLIS to GNU Hurd OS.

### DIFF
--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -56,6 +56,8 @@
 // Determine the target operating system.
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define BLIS_OS_WINDOWS 1
+#elif defined(__gnu_hurd__)
+#define BLIS_OS_GNU 1
 #elif defined(__APPLE__) || defined(__MACH__)
 #define BLIS_OS_OSX 1
 #elif defined(__ANDROID__)


### PR DESCRIPTION
This change prevents the header from misrecognizing Hurd as OSX.

builddlog: https://buildd.debian.org/status/fetch.php?pkg=blis&arch=hurd-i386&ver=0.5.1-2&stamp=1547649509&raw=0
GNU Hurd: https://www.gnu.org/software/hurd/

Please don't merge it until this has been proved working.