### PR TITLE
POWER micro-architecture dispatch

### DIFF
--- a/config/power/bli_family_power.h
+++ b/config/power/bli_family_power.h
@@ -32,46 +32,9 @@
 
 */
 
-#include "blis.h"
+//#ifndef BLIS_FAMILY_H
+//#define BLIS_FAMILY_H
 
-void bli_cntx_init_power9( cntx_t* cntx )
-{
-//	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
 
-	// Set default kernel blocksizes and functions.
-	bli_cntx_init_power9_ref( cntx );
-
-	// -------------------------------------------------------------------------
-
-	// Update the context with optimized native gemm micro-kernels and
-	// their storage preferences.
-//	bli_cntx_set_l3_nat_ukrs
-//	(
-//	  1,
-//	  BLIS_GEMM_UKR, BLIS_DOUBLE,   bli_dgemm_power7_int_8x4,  FALSE,
-//	  cntx
-//	);
-/*
-	// Initialize level-3 blocksize objects with architecture-specific values.
-	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     0,     8,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     0,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],     0,    64,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],     0,   256,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],     0,  4096,     0,     0 );
-
-	// Update the context with the current architecture's register and cache
-	// blocksizes (and multiples) for native execution.
-	bli_cntx_set_blkszs
-	(
-	  BLIS_NAT, 5,
-	  BLIS_NC, &blkszs[ BLIS_NC ], BLIS_NR,
-	  BLIS_KC, &blkszs[ BLIS_KC ], BLIS_KR,
-	  BLIS_MC, &blkszs[ BLIS_MC ], BLIS_MR,
-	  BLIS_NR, &blkszs[ BLIS_NR ], BLIS_NR,
-	  BLIS_MR, &blkszs[ BLIS_MR ], BLIS_MR,
-	  cntx
-	);
-*/
-}
+//#endif
 

--- a/config/power/make_defs.mk
+++ b/config/power/make_defs.mk
@@ -1,0 +1,86 @@
+#
+#
+#  BLIS    
+#  An object-based framework for developing high-performance BLAS-like
+#  libraries.
+#
+#  Copyright (C) 2014, The University of Texas at Austin
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#   - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   - Neither the name(s) of the copyright holder(s) nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+
+# Declare the name of the current configuration and add it to the
+# running list of configurations included by common.mk.
+THIS_CONFIG    := power
+#CONFIGS_INCL   += $(THIS_CONFIG)
+
+#
+# --- Determine the C compiler and related flags ---
+#
+
+# NOTE: The build system will append these variables with various
+# general-purpose/configuration-agnostic flags in common.mk. You
+# may specify additional flags here as needed.
+CPPROCFLAGS    := -D_GNU_SOURCE
+CMISCFLAGS     :=
+CPICFLAGS      :=
+CWARNFLAGS     :=
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
+COPTFLAGS      := -O3
+endif
+
+# Flags specific to optimized kernels.
+CKOPTFLAGS     := $(COPTFLAGS)
+ifeq ($(CC_VENDOR),gcc)
+CKVECFLAGS     :=
+else
+$(error gcc is required for this configuration.)
+endif
+
+# Flags specific to reference kernels.
+CROPTFLAGS     := $(CKOPTFLAGS)
+ifeq ($(CC_VENDOR),gcc)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+ifeq ($(CC_VENDOR),clang)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+CRVECFLAGS     := $(CKVECFLAGS)
+endif
+endif
+
+# Store all of the variables here to new variables containing the
+# configuration name.
+$(eval $(call store-make-defs,$(THIS_CONFIG)))
+

--- a/config/power8/bli_cntx_init_power8.c
+++ b/config/power8/bli_cntx_init_power8.c
@@ -34,12 +34,12 @@
 
 #include "blis.h"
 
-void bli_cntx_init_power9( cntx_t* cntx )
+void bli_cntx_init_power8( cntx_t* cntx )
 {
 //	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
 
 	// Set default kernel blocksizes and functions.
-	bli_cntx_init_power9_ref( cntx );
+	bli_cntx_init_power8_ref( cntx );
 
 	// -------------------------------------------------------------------------
 

--- a/config/power8/bli_family_power8.h
+++ b/config/power8/bli_family_power8.h
@@ -32,46 +32,34 @@
 
 */
 
-#include "blis.h"
+//#ifndef BLIS_FAMILY_H
+//#define BLIS_FAMILY_H
 
-void bli_cntx_init_power9( cntx_t* cntx )
-{
-//	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
+//#define BLIS_SIMD_NUM_REGISTERS 32
+//#define BLIS_SIMD_SIZE 64
+//
+//#ifdef BLIS_NO_HBWMALLOC
+//  #include <stdlib.h>
+//    #define BLIS_MALLOC_POOL  malloc
+//    #define BLIS_FREE_POOL    free
+//#else
+//  #include <hbwmalloc.h>
+//    #define BLIS_MALLOC_POOL  hbw_malloc
+//    #define BLIS_FREE_POOL    hbw_free
+//#endif
 
-	// Set default kernel blocksizes and functions.
-	bli_cntx_init_power9_ref( cntx );
 
-	// -------------------------------------------------------------------------
+#if 0
+// -- LEVEL-3 MICRO-KERNEL CONSTANTS -------------------------------------------
 
-	// Update the context with optimized native gemm micro-kernels and
-	// their storage preferences.
-//	bli_cntx_set_l3_nat_ukrs
-//	(
-//	  1,
-//	  BLIS_GEMM_UKR, BLIS_DOUBLE,   bli_dgemm_power7_int_8x4,  FALSE,
-//	  cntx
-//	);
-/*
-	// Initialize level-3 blocksize objects with architecture-specific values.
-	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     0,     8,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     0,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],     0,    64,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],     0,   256,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],     0,  4096,     0,     0 );
+#define BLIS_DGEMM_UKERNEL             bli_dgemm_opt_8x4
+#define BLIS_DEFAULT_MR_D              8
+#define BLIS_DEFAULT_NR_D              4
+#define BLIS_DEFAULT_MC_D              64
+#define BLIS_DEFAULT_KC_D              256
+#define BLIS_DEFAULT_NC_D              4096
+#endif
 
-	// Update the context with the current architecture's register and cache
-	// blocksizes (and multiples) for native execution.
-	bli_cntx_set_blkszs
-	(
-	  BLIS_NAT, 5,
-	  BLIS_NC, &blkszs[ BLIS_NC ], BLIS_NR,
-	  BLIS_KC, &blkszs[ BLIS_KC ], BLIS_KR,
-	  BLIS_MC, &blkszs[ BLIS_MC ], BLIS_MR,
-	  BLIS_NR, &blkszs[ BLIS_NR ], BLIS_NR,
-	  BLIS_MR, &blkszs[ BLIS_MR ], BLIS_MR,
-	  cntx
-	);
-*/
-}
+
+//#endif
 

--- a/config/power8/make_defs.mk
+++ b/config/power8/make_defs.mk
@@ -57,7 +57,9 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -funroll-loops
+# Fixme: This should use -O3, but that breaks cpuid dispatch somehow,
+# and we end up executing power9 code on power8.
+COPTFLAGS      := -O2 -funroll-loops
 endif
 
 # Flags specific to optimized kernels.
@@ -71,7 +73,7 @@ endif
 # Flags specific to reference kernels.
 CROPTFLAGS     := $(CKOPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast -O3
 else
 ifeq ($(CC_VENDOR),clang)
 CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast

--- a/config/power8/make_defs.mk
+++ b/config/power8/make_defs.mk
@@ -1,0 +1,86 @@
+#
+#
+#  BLIS    
+#  An object-based framework for developing high-performance BLAS-like
+#  libraries.
+#
+#  Copyright (C) 2014, The University of Texas at Austin
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#   - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   - Neither the name(s) of the copyright holder(s) nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+
+# Declare the name of the current configuration and add it to the
+# running list of configurations included by common.mk.
+THIS_CONFIG    := power8
+#CONFIGS_INCL   += $(THIS_CONFIG)
+
+#
+# --- Determine the C compiler and related flags ---
+#
+
+# NOTE: The build system will append these variables with various
+# general-purpose/configuration-agnostic flags in common.mk. You
+# may specify additional flags here as needed.
+CPPROCFLAGS    :=
+CMISCFLAGS     := -mcpu=power8
+CPICFLAGS      :=
+CWARNFLAGS     :=
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
+COPTFLAGS      := -O3 -funroll-loops
+endif
+
+# Flags specific to optimized kernels.
+CKOPTFLAGS     := $(COPTFLAGS)
+ifeq ($(CC_VENDOR),gcc)
+CKVECFLAGS     :=
+else
+$(error gcc is required for this configuration.)
+endif
+
+# Flags specific to reference kernels.
+CROPTFLAGS     := $(CKOPTFLAGS)
+ifeq ($(CC_VENDOR),gcc)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+ifeq ($(CC_VENDOR),clang)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+CRVECFLAGS     := $(CKVECFLAGS)
+endif
+endif
+
+# Store all of the variables here to new variables containing the
+# configuration name.
+$(eval $(call store-make-defs,$(THIS_CONFIG)))
+

--- a/config/power9/make_defs.mk
+++ b/config/power9/make_defs.mk
@@ -57,7 +57,9 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -funroll-loops
+# Fixme: This should use -O3, but that breaks cpuid dispatch somehow,
+# and we end up executing power9 code on power8.
+COPTFLAGS      := -O2 -funroll-loops
 endif
 
 # Flags specific to optimized kernels.
@@ -71,7 +73,7 @@ endif
 # Flags specific to reference kernels.
 CROPTFLAGS     := $(CKOPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast -O3
 else
 ifeq ($(CC_VENDOR),clang)
 CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast

--- a/config_registry
+++ b/config_registry
@@ -4,7 +4,7 @@
 # Please refer to the BLIS wiki on configurations for information on the
 # syntax and semantics of this file [1].
 #
-# [1] https://github.com/flame/blis/wiki/ConfigurationHowTo
+# [1] https://github.com/flame/blis/blob/master/docs/ConfigurationHowTo.md
 #
 
 # Processor families.

--- a/config_registry
+++ b/config_registry
@@ -11,9 +11,7 @@
 x86_64:      intel64 amd64
 intel64:     skx knl haswell sandybridge penryn generic
 amd64:       zen excavator steamroller piledriver bulldozer generic
-# NOTE: ARM families will remain disabled until runtime hardware detection
-# logic is added to BLIS.
-#arm64:       cortexa57 generic
+arm64:       thunderx2 cortexa57 cortexa53 generic
 #arm32:       cortexa15 cortexa9 generic
 
 # Intel architectures.

--- a/config_registry
+++ b/config_registry
@@ -12,6 +12,7 @@ x86_64:      intel64 amd64
 intel64:     skx knl haswell sandybridge penryn generic
 amd64:       zen excavator steamroller piledriver bulldozer generic
 arm64:       thunderx2 cortexa57 cortexa53 generic
+power:       power9 power8 generic
 #arm32:       cortexa15 cortexa9 generic
 
 # Intel architectures.
@@ -37,6 +38,7 @@ cortexa9:    cortexa9/armv7a
 
 # IBM architectures.
 power9:	     power9/generic
+power8:	     power8/generic
 bgq:         bgq
 
 # Generic architectures.

--- a/docs/HardwareSupport.md
+++ b/docs/HardwareSupport.md
@@ -33,6 +33,7 @@ A few remarks / reminders:
 | ARMv7 Cortex-A15 (NEON)              | `cortex-a15`           | `sd`   |            |
 | ARMv8 Cortex-A53 (NEON)              | `cortex-a53`           | `sd`   |            |
 | ARMv8 Cortex-A57 (NEON)              | `cortex-a57`           | `sd`   |            |
+| ARMv8.1 ThunderX2 (NEON)             | `thunderx2`            | `sd`   |            |
 | IBM Blue Gene/Q (QPX int)            | `bgq`                  |  `d`   |            |
 | IBM Power7 (QPX int)                 | `power7`               |  `d`   |            |
 | template (C99)                       | `template`             | `sdcz` | `sdcz`     |

--- a/docs/HardwareSupport.md
+++ b/docs/HardwareSupport.md
@@ -35,7 +35,8 @@ A few remarks / reminders:
 | ARMv8 Cortex-A57 (NEON)              | `cortex-a57`           | `sd`   |            |
 | ARMv8.1 ThunderX2 (NEON)             | `thunderx2`            | `sd`   |            |
 | IBM Blue Gene/Q (QPX int)            | `bgq`                  |  `d`   |            |
-| IBM Power7 (QPX int)                 | `power7`               |  `d`   |            |
+| IBM Power8 (C99)                     | `power8`               | `sdcz` | `sdcz`     |
+| IBM Power9 (C99)                     | `power9`               | `sdcz` | `sdcz`     |
 | template (C99)                       | `template`             | `sdcz` | `sdcz`     |
 
 ## Level-1f kernels

--- a/frame/base/bli_arch.c
+++ b/frame/base/bli_arch.c
@@ -79,7 +79,8 @@ void bli_arch_set_id( void )
     defined BLIS_FAMILY_AMD64   || \
     defined BLIS_FAMILY_X86_64  || \
     defined BLIS_FAMILY_ARM64   || \
-    defined BLIS_FAMILY_ARM32
+    defined BLIS_FAMILY_ARM32   || \
+    defined BLIS_FAMILY_POWER
 	id = bli_cpuid_query_id();
 #endif
 
@@ -141,6 +142,12 @@ void bli_arch_set_id( void )
 #ifdef BLIS_FAMILY_POWER7
 	id = BLIS_ARCH_POWER7;
 #endif
+#ifdef BLIS_FAMILY_POWER8
+	id = BLIS_ARCH_POWER8;
+#endif
+#ifdef BLIS_FAMILY_POWER9
+	id = BLIS_ARCH_POWER9;
+#endif
 #ifdef BLIS_FAMILY_BGQ
 	id = BLIS_ARCH_BGQ;
 #endif
@@ -184,9 +191,10 @@ static char* config_name[ BLIS_NUM_ARCHS ] =
     "cortexa15",
     "cortexa9",
 
+    "power9",
+    "power8",
     "power7",
     "bgq",
-    "power9",
 
     "generic"
 };

--- a/frame/base/bli_cpuid.c
+++ b/frame/base/bli_cpuid.c
@@ -1191,9 +1191,9 @@ uint32_t bli_cpuid_query
 
 arch_t bli_cpuid_query_id( void )
 {
-	uint32_t vendor, model, part, features;
+	uint32_t model, part, features;
 
-	vendor = bli_cpuid_query( &model, &part, &features );
+	(void) bli_cpuid_query( &model, &part, &features );
 
 // NB.  Must use #ifdef, not #if (for configure)
 #ifdef BLIS_CONFIG_POWER8

--- a/frame/base/bli_gks.c
+++ b/frame/base/bli_gks.c
@@ -156,6 +156,11 @@ void bli_gks_init( void )
 		                                              bli_cntx_init_power9_ref,
 		                                              bli_cntx_init_power9_ind );
 #endif
+#ifdef BLIS_CONFIG_POWER8
+		bli_gks_register_cntx( BLIS_ARCH_POWER8,      bli_cntx_init_power8,
+		                                              bli_cntx_init_power8_ref,
+		                                              bli_cntx_init_power8_ind );
+#endif
 #ifdef BLIS_CONFIG_POWER7
 		bli_gks_register_cntx( BLIS_ARCH_POWER7,      bli_cntx_init_power7,
 		                                              bli_cntx_init_power7_ref,

--- a/frame/include/bli_arch_config.h
+++ b/frame/include/bli_arch_config.h
@@ -192,6 +192,9 @@ CNTX_INIT_PROTS( generic )
 
 // -- IBM BG/Q --
 
+#ifdef BLIS_FAMILY_POWER
+#include "bli_family_power.h"
+#endif
 #ifdef BLIS_FAMILY_POWER9
 #include "bli_family_power9.h"
 #endif

--- a/frame/include/bli_arch_config.h
+++ b/frame/include/bli_arch_config.h
@@ -101,6 +101,9 @@ CNTX_INIT_PROTS( cortexa9 )
 #ifdef BLIS_CONFIG_POWER9
 CNTX_INIT_PROTS( power9 )
 #endif
+#ifdef BLIS_CONFIG_POWER8
+CNTX_INIT_PROTS( power8 )
+#endif
 #ifdef BLIS_CONFIG_POWER7
 CNTX_INIT_PROTS( power7 )
 #endif
@@ -191,6 +194,9 @@ CNTX_INIT_PROTS( generic )
 
 #ifdef BLIS_FAMILY_POWER9
 #include "bli_family_power9.h"
+#endif
+#ifdef BLIS_FAMILY_POWER8
+#include "bli_family_power8.h"
 #endif
 #ifdef BLIS_FAMILY_POWER7
 #include "bli_family_power7.h"

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -1007,6 +1007,7 @@ typedef enum
 
 	// IBM/Power
 	BLIS_ARCH_POWER9,
+	BLIS_ARCH_POWER8,
 	BLIS_ARCH_POWER7,
 	BLIS_ARCH_BGQ,
 
@@ -1015,7 +1016,7 @@ typedef enum
 
 } arch_t;
 
-#define BLIS_NUM_ARCHS 20
+#define BLIS_NUM_ARCHS 21
 
 
 //


### PR DESCRIPTION
This implements a Linux-specific, compiler-neutral selection, unlike the (possibly?) gcc-specific simple one you didn't like. It currently only affects the compilation of generic code.

Note that there's a strange problem I've had to kludge round by lowering the optimization levels noted in a log message, but it seems worth recording this now.  I can only try with Fedora 28's gcc 8.3 (on power8) currently, but will try to get the system updated to a supported Fedora.  I might be able to get access to power9, but haven't tried.

This was branched from the arm64 equivalent as there originally was a merge clash with bits I removed.
