### PR TITLE
Fix description for function bli_*pxby2v

### DIFF
--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -845,7 +845,7 @@ void bli_?axpy2v
 ```
 Perform
 ```
-  y := y + alphax * conjx(x) + alphay * conjy(y)
+  z := y + alphax * conjx(x) + alphay * conjy(y)
 ```
 where `x`, `y`, and `z` are vectors of length _m_. The kernel, if optimized, is implemented as a fused pair of calls to [axpyv](BLISTypedAPI.md#axpyv).
 


### PR DESCRIPTION
Revise the description of this function to reflect that the sum of the scaled elements of each vector are saved into a 3rd vector, rather than overwriting one of the original vectors.