### PR TITLE
add info about CXX in configure

### DIFF
--- a/configure
+++ b/configure
@@ -298,6 +298,7 @@ print_usage()
 	echo " Environment Variables:"
 	echo " "
 	echo "   CC            Specifies the C compiler to use."
+        echo "   CXX           Specifies the C++ compiler to use (sandbox only)."
 	echo "   RANLIB        Specifies the ranlib executable to use."
 	echo "   AR            Specifies the archiver to use."
 	echo "   CFLAGS        Specifies additional compiler flags to use (prepended)."


### PR DESCRIPTION
BLIS now uses a C++ compiler, albeit in a limited way.  The `CXX` environment variables controls this but isn't documented by `print_usage()`.

I am not sure it actually matters, but if the user is settings `CC` explicitly, they probably want to set `CXX` to the same toolchain.