### PR TITLE
Avoid #pragma omp simd with GCC

### DIFF
--- a/configure
+++ b/configure
@@ -2756,8 +2756,13 @@ main()
 		enable_memkind_01=0
 	fi
 	if [ "x${pragma_omp_simd}" = "xyes" ]; then
-		echo "${script_name}: compiler appears to support #pragma omp simd."
-		enable_pragma_omp_simd_01=1
+		if [ "x${cc_vendor}" = "xgcc" ]; then
+			echo "${script_name}: #pragma omp simd not used with GCC."
+			enable_pragma_omp_simd_01=0
+		else
+			echo "${script_name}: compiler appears to support #pragma omp simd."
+			enable_pragma_omp_simd_01=1
+		fi
 	else
 		echo "${script_name}: compiler appears to not support #pragma omp simd."
 		enable_pragma_omp_simd_01=0

--- a/configure
+++ b/configure
@@ -2756,11 +2756,12 @@ main()
 		enable_memkind_01=0
 	fi
 	if [ "x${pragma_omp_simd}" = "xyes" ]; then
+		echo "${script_name}: compiler appears to support #pragma omp simd."
 		if [ "x${cc_vendor}" = "xgcc" ]; then
-			echo "${script_name}: #pragma omp simd not used with GCC."
+			echo "${script_name}: however, BLIS does not use #pragma omp simd with gcc."
 			enable_pragma_omp_simd_01=0
 		else
-			echo "${script_name}: compiler appears to support #pragma omp simd."
+			echo "${script_name}: enabling #pragma omp simd."
 			enable_pragma_omp_simd_01=1
 		fi
 	else


### PR DESCRIPTION
It just uses SIMD, and not FMA, at least for x86_64.  Versions that
support that pragma do the vectorization automatically anyhow.