### PR TITLE
Make xerbla_ test routine visible

### DIFF
--- a/blastest/src/cblat2.c
+++ b/blastest/src/cblat2.c
@@ -5451,7 +5451,7 @@ real sdiff_(real *x, real *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/cblat3.c
+++ b/blastest/src/cblat3.c
@@ -5815,7 +5815,7 @@ real sdiff_(real *x, real *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/dblat2.c
+++ b/blastest/src/dblat2.c
@@ -5143,7 +5143,7 @@ doublereal ddiff_(doublereal *x, doublereal *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/dblat3.c
+++ b/blastest/src/dblat3.c
@@ -4563,7 +4563,7 @@ doublereal ddiff_(doublereal *x, doublereal *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/sblat2.c
+++ b/blastest/src/sblat2.c
@@ -5105,7 +5105,7 @@ real sdiff_(real *x, real *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/sblat3.c
+++ b/blastest/src/sblat3.c
@@ -4538,7 +4538,7 @@ real sdiff_(real *x, real *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/zblat2.c
+++ b/blastest/src/zblat2.c
@@ -5500,7 +5500,7 @@ doublereal ddiff_(doublereal *x, doublereal *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="

--- a/blastest/src/zblat3.c
+++ b/blastest/src/zblat3.c
@@ -5850,7 +5850,7 @@ doublereal ddiff_(doublereal *x, doublereal *y)
 
 } /* chkxer_ */
 
-/* Subroutine */ int xerbla_(char *srname, integer *info, ftnlen srname_len)
+/* Subroutine */ BLIS_EXPORT_BLAS int xerbla_(char *srname, integer *info, ftnlen srname_len)
 {
     /* Format strings */
     static char fmt_9999[] = "(\002 ******* XERBLA WAS CALLED WITH INFO ="


### PR DESCRIPTION
Otherwise if only the shared library is built, the original
xerbla_ routine is used resulting in failing tests

Fixes #313