### PR TITLE
Fixed bug in amaxv which returned incorrect index on constant input.

### DIFF
--- a/kernels/zen/1/bli_amaxv_zen_int.c
+++ b/kernels/zen/1/bli_amaxv_zen_int.c
@@ -183,7 +183,7 @@ void bli_samaxv_zen_int
 		max_vec_lo.v    = _mm_blendv_ps( max_vec_lo.v, max_vec_hi.v, mask_vec_lo.v );
 		maxInx_vec_lo.v = _mm_blendv_ps( maxInx_vec_lo.v, maxInx_vec_hi.v, mask_vec_lo.v );
 
-		if ( max_vec_lo.f[0] > max_vec_lo.f[1] )
+		if ( max_vec_lo.f[0] >= max_vec_lo.f[1] )
 		{
 			abs_chi1_max = max_vec_lo.f[0];
 			i_max_l      = maxInx_vec_lo.f[0];
@@ -340,7 +340,7 @@ void bli_damaxv_zen_int
 		maxInx_vec_hi.v = _mm256_extractf128_pd( maxInx_vec.v, 1 );
 		maxInx_vec_lo.v = _mm_blendv_pd( maxInx_vec_lo.v, maxInx_vec_hi.v, mask_vec_lo.v );
 
-		if ( max_vec_lo.d[0] > max_vec_lo.d[1] )
+		if ( max_vec_lo.d[0] >= max_vec_lo.d[1] )
 		{
 			abs_chi1_max = max_vec_lo.d[0];
 			i_max_l      = maxInx_vec_lo.d[0];


### PR DESCRIPTION
Hi,

A constant vector with increment 1 and more than 3 elements gets the wrong amaxv index computed because of an incorrect comparison operator when initializing i_max_l.

We at NAG noticed this was affecting a few of our LAPACK test programs.

I'm afraid I didn't look into an associated test case for the BLIS framework. I do have a Fortran test program, if that helps at all:

```
   Program p
     Double Precision, Allocatable :: x(:)
     x = [ (42.D0,i=1,4) ]
     If (idamax(size(x),x,1)/=1) Stop 'FAIL'
     Print *, 'ok'
   End Program
```
