### PR TITLE
Test with shared on windows

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -530,6 +530,11 @@ ifeq ($(IS_WIN),no)
 LDFLAGS        += -Wl,-rpath,$(BASE_LIB_PATH)
 endif
 endif
+# On windows, use the shared library even if static is created.
+ifeq ($(IS_WIN),yes)
+LIBBLIS_L      := $(LIBBLIS_SO)
+LIBBLIS_LINK   := $(LIBBLIS_SO_PATH)
+endif
 endif
 
 

--- a/frame/include/bli_config_macro_defs.h
+++ b/frame/include/bli_config_macro_defs.h
@@ -190,20 +190,22 @@
 // with that setting overridden only for function prototypes or variable
 // declarations that are annotated with BLIS_EXPORT_BLIS.
 
-#if !defined(BLIS_ENABLE_SHARED)
+#ifndef BLIS_EXPORT
+  #if !defined(BLIS_ENABLE_SHARED)
     #define BLIS_EXPORT
-#else
+  #else
     #if defined(_WIN32) || defined(__CYGWIN__)
-        #ifdef BLIS_IS_BUILDING_LIBRARY
-            #define BLIS_EXPORT __declspec(dllexport)
-        #else
-            #define BLIS_EXPORT __declspec(dllimport)
-        #endif
+      #ifdef BLIS_IS_BUILDING_LIBRARY
+        #define BLIS_EXPORT __declspec(dllexport)
+      #else
+        #define BLIS_EXPORT __declspec(dllimport)
+      #endif
     #elif defined(__GNUC__) && __GNUC__ >= 4
-        #define BLIS_EXPORT __attribute__ ((visibility ("default")))
+      #define BLIS_EXPORT __attribute__ ((visibility ("default")))
     #else
-        #define BLIS_EXPORT
+      #define BLIS_EXPORT
     #endif
+  #endif
 #endif
 
 #define BLIS_EXPORT_BLIS BLIS_EXPORT


### PR DESCRIPTION
Export macros can't support both shared and static at the same time.
When blis is built with both shared and static, headers assume that
shared is used at link time and dllimports the symbols with `__imp_`
prefix.

To use the headers with static libraries a user can give
-DBLIS_EXPORT= to import the symbol without the `__imp_` prefix