### PR TITLE
Add .dir-locals.el for Emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,8 @@
+;; First (minimal) attempt at configuring Emacs CC mode for the BLIS
+;; layout requirements.
+((nil . ((indent-tabs-mode . t)
+	 (tab-width . 4)
+	 (parens-require-spaces . nil)))
+ (c-mode . ((c-file-style . "stroustrup")
+	    (c-basic-offset . 4)
+            (subdirs . nil))))


### PR DESCRIPTION
This is some basic configuration of editing with Emacs according to the documented coding conventions. It applies automatically for editing files in the blis directory.