### PR TITLE
OSX: specify the full path to the location of libblis.dylib

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -15,6 +15,7 @@ but many others have contributed code and feedback, including
   Erling Andersen          @erling-d-andersen
   Alex Arslan              @ararslan
   Vernon Austel                                (IBM, T.J. Watson Research Center)
+  Satish Balay             @balay              (Argonne National Laboratory)
   Matthew Brett            @matthew-brett      (University of Birmingham)
   Jed Brown                @jedbrown           (Argonne National Laboratory)
   Robin Christ             @robinchrist

--- a/common.mk
+++ b/common.mk
@@ -515,7 +515,7 @@ endif
 ifeq ($(OS_NAME),Darwin)
 # OS X shared library link flags.
 SOFLAGS    := -dynamiclib
-SOFLAGS    += -Wl,-install_name,$(LIBBLIS_SONAME)
+SOFLAGS    += -Wl,-install_name,$(INSTALL_LIBDIR)/$(LIBBLIS_SONAME)
 else
 SOFLAGS    := -shared
 ifeq ($(IS_WIN),yes)

--- a/common.mk
+++ b/common.mk
@@ -515,7 +515,7 @@ endif
 ifeq ($(OS_NAME),Darwin)
 # OS X shared library link flags.
 SOFLAGS    := -dynamiclib
-SOFLAGS    += -Wl,-install_name,$(INSTALL_LIBDIR)/$(LIBBLIS_SONAME)
+SOFLAGS    += -Wl,-install_name,$(libdir)/$(LIBBLIS_SONAME)
 else
 SOFLAGS    := -shared
 ifeq ($(IS_WIN),yes)
@@ -1056,5 +1056,4 @@ BUILD_CPPFLAGS := -DBLIS_IS_BUILDING_LIBRARY
 
 # end of ifndef COMMON_MK_INCLUDED conditional block
 endif
-
 


### PR DESCRIPTION
OSX: specify the full path to the location of libblis.dylib so that it can be found at runtime

Before this change:

Appication gives runtime error [when linked with blis]
```
dyld: Library not loaded: libblis.3.dylib
```
```
balay@kpro lib % otool -L libblis.dylib
libblis.dylib:
        libblis.3.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
After this change:
```
balay@kpro lib % otool -L libblis.dylib
libblis.dylib:
	/Users/balay/petsc/arch-darwin-c-debug/lib/libblis.3.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```

Note: this build  is with:
```
Executing: ['./configure', '--prefix=/Users/balay/petsc/arch-darwin-c-debug', '--enable-threading=no', 'CC=gcc', 'auto']
```
```