### PR TITLE
Always use sqsumv to compute normfv.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -83,6 +83,7 @@ but many others have contributed code and feedback, including
   Benda Xu              @heroxbd
   Costas Yamin          @cosstas
   Chenhan Yu            @ChenhanYu          (The University of Texas at Austin)
+  Roman Yurchak         @rth                (Symerio)
   M. Zhou               @cdluminate
 
 BLIS's development was partially funded by grants from industry

--- a/frame/util/bli_util_unb_var1.c
+++ b/frame/util/bli_util_unb_var1.c
@@ -311,7 +311,7 @@ GENTFUNCR( scomplex, float,  c, s, normfv_unb_var1, sumsqv_unb_var1 )
 GENTFUNCR( dcomplex, double, z, d, normfv_unb_var1, sumsqv_unb_var1 )
 
 #undef  GENTFUNCR
-#ifdef FE_OVERFLOW
+#if defined(FE_OVERFLOW) && !defined(__APPLE__)
 #define GENTFUNCR( ctype, ctype_r, ch, chr, varname, kername ) \
 \
 void PASTEMAC(ch,varname) \

--- a/frame/util/bli_util_unb_var1.c
+++ b/frame/util/bli_util_unb_var1.c
@@ -311,6 +311,13 @@ GENTFUNCR( scomplex, float,  c, s, normfv_unb_var1, sumsqv_unb_var1 )
 GENTFUNCR( dcomplex, double, z, d, normfv_unb_var1, sumsqv_unb_var1 )
 
 #undef  GENTFUNCR
+// We've disabled the dotv-based implementation because that method of
+// computing the sum of the squares of x inherently does not check for
+// overflow. Instead, we use the fallback method based on sumsqv, which
+// takes care to not overflow unnecessarily (ie: takes care for the
+// sqrt( sum of the squares of x ) to not overflow if the sum of the
+// squares of x would normally overflow. See GitHub issue #332 for
+// discussion.
 #if 0 //defined(FE_OVERFLOW) && !defined(__APPLE__)
 #define GENTFUNCR( ctype, ctype_r, ch, chr, varname, kername ) \
 \

--- a/frame/util/bli_util_unb_var1.c
+++ b/frame/util/bli_util_unb_var1.c
@@ -311,7 +311,7 @@ GENTFUNCR( scomplex, float,  c, s, normfv_unb_var1, sumsqv_unb_var1 )
 GENTFUNCR( dcomplex, double, z, d, normfv_unb_var1, sumsqv_unb_var1 )
 
 #undef  GENTFUNCR
-#if defined(FE_OVERFLOW) && !defined(__APPLE__)
+#if 0 //defined(FE_OVERFLOW) && !defined(__APPLE__)
 #define GENTFUNCR( ctype, ctype_r, ch, chr, varname, kername ) \
 \
 void PASTEMAC(ch,varname) \


### PR DESCRIPTION
Fixes #332, but don't merge until @rth confirms the problem is MacOS and not something else.