### PR TITLE
Don't override -mcpu with -march on ARM

### DIFF
--- a/config/cortexa15/make_defs.mk
+++ b/config/cortexa15/make_defs.mk
@@ -63,7 +63,7 @@ endif
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -mcpu=cortexa15
+CKVECFLAGS     := -mcpu=cortex-a15
 else
 $(error gcc is required for this configuration.)
 endif

--- a/config/cortexa15/make_defs.mk
+++ b/config/cortexa15/make_defs.mk
@@ -63,7 +63,7 @@ endif
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -march=armv7-a
+CKVECFLAGS     := -mcpu=cortexa15
 else
 $(error gcc is required for this configuration.)
 endif

--- a/config/cortexa53/make_defs.mk
+++ b/config/cortexa53/make_defs.mk
@@ -57,7 +57,9 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -mcpu=cortex-a53
+# Use -O2 here to avoid issue #341 -- BLAS check failing, using GCC 8.
+# (It's at least  -ftree-loop-vectorize which causes the trouble.)
+COPTFLAGS      := -O2 -mcpu=cortex-a53
 endif
 
 # Flags specific to optimized kernels.
@@ -69,7 +71,7 @@ $(error gcc is required for this configuration.)
 endif
 
 # Flags specific to reference kernels.
-CROPTFLAGS     := $(CKOPTFLAGS)
+CROPTFLAGS     := $(CKOPTFLAGS) -O3
 ifeq ($(CC_VENDOR),gcc)
 CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
 else

--- a/config/cortexa53/make_defs.mk
+++ b/config/cortexa53/make_defs.mk
@@ -57,13 +57,13 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -ftree-vectorize -mtune=cortex-a53
+COPTFLAGS      := -O3 -mcpu=cortex-a53
 endif
 
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -march=armv8-a+fp+simd -mcpu=cortex-a53
+CKVECFLAGS     := -mcpu=cortex-a53
 else
 $(error gcc is required for this configuration.)
 endif

--- a/config/cortexa57/make_defs.mk
+++ b/config/cortexa57/make_defs.mk
@@ -57,13 +57,13 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -ftree-vectorize -mtune=cortex-a57
+COPTFLAGS      := -O3 -mcpu=cortex-a57
 endif
 
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -march=armv8-a+fp+simd -mcpu=cortex-a57
+CKVECFLAGS     := -mcpu=cortex-a57
 else
 $(error gcc is required for this configuration.)
 endif

--- a/config/cortexa9/make_defs.mk
+++ b/config/cortexa9/make_defs.mk
@@ -63,7 +63,7 @@ endif
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -mcpu=cortexa9
+CKVECFLAGS     := -mcpu=cortex-a9
 else
 $(error gcc is required for this configuration.)
 endif

--- a/config/cortexa9/make_defs.mk
+++ b/config/cortexa9/make_defs.mk
@@ -63,7 +63,7 @@ endif
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -march=armv7-a
+CKVECFLAGS     := -mcpu=cortexa9
 else
 $(error gcc is required for this configuration.)
 endif

--- a/config/thunderx2/make_defs.mk
+++ b/config/thunderx2/make_defs.mk
@@ -57,13 +57,13 @@ endif
 ifeq ($(DEBUG_TYPE),noopt)
 COPTFLAGS      := -O0
 else
-COPTFLAGS      := -O3 -ftree-vectorize -mtune=thunderx2t99
+COPTFLAGS      := -O3 -mcpu=thunderx2t99
 endif
 
 # Flags specific to optimized kernels.
 CKOPTFLAGS     := $(COPTFLAGS)
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := -march=armv8.1-a+fp+simd -mcpu=thunderx2t99
+CKVECFLAGS     := -mcpu=thunderx2t99
 else
 $(error gcc is required for this configuration.)
 endif


### PR DESCRIPTION
Use -mcpu for ARM
See the GCC doc about -march, -mtune, and -mpu and maybe
https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
