### PR TITLE
New GEMM Assembly & Configuration Set for Arm SVE 

### DIFF
--- a/config/armsve/bli_cntx_init_armsve.c
+++ b/config/armsve/bli_cntx_init_armsve.c
@@ -1,0 +1,95 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+
+void bli_cntx_init_armsve( cntx_t* cntx )
+{
+	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
+
+	// Set default kernel blocksizes and functions.
+	bli_cntx_init_armsve_ref( cntx );
+
+	// Get SVE vector length, in number of 64-bit words.
+	uint64_t vlen;
+	__asm__ volatile (
+" mov  x0, xzr  \n\t"
+" incd x0       \n\t"
+" str  x0, %[v] \n\t"
+	: [v] "=m" (vlen)
+	: );
+	// Determine kernel based on SVE vector length.
+	// Now that we have 256 and 512 bits supported.
+	void_fp bli_dgemm_armsve_asm_use;
+	uint64_t mr_d = 0, nr_d = 0, mc_d = 0, nc_d = 0;
+	switch (vlen) {
+		case 4:  bli_dgemm_armsve_asm_use = bli_dgemm_armsve256_asm_8x8;   mr_d = 8;  nr_d = 8;  mc_d = 160; nc_d = 3072; break;
+		case 8:  bli_dgemm_armsve_asm_use = bli_dgemm_armsve512_asm_16x12; mr_d = 16; nr_d = 12; mc_d = 160; nc_d = 3072; break;
+		default: bli_dgemm_armsve_asm_use = bli_dgemm_armv8a_asm_6x8;      mr_d = 6;  nr_d = 8;  mc_d = 120; nc_d = 3072; break;
+	}
+
+	// -------------------------------------------------------------------------
+
+	// Update the context with optimized native gemm micro-kernels and
+	// their storage preferences.
+	bli_cntx_set_l3_nat_ukrs
+	(
+	  2,
+	  BLIS_GEMM_UKR, BLIS_FLOAT,    bli_sgemm_armv8a_asm_8x12, FALSE,
+	  BLIS_GEMM_UKR, BLIS_DOUBLE,   bli_dgemm_armsve_asm_use,  FALSE,
+	  cntx
+	);
+
+	// Initialize level-3 blocksize objects with architecture-specific values.
+	//                                           s      d      c      z
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     8,  mr_d,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    12,  nr_d,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   120,  mc_d,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   640,   240,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  3072,  nc_d,    -1,    -1 );
+
+	// Update the context with the current architecture's register and cache
+	// blocksizes (and multiples) for native execution.
+	bli_cntx_set_blkszs
+	(
+	  BLIS_NAT, 5,
+	  BLIS_NC, &blkszs[ BLIS_NC ], BLIS_NR,
+	  BLIS_KC, &blkszs[ BLIS_KC ], BLIS_KR,
+	  BLIS_MC, &blkszs[ BLIS_MC ], BLIS_MR,
+	  BLIS_NR, &blkszs[ BLIS_NR ], BLIS_NR,
+	  BLIS_MR, &blkszs[ BLIS_MR ], BLIS_MR,
+	  cntx
+	);
+}
+

--- a/config/armsve/bli_family_armsve.h
+++ b/config/armsve/bli_family_armsve.h
@@ -1,0 +1,47 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+//#ifndef BLIS_FAMILY_H
+//#define BLIS_FAMILY_H
+
+
+// -- MEMORY ALLOCATION --------------------------------------------------------
+
+#define BLIS_SIMD_ALIGN_SIZE 64
+
+#define BLIS_SIMD_NUM_REGISTERS 32
+
+
+//#endif
+

--- a/config/armsve/make_defs.mk
+++ b/config/armsve/make_defs.mk
@@ -1,0 +1,82 @@
+#
+#
+#  BLIS
+#  An object-based framework for developing high-performance BLAS-like
+#  libraries.
+#
+#  Copyright (C) 2014, The University of Texas at Austin
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#   - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   - Neither the name(s) of the copyright holder(s) nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+
+# Declare the name of the current configuration and add it to the
+# running list of configurations included by common.mk.
+THIS_CONFIG    := armsve
+#CONFIGS_INCL   += $(THIS_CONFIG)
+
+#
+# --- Determine the C compiler and related flags ---
+#
+
+# NOTE: The build system will append these variables with various
+# general-purpose/configuration-agnostic flags in common.mk. You
+# may specify additional flags here as needed.
+CPPROCFLAGS    := -D_GNU_SOURCE
+CMISCFLAGS     :=
+CPICFLAGS      :=
+CWARNFLAGS     :=
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
+COPTFLAGS      := -O3 -ftree-vectorize -march=armv8-a+sve
+endif
+
+# Flags specific to optimized kernels.
+CKOPTFLAGS     := $(COPTFLAGS)
+CKVECFLAGS     :=
+
+# Flags specific to reference kernels.
+CROPTFLAGS     := $(CKOPTFLAGS)
+ifeq ($(CC_VENDOR),gcc)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+ifeq ($(CC_VENDOR),clang)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+CRVECFLAGS     := $(CKVECFLAGS)
+endif
+endif
+
+# Store all of the variables here to new variables containing the
+# configuration name.
+$(eval $(call store-make-defs,$(THIS_CONFIG)))
+

--- a/config_registry
+++ b/config_registry
@@ -35,6 +35,7 @@ bulldozer:   bulldozer
 thunderx2:   thunderx2/armv8a
 cortexa57:   cortexa57/armv8a
 cortexa53:   cortexa53/armv8a
+armsve:      armsve/armsve/armv8a
 cortexa15:   cortexa15/armv7a
 cortexa9:    cortexa9/armv7a
 

--- a/frame/base/bli_arch.c
+++ b/frame/base/bli_arch.c
@@ -140,6 +140,9 @@ void bli_arch_set_id( void )
 #ifdef BLIS_FAMILY_CORTEXA53
 	id = BLIS_ARCH_CORTEXA53;
 #endif
+#ifdef BLIS_FAMILY_ARMSVE
+	id = BLIS_ARCH_ARMSVE;
+#endif
 #ifdef BLIS_FAMILY_CORTEXA15
 	id = BLIS_ARCH_CORTEXA15;
 #endif
@@ -196,6 +199,7 @@ static char* config_name[ BLIS_NUM_ARCHS ] =
     "thunderx2",
     "cortexa57",
     "cortexa53",
+    "armsve",
     "cortexa15",
     "cortexa9",
 

--- a/frame/base/bli_cpuid.c
+++ b/frame/base/bli_cpuid.c
@@ -76,7 +76,7 @@ arch_t bli_cpuid_query_id( void )
 	printf( "vendor   = %s\n", vendor==1 ? "AMD": "INTEL" );
 	printf("family    = %x\n", family );
 	printf( "model    = %x\n", model );
-	
+ 
 	printf( "features = %x\n", features );
 #endif
 
@@ -463,6 +463,10 @@ arch_t bli_cpuid_query_id( void )
 			if ( bli_cpuid_is_cortexa57( model, part, features ) )
 				return BLIS_ARCH_CORTEXA57;
 #endif
+#ifdef BLIS_CONFIG_ARMSVE
+			if ( bli_cpuid_is_armsve( model, part, features ) )
+				return BLIS_ARCH_ARMSVE;
+#endif
 			// If none of the other sub-configurations were detected, return
 			// the 'generic' arch_t id value.
 			return BLIS_ARCH_GENERIC;
@@ -531,6 +535,21 @@ bool_t bli_cpuid_is_cortexa53
 {
 	// Check for expected CPU features.
 	const uint32_t expected = FEATURE_NEON;
+
+	if ( !bli_cpuid_has_features( features, expected ) ) return FALSE;
+
+	return TRUE;
+}
+
+bool_t bli_cpuid_is_armsve
+     (
+       uint32_t family,
+       uint32_t model,
+       uint32_t features
+     )
+{
+	// Check for expected CPU features.
+	const uint32_t expected = FEATURE_SVE;
 
 	if ( !bli_cpuid_has_features( features, expected ) ) return FALSE;
 
@@ -1031,6 +1050,10 @@ uint32_t bli_cpuid_query
 	if ( strstr( feat_str, "neon"  ) != NULL ||
 	     strstr( feat_str, "asimd" ) != NULL )
 		*features |= FEATURE_NEON;
+
+	// Parse the feature string to check for SVE features.
+	if ( strstr( feat_str, "sve" ) != NULL )
+		*features |= FEATURE_SVE;
 
 	//printf( "bli_cpuid_query(): features var: %u\n", *features );
 

--- a/frame/base/bli_cpuid.h
+++ b/frame/base/bli_cpuid.h
@@ -72,6 +72,7 @@ bool_t   bli_cpuid_is_bulldozer( uint32_t family, uint32_t model, uint32_t featu
 bool_t   bli_cpuid_is_thunderx2( uint32_t model, uint32_t part, uint32_t features );
 bool_t   bli_cpuid_is_cortexa57( uint32_t model, uint32_t part, uint32_t features );
 bool_t   bli_cpuid_is_cortexa53( uint32_t model, uint32_t part, uint32_t features );
+bool_t   bli_cpuid_is_armsve( uint32_t model, uint32_t part, uint32_t features );
 bool_t   bli_cpuid_is_cortexa15( uint32_t model, uint32_t part, uint32_t features );
 bool_t   bli_cpuid_is_cortexa9( uint32_t model, uint32_t part, uint32_t features );
 
@@ -175,7 +176,8 @@ enum
 };
 enum
 {
-	FEATURE_NEON = 0x1
+	FEATURE_NEON = 0x01,
+	FEATURE_SVE  = 0x02
 };
 
 #endif

--- a/frame/base/bli_gks.c
+++ b/frame/base/bli_gks.c
@@ -144,6 +144,11 @@ void bli_gks_init( void )
 		                                              bli_cntx_init_cortexa53_ref,
 		                                              bli_cntx_init_cortexa53_ind );
 #endif
+#ifdef BLIS_CONFIG_ARMSVE
+		bli_gks_register_cntx( BLIS_ARCH_ARMSVE,      bli_cntx_init_armsve,
+		                                              bli_cntx_init_armsve_ref,
+		                                              bli_cntx_init_armsve_ind );
+#endif
 #ifdef BLIS_CONFIG_CORTEXA15
 		bli_gks_register_cntx( BLIS_ARCH_CORTEXA15,   bli_cntx_init_cortexa15,
 		                                              bli_cntx_init_cortexa15_ref,

--- a/frame/include/bli_arch_config.h
+++ b/frame/include/bli_arch_config.h
@@ -92,6 +92,9 @@ CNTX_INIT_PROTS( cortexa57 )
 #ifdef BLIS_CONFIG_CORTEXA53
 CNTX_INIT_PROTS( cortexa53 )
 #endif
+#ifdef BLIS_CONFIG_ARMSVE
+CNTX_INIT_PROTS( armsve )
+#endif
 #ifdef BLIS_CONFIG_CORTEXA15
 CNTX_INIT_PROTS( cortexa15 )
 #endif

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -1003,6 +1003,7 @@ typedef enum
 	BLIS_ARCH_THUNDERX2,
 	BLIS_ARCH_CORTEXA57,
 	BLIS_ARCH_CORTEXA53,
+	BLIS_ARCH_ARMSVE,
 	BLIS_ARCH_CORTEXA15,
 	BLIS_ARCH_CORTEXA9,
 
@@ -1018,7 +1019,7 @@ typedef enum
 
 // NOTE: This value must be updated to reflect the number of enum values
 // listed above for arch_t!
-#define BLIS_NUM_ARCHS 21
+#define BLIS_NUM_ARCHS 22
 
 
 //

--- a/kernels/armsve/3/bli_gemm_armsve512_asm_d16x12.c
+++ b/kernels/armsve/3/bli_gemm_armsve512_asm_d16x12.c
@@ -1,0 +1,738 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020, Dept. Physics, The University of Tokyo
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+#include "blis.h"
+
+/*
+   o 16x12 Double precision micro-kernel
+   o Runnable on ARMv8a with SVE 512 feature.
+   o Tested on armie for SVE.
+   o Tested on A64fx (GCC & Fujitsu-Clang compiler).
+   o Currently yields about 18GFlOps on A64fx @2.2GHz.
+   x Gather-load / Scatter-store does not support prefetching at the moment.
+
+   July 2020.
+*/
+void bli_dgemm_armsve512_asm_16x12
+     (
+       dim_t               k0,
+       double*    restrict alpha,
+       double*    restrict a,
+       double*    restrict b,
+       double*    restrict beta,
+       double*    restrict c, inc_t rs_c0, inc_t cs_c0,
+       auxinfo_t* restrict data,
+       cntx_t*    restrict cntx
+     )
+{
+  void* a_next = bli_auxinfo_next_a( data );
+  void* b_next = bli_auxinfo_next_b( data );
+
+  // Typecast local copies of integers in case dim_t and inc_t are a
+  // different size than is expected by load instructions.
+	uint64_t k_mker = k0 / 4;
+	uint64_t k_left = k0 % 4;
+  uint64_t rs_c   = rs_c0;
+  uint64_t cs_c   = cs_c0;
+
+__asm__ volatile (
+" mov             x9, #16                         \n\t" // Shape M, can be input
+"                                                 \n\t" // Shape N is fixed to be 12
+" ldr             x8, %[k_left]                   \n\t" // Shape K to be contracted
+" ldr             x21, %[k_mker]                  \n\t" // Size of K-microblock
+"                                                 \n\t"
+" ldr             x20, %[rs_c]                    \n\t" // Row-skip of C
+" ldr             x6, %[caddr]                    \n\t" // Load address of C
+" ldr             x7, %[cs_c]                     \n\t" // LdC, which is called column-skip in BLIS
+" cmp             x20, #1                         \n\t"
+"                                                 \n\t"
+" ldr             x0, %[alpha]                    \n\t" // Alpha address
+" ldr             x1, %[beta]                     \n\t" // Beta address
+"                                                 \n\t"
+" ldr             x2, %[aaddr]                    \n\t" // Load address of A
+" mov             x3, #16                         \n\t" // LdA is 16 from packing, can be input
+" ldr             x4, %[baddr]                    \n\t" // Load address of B
+" mov             x5, #12                         \n\t" // LdB is 12 from packing, can be input
+"                                                 \n\t"
+" b.ne            NO_C_PRFM                       \n\t" // C cannot be effectively prefetched if 
+"                                                 \n\t" //   stored strided.
+"                                                 \n\t" // Registers occupied: X0-9, X20(=1), X21
+" mov             x10, #8                         \n\t" // Double in bytes, will be destroyed.
+" madd            x20, x7, x10, xzr               \n\t"
+"                                                 \n\t" // A64fx has 64KiB-4way L1 per core
+"                                                 \n\t" // Should be able to hold all 16Dx12=1.5KiB
+"                                                 \n\t"
+"                                                 \n\t" // C column 0 is x6
+" add             x11, x6, x20                    \n\t" // C column 1
+" add             x12, x11, x20                   \n\t" // C column 2
+" add             x13, x12, x20                   \n\t" // C column 3
+" add             x14, x13, x20                   \n\t" // C column 4
+" add             x15, x14, x20                   \n\t" // C column 5
+" prfm            PSTL1KEEP, [x6]                 \n\t" // Prefetch C column 0
+" prfm            PSTL1KEEP, [x6, #64]            \n\t"
+" prfm            PSTL1KEEP, [x11]                \n\t" // Prefetch C column 1
+" prfm            PSTL1KEEP, [x11,#64]            \n\t"
+" prfm            PSTL1KEEP, [x12]                \n\t" // Prefetch C column 2
+" prfm            PSTL1KEEP, [x12,#64]            \n\t"
+" prfm            PSTL1KEEP, [x13]                \n\t" // Prefetch C column 3
+" prfm            PSTL1KEEP, [x13,#64]            \n\t"
+" prfm            PSTL1KEEP, [x14]                \n\t" // Prefetch C column 4
+" prfm            PSTL1KEEP, [x14,#64]            \n\t"
+" prfm            PSTL1KEEP, [x15]                \n\t" // Prefetch C column 5
+" prfm            PSTL1KEEP, [x15,#64]            \n\t"
+"                                                 \n\t"
+" add             x10, x15, x20                   \n\t" // C column 6
+" add             x11, x10, x20                   \n\t" // C column 7
+" add             x12, x11, x20                   \n\t" // C column 8
+" add             x13, x12, x20                   \n\t" // C column 9
+" add             x14, x13, x20                   \n\t" // C column 10
+" add             x15, x14, x20                   \n\t" // C column 11
+" prfm            PSTL1KEEP, [x10]                \n\t" // Prefetch C column 6
+" prfm            PSTL1KEEP, [x10,#64]            \n\t"
+" prfm            PSTL1KEEP, [x11]                \n\t" // Prefetch C column 7
+" prfm            PSTL1KEEP, [x11,#64]            \n\t"
+" prfm            PSTL1KEEP, [x12]                \n\t" // Prefetch C column 8
+" prfm            PSTL1KEEP, [x12,#64]            \n\t"
+" prfm            PSTL1KEEP, [x13]                \n\t" // Prefetch C column 9
+" prfm            PSTL1KEEP, [x13,#64]            \n\t"
+" prfm            PSTL1KEEP, [x14]                \n\t" // Prefetch C column 10
+" prfm            PSTL1KEEP, [x14,#64]            \n\t"
+" prfm            PSTL1KEEP, [x15]                \n\t" // Prefetch C column 11
+" prfm            PSTL1KEEP, [x15,#64]            \n\t"
+"                                                 \n\t"
+" mov             x20, #1                         \n\t" // Restore X20.
+"                                                 \n\t"
+" NO_C_PRFM:                                      \n\t"
+"                                                 \n\t"
+" ldr             x18, %[a_next]                  \n\t" // Pointer to next A pack
+" ldr             x19, %[b_next]                  \n\t" // Pointer to next B pack
+" mov             x12, #8                         \n\t" // Double in bytes
+"                                                 \n\t"
+" mov             x11, xzr                        \n\t"
+" incd            x11                             \n\t" // Determine vector length, in doubles.
+"                                                 \n\t"
+" ptrue           p0.d, all                       \n\t" // First half is all-true.
+" whilelo         p1.d, x11, x9                   \n\t" // Second half from M argument.
+" fmov            d0, #1.0                        \n\t" // Exact floating-point 1.0.
+" fmov            x14, d0                         \n\t" // Hard float to avoid conflict with SVE.
+"                                                 \n\t"
+" prfm            PLDL1STRM, [x2]                 \n\t" // Prefetch A for first microkernel
+" prfm            PLDL1STRM, [x2, #64]            \n\t"
+" prfm            PLDL1STRM, [x2, #128]           \n\t"
+" prfm            PLDL1STRM, [x2, #192]           \n\t"
+" prfm            PLDL1STRM, [x2, #256]           \n\t"
+" prfm            PLDL1STRM, [x2, #320]           \n\t"
+" prfm            PLDL1STRM, [x2, #384]           \n\t"
+" prfm            PLDL1STRM, [x2, #448]           \n\t"
+" prfm            PLDL1STRM, [x4]                 \n\t" // Prefetch B for first microkernel
+" prfm            PLDL1STRM, [x4, #64]            \n\t"
+" prfm            PLDL1STRM, [x4, #128]           \n\t"
+" prfm            PLDL1STRM, [x4, #192]           \n\t"
+" prfm            PLDL1STRM, [x4, #256]           \n\t"
+" prfm            PLDL1STRM, [x4, #320]           \n\t"
+"                                                 \n\t"
+"                                                 \n\t" // SVE Register configuration:
+"                                                 \n\t" // Z[30-31]: A columns
+"                                                 \n\t" // Z[0-5]: B elements broadcasted
+"                                                 \n\t" // Z[6-29]: C change buffer
+"                                                 \n\t"
+" fmov            z6.d, p0/m, #0.0                \n\t"
+" fmov            z7.d, p0/m, #0.0                \n\t"
+" fmov            z8.d, p0/m, #0.0                \n\t"
+" fmov            z9.d, p0/m, #0.0                \n\t"
+" fmov            z10.d, p0/m, #0.0               \n\t"
+" fmov            z11.d, p0/m, #0.0               \n\t"
+" fmov            z12.d, p0/m, #0.0               \n\t"
+" fmov            z13.d, p0/m, #0.0               \n\t"
+" fmov            z14.d, p0/m, #0.0               \n\t"
+" fmov            z15.d, p0/m, #0.0               \n\t"
+" fmov            z16.d, p0/m, #0.0               \n\t"
+" fmov            z17.d, p0/m, #0.0               \n\t"
+" fmov            z18.d, p0/m, #0.0               \n\t"
+" fmov            z19.d, p0/m, #0.0               \n\t"
+" fmov            z20.d, p0/m, #0.0               \n\t"
+" fmov            z21.d, p0/m, #0.0               \n\t"
+" fmov            z22.d, p0/m, #0.0               \n\t"
+" fmov            z23.d, p0/m, #0.0               \n\t"
+" fmov            z24.d, p0/m, #0.0               \n\t"
+" fmov            z25.d, p0/m, #0.0               \n\t"
+" fmov            z26.d, p0/m, #0.0               \n\t"
+" fmov            z27.d, p0/m, #0.0               \n\t"
+" fmov            z28.d, p0/m, #0.0               \n\t"
+" fmov            z29.d, p0/m, #0.0               \n\t"
+"                                                 \n\t"
+" FIRST_BCOL:                                     \n\t" // Load of first column of B.
+" ld1rqd          z0.d, p0/z, [x4, #0]            \n\t"
+" ld1rqd          z1.d, p0/z, [x4, #16]           \n\t"
+" ld1rqd          z2.d, p0/z, [x4, #32]           \n\t"
+" ld1rqd          z3.d, p0/z, [x4, #48]           \n\t"
+" ld1rqd          z4.d, p0/z, [x4, #64]           \n\t"
+" ld1rqd          z5.d, p0/z, [x4, #80]           \n\t"
+"                                                 \n\t"
+" cmp             x21, #0                         \n\t" // If no 4-microkernel can be applied
+" b.eq            K_LEFT_LOOP                     \n\t"
+"                                                 \n\t"
+" K_MKER_LOOP:                                    \n\t" // Unroll the 4-loop.
+"                                                 \n\t"
+"                                                 \n\t" // [BEGIN] This block will be repeated 4 times
+" ld1d            z30.d, p0/z, [x2]               \n\t" // A columns
+" ld1d            z31.d, p1/z, [x2, x11, lsl 3]   \n\t"
+" madd            x2, x3, x12, x2                 \n\t" // A address forward
+" madd            x4, x5, x12, x4                 \n\t" // B address forward
+" fmla            z6.d, z30.d, z0.d[0]            \n\t" // Row L column 0 and 1
+" fmla            z7.d, z31.d, z0.d[0]            \n\t" // Row L column 2 and 3
+" fmla            z8.d, z30.d, z0.d[1]            \n\t"
+" fmla            z9.d, z31.d, z0.d[1]            \n\t"
+" ld1rqd          z0.d, p0/z, [x4, #0]            \n\t" // Load the next Z0.
+" fmla            z10.d, z30.d, z1.d[0]           \n\t"
+" fmla            z11.d, z31.d, z1.d[0]           \n\t"
+" fmla            z12.d, z30.d, z1.d[1]           \n\t"
+" fmla            z13.d, z31.d, z1.d[1]           \n\t"
+" ld1rqd          z1.d, p0/z, [x4, #16]           \n\t" // Load the next Z1.
+" fmla            z14.d, z30.d, z2.d[0]           \n\t" // Row L column 4 and 5
+" fmla            z15.d, z31.d, z2.d[0]           \n\t" // Row L column 6 and 7
+" fmla            z16.d, z30.d, z2.d[1]           \n\t"
+" fmla            z17.d, z31.d, z2.d[1]           \n\t"
+" ld1rqd          z2.d, p0/z, [x4, #32]           \n\t" // Load the next Z2.
+" fmla            z18.d, z30.d, z3.d[0]           \n\t"
+" fmla            z19.d, z31.d, z3.d[0]           \n\t"
+" fmla            z20.d, z30.d, z3.d[1]           \n\t"
+" fmla            z21.d, z31.d, z3.d[1]           \n\t"
+" ld1rqd          z3.d, p0/z, [x4, #48]           \n\t" // Load the next Z3.
+" fmla            z22.d, z30.d, z4.d[0]           \n\t" // Row L column 8 and 9
+" fmla            z23.d, z31.d, z4.d[0]           \n\t" // Row L column 10 and 11
+" fmla            z24.d, z30.d, z4.d[1]           \n\t"
+" fmla            z25.d, z31.d, z4.d[1]           \n\t"
+" ld1rqd          z4.d, p0/z, [x4, #64]           \n\t" // Load the next Z4.
+" fmla            z26.d, z30.d, z5.d[0]           \n\t"
+" fmla            z27.d, z31.d, z5.d[0]           \n\t"
+" fmla            z28.d, z30.d, z5.d[1]           \n\t"
+" fmla            z29.d, z31.d, z5.d[1]           \n\t"
+" ld1rqd          z5.d, p0/z, [x4, #80]           \n\t" // Load the next Z5.
+"                                                 \n\t" // [END] This block will be repeated 4 times
+"                                                 \n\t"
+" ld1d            z30.d, p0/z, [x2]               \n\t" // A columns
+" ld1d            z31.d, p1/z, [x2, x11, lsl 3]   \n\t"
+" madd            x2, x3, x12, x2                 \n\t" // A address forward
+" madd            x4, x5, x12, x4                 \n\t" // B address forward
+" fmla            z6.d, z30.d, z0.d[0]            \n\t" // Row L column 0 and 1
+" fmla            z7.d, z31.d, z0.d[0]            \n\t" // Row L column 2 and 3
+" fmla            z8.d, z30.d, z0.d[1]            \n\t"
+" fmla            z9.d, z31.d, z0.d[1]            \n\t"
+" ld1rqd          z0.d, p0/z, [x4, #0]            \n\t" // Load the next Z0.
+" fmla            z10.d, z30.d, z1.d[0]           \n\t"
+" fmla            z11.d, z31.d, z1.d[0]           \n\t"
+" fmla            z12.d, z30.d, z1.d[1]           \n\t"
+" fmla            z13.d, z31.d, z1.d[1]           \n\t"
+" ld1rqd          z1.d, p0/z, [x4, #16]           \n\t" // Load the next Z1.
+" fmla            z14.d, z30.d, z2.d[0]           \n\t" // Row L column 4 and 5
+" fmla            z15.d, z31.d, z2.d[0]           \n\t" // Row L column 6 and 7
+" fmla            z16.d, z30.d, z2.d[1]           \n\t"
+" fmla            z17.d, z31.d, z2.d[1]           \n\t"
+" ld1rqd          z2.d, p0/z, [x4, #32]           \n\t" // Load the next Z2.
+" fmla            z18.d, z30.d, z3.d[0]           \n\t"
+" fmla            z19.d, z31.d, z3.d[0]           \n\t"
+" fmla            z20.d, z30.d, z3.d[1]           \n\t"
+" fmla            z21.d, z31.d, z3.d[1]           \n\t"
+" ld1rqd          z3.d, p0/z, [x4, #48]           \n\t" // Load the next Z3.
+" fmla            z22.d, z30.d, z4.d[0]           \n\t" // Row L column 8 and 9
+" fmla            z23.d, z31.d, z4.d[0]           \n\t" // Row L column 10 and 11
+" fmla            z24.d, z30.d, z4.d[1]           \n\t"
+" fmla            z25.d, z31.d, z4.d[1]           \n\t"
+" ld1rqd          z4.d, p0/z, [x4, #64]           \n\t" // Load the next Z4.
+" fmla            z26.d, z30.d, z5.d[0]           \n\t"
+" fmla            z27.d, z31.d, z5.d[0]           \n\t"
+" fmla            z28.d, z30.d, z5.d[1]           \n\t"
+" fmla            z29.d, z31.d, z5.d[1]           \n\t"
+" ld1rqd          z5.d, p0/z, [x4, #80]           \n\t" // Load the next Z5.
+"                                                 \n\t"
+"                                                 \n\t" // Before third replica,
+"                                                 \n\t" //   do prefetching.
+"                                                 \n\t" // X2, X4 will be modified later,
+"                                                 \n\t" //   so shift is different from
+"                                                 \n\t" //   first PRFM block.
+" prfm            PLDL1STRM, [x2, #256]           \n\t" // Prefetch A (first-half)
+" prfm            PLDL1STRM, [x2, #320]           \n\t" //  for next microkernel
+" prfm            PLDL1STRM, [x2, #384]           \n\t"
+" prfm            PLDL1STRM, [x2, #448]           \n\t"
+" prfm            PLDL1STRM, [x4, #192]           \n\t" // Prefetch B (first-half)
+" prfm            PLDL1STRM, [x4, #256]           \n\t" //  for next microkernel
+" prfm            PLDL1STRM, [x4, #320]           \n\t"
+"                                                 \n\t"
+" ld1d            z30.d, p0/z, [x2]               \n\t" // A columns
+" ld1d            z31.d, p1/z, [x2, x11, lsl 3]   \n\t"
+" madd            x2, x3, x12, x2                 \n\t" // A address forward
+" madd            x4, x5, x12, x4                 \n\t" // B address forward
+" fmla            z6.d, z30.d, z0.d[0]            \n\t" // Row L column 0 and 1
+" fmla            z7.d, z31.d, z0.d[0]            \n\t" // Row L column 2 and 3
+" fmla            z8.d, z30.d, z0.d[1]            \n\t"
+" fmla            z9.d, z31.d, z0.d[1]            \n\t"
+" ld1rqd          z0.d, p0/z, [x4, #0]            \n\t" // Load the next Z0.
+" fmla            z10.d, z30.d, z1.d[0]           \n\t"
+" fmla            z11.d, z31.d, z1.d[0]           \n\t"
+" fmla            z12.d, z30.d, z1.d[1]           \n\t"
+" fmla            z13.d, z31.d, z1.d[1]           \n\t"
+" ld1rqd          z1.d, p0/z, [x4, #16]           \n\t" // Load the next Z1.
+" fmla            z14.d, z30.d, z2.d[0]           \n\t" // Row L column 4 and 5
+" fmla            z15.d, z31.d, z2.d[0]           \n\t" // Row L column 6 and 7
+" fmla            z16.d, z30.d, z2.d[1]           \n\t"
+" fmla            z17.d, z31.d, z2.d[1]           \n\t"
+" ld1rqd          z2.d, p0/z, [x4, #32]           \n\t" // Load the next Z2.
+" fmla            z18.d, z30.d, z3.d[0]           \n\t"
+" fmla            z19.d, z31.d, z3.d[0]           \n\t"
+" fmla            z20.d, z30.d, z3.d[1]           \n\t"
+" fmla            z21.d, z31.d, z3.d[1]           \n\t"
+" ld1rqd          z3.d, p0/z, [x4, #48]           \n\t" // Load the next Z3.
+" fmla            z22.d, z30.d, z4.d[0]           \n\t" // Row L column 8 and 9
+" fmla            z23.d, z31.d, z4.d[0]           \n\t" // Row L column 10 and 11
+" fmla            z24.d, z30.d, z4.d[1]           \n\t"
+" fmla            z25.d, z31.d, z4.d[1]           \n\t"
+" ld1rqd          z4.d, p0/z, [x4, #64]           \n\t" // Load the next Z4.
+" fmla            z26.d, z30.d, z5.d[0]           \n\t"
+" fmla            z27.d, z31.d, z5.d[0]           \n\t"
+" fmla            z28.d, z30.d, z5.d[1]           \n\t"
+" fmla            z29.d, z31.d, z5.d[1]           \n\t"
+" ld1rqd          z5.d, p0/z, [x4, #80]           \n\t" // Load the next Z5.
+"                                                 \n\t"
+" sub             x10, x21, #1                    \n\t" // Before final replica, 
+" adds            x10, x10, x8                    \n\t" //  check if this iteration is final
+" b.eq            FIN_LOOP                        \n\t"
+"                                                 \n\t"
+" prfm            PLDL1STRM, [x2, #384]           \n\t" // Prefetch A (last-half)
+" prfm            PLDL1STRM, [x2, #448]           \n\t" //  for next microkernel
+" prfm            PLDL1STRM, [x2, #512]           \n\t"
+" prfm            PLDL1STRM, [x2, #576]           \n\t"
+" prfm            PLDL1STRM, [x4, #288]           \n\t" // Prefetch B (last-half)
+" prfm            PLDL1STRM, [x4, #352]           \n\t" //  for next microkernel
+" prfm            PLDL1STRM, [x4, #416]           \n\t"
+"                                                 \n\t"
+" ld1d            z30.d, p0/z, [x2]               \n\t" // A columns
+" ld1d            z31.d, p1/z, [x2, x11, lsl 3]   \n\t"
+" madd            x2, x3, x12, x2                 \n\t" // A address forward
+" madd            x4, x5, x12, x4                 \n\t" // B address forward
+" fmla            z6.d, z30.d, z0.d[0]            \n\t" // Row L column 0 and 1
+" fmla            z7.d, z31.d, z0.d[0]            \n\t" // Row L column 2 and 3
+" fmla            z8.d, z30.d, z0.d[1]            \n\t"
+" fmla            z9.d, z31.d, z0.d[1]            \n\t"
+" ld1rqd          z0.d, p0/z, [x4, #0]            \n\t" // Load the next Z0.
+" fmla            z10.d, z30.d, z1.d[0]           \n\t"
+" fmla            z11.d, z31.d, z1.d[0]           \n\t"
+" fmla            z12.d, z30.d, z1.d[1]           \n\t"
+" fmla            z13.d, z31.d, z1.d[1]           \n\t"
+" ld1rqd          z1.d, p0/z, [x4, #16]           \n\t" // Load the next Z1.
+" fmla            z14.d, z30.d, z2.d[0]           \n\t" // Row L column 4 and 5
+" fmla            z15.d, z31.d, z2.d[0]           \n\t" // Row L column 6 and 7
+" fmla            z16.d, z30.d, z2.d[1]           \n\t"
+" fmla            z17.d, z31.d, z2.d[1]           \n\t"
+" ld1rqd          z2.d, p0/z, [x4, #32]           \n\t" // Load the next Z2.
+" fmla            z18.d, z30.d, z3.d[0]           \n\t"
+" fmla            z19.d, z31.d, z3.d[0]           \n\t"
+" fmla            z20.d, z30.d, z3.d[1]           \n\t"
+" fmla            z21.d, z31.d, z3.d[1]           \n\t"
+" ld1rqd          z3.d, p0/z, [x4, #48]           \n\t" // Load the next Z3.
+" fmla            z22.d, z30.d, z4.d[0]           \n\t" // Row L column 8 and 9
+" fmla            z23.d, z31.d, z4.d[0]           \n\t" // Row L column 10 and 11
+" fmla            z24.d, z30.d, z4.d[1]           \n\t"
+" fmla            z25.d, z31.d, z4.d[1]           \n\t"
+" ld1rqd          z4.d, p0/z, [x4, #64]           \n\t" // Load the next Z4.
+" fmla            z26.d, z30.d, z5.d[0]           \n\t"
+" fmla            z27.d, z31.d, z5.d[0]           \n\t"
+" fmla            z28.d, z30.d, z5.d[1]           \n\t"
+" fmla            z29.d, z31.d, z5.d[1]           \n\t"
+" ld1rqd          z5.d, p0/z, [x4, #80]           \n\t" // Load the next Z5.
+"                                                 \n\t"
+"                                                 \n\t" // End of repeating.
+"                                                 \n\t"
+" subs            x21, x21, #1                    \n\t" // Decrease counter.
+" b.ne            K_MKER_LOOP                     \n\t"
+"                                                 \n\t"
+" K_LEFT_LOOP:                                    \n\t"
+"                                                 \n\t"
+" cmp             x8, #1                          \n\t" // If K=1.
+" b.eq            FIN_LOOP                        \n\t"
+"                                                 \n\t"
+" ld1d            z30.d, p0/z, [x2]               \n\t" // Load columns from A.
+" ld1d            z31.d, p1/z, [x2, x11, lsl 3]   \n\t" // Second vector
+" madd            x2, x3, x12, x2                 \n\t" // A address forward
+" madd            x4, x5, x12, x4                 \n\t" // B address forward
+" fmla            z6.d, z30.d, z0.d[0]            \n\t" // Row L column 0 and 1
+" fmla            z7.d, z31.d, z0.d[0]            \n\t" // Row L column 2 and 3
+" fmla            z8.d, z30.d, z0.d[1]            \n\t"
+" fmla            z9.d, z31.d, z0.d[1]            \n\t"
+" fmla            z10.d, z30.d, z1.d[0]           \n\t"
+" fmla            z11.d, z31.d, z1.d[0]           \n\t"
+" fmla            z12.d, z30.d, z1.d[1]           \n\t"
+" fmla            z13.d, z31.d, z1.d[1]           \n\t"
+" fmla            z14.d, z30.d, z2.d[0]           \n\t" // Row L column 4 and 5
+" fmla            z15.d, z31.d, z2.d[0]           \n\t" // Row L column 6 and 7
+" fmla            z16.d, z30.d, z2.d[1]           \n\t"
+" fmla            z17.d, z31.d, z2.d[1]           \n\t"
+" ld1rqd          z0.d, p0/z, [x4, #0]            \n\t" // Fetch the next Z0.
+" ld1rqd          z1.d, p0/z, [x4, #16]           \n\t" // Fetch the next Z1.
+" ld1rqd          z2.d, p0/z, [x4, #32]           \n\t" // Fetch the next Z2 as soon as used.
+" fmla            z18.d, z30.d, z3.d[0]           \n\t"
+" fmla            z19.d, z31.d, z3.d[0]           \n\t"
+" fmla            z20.d, z30.d, z3.d[1]           \n\t"
+" fmla            z21.d, z31.d, z3.d[1]           \n\t"
+" ld1rqd          z3.d, p0/z, [x4, #48]           \n\t" // Fetch the next Z3 as soon as used.
+" fmla            z22.d, z30.d, z4.d[0]           \n\t" // Row L column 8 and 9
+" fmla            z23.d, z31.d, z4.d[0]           \n\t" // Row L column 10 and 11
+" fmla            z24.d, z30.d, z4.d[1]           \n\t"
+" fmla            z25.d, z31.d, z4.d[1]           \n\t"
+" ld1rqd          z4.d, p0/z, [x4, #64]           \n\t" // Fetch the next Z4 as soon as used.
+" fmla            z26.d, z30.d, z5.d[0]           \n\t"
+" fmla            z27.d, z31.d, z5.d[0]           \n\t"
+" fmla            z28.d, z30.d, z5.d[1]           \n\t"
+" fmla            z29.d, z31.d, z5.d[1]           \n\t"
+" ld1rqd          z5.d, p0/z, [x4, #80]           \n\t" // Fetch the next Z5 as soon as used.
+"                                                 \n\t"
+" NEXT_ROW:                                       \n\t"
+" sub             x8, x8, #1                      \n\t"
+" cmp             x8, #1                          \n\t"
+" b.ne            K_LEFT_LOOP                     \n\t" // Next column / row.
+"                                                 \n\t"
+" FIN_LOOP:                                       \n\t" // Final K-loop
+"                                                 \n\t"
+" ld1d            z30.d, p0/z, [x2]               \n\t" // Final A
+" ld1d            z31.d, p1/z, [x2, x11, lsl 3]   \n\t"
+"                                                 \n\t" // Final B is already loaded.
+" fmla            z6.d, z30.d, z0.d[0]            \n\t" // Row L column 0 and 1
+" fmla            z7.d, z31.d, z0.d[0]            \n\t" // Row L column 2 and 3
+" fmla            z8.d, z30.d, z0.d[1]            \n\t"
+" fmla            z9.d, z31.d, z0.d[1]            \n\t"
+" fmla            z10.d, z30.d, z1.d[0]           \n\t"
+" fmla            z11.d, z31.d, z1.d[0]           \n\t"
+" fmla            z12.d, z30.d, z1.d[1]           \n\t"
+" fmla            z13.d, z31.d, z1.d[1]           \n\t"
+" fmla            z14.d, z30.d, z2.d[0]           \n\t" // Row L column 4 and 5
+" fmla            z15.d, z31.d, z2.d[0]           \n\t" // Row L column 6 and 7
+" fmla            z16.d, z30.d, z2.d[1]           \n\t"
+" fmla            z17.d, z31.d, z2.d[1]           \n\t"
+" fmla            z18.d, z30.d, z3.d[0]           \n\t"
+" fmla            z19.d, z31.d, z3.d[0]           \n\t"
+" fmla            z20.d, z30.d, z3.d[1]           \n\t"
+" fmla            z21.d, z31.d, z3.d[1]           \n\t"
+" fmla            z22.d, z30.d, z4.d[0]           \n\t" // Row L column 8 and 9
+" fmla            z23.d, z31.d, z4.d[0]           \n\t" // Row L column 10 and 11
+" fmla            z24.d, z30.d, z4.d[1]           \n\t"
+" fmla            z25.d, z31.d, z4.d[1]           \n\t"
+" fmla            z26.d, z30.d, z5.d[0]           \n\t"
+" fmla            z27.d, z31.d, z5.d[0]           \n\t"
+" fmla            z28.d, z30.d, z5.d[1]           \n\t"
+" fmla            z29.d, z31.d, z5.d[1]           \n\t"
+"                                                 \n\t"
+" WRITE_MEM:                                      \n\t"
+"                                                 \n\t" // Override A and B buffers:
+"                                                 \n\t" // Z[30-31]: extended alpha and beta.
+"                                                 \n\t" // Z[0-1]: C memory buffer.
+"                                                 \n\t"
+" ldr             x15, [x0]                       \n\t" // Alpha, as 64-bits
+" ld1rd           z30.d, p0/z, [x0]               \n\t" // Alpha, to the vector.
+" ld1rd           z31.d, p0/z, [x1]               \n\t" // Beta, to the vector.
+"                                                 \n\t"
+" prfm            PLDL2KEEP, [x18]                \n\t" // Prefetch next A and B.
+" prfm            PLDL2KEEP, [x19]                \n\t"
+"                                                 \n\t"
+" cmp             x14, x15                        \n\t" // (R&)Write data back to C memory.
+" b.eq            UNIT_ALPHA                      \n\t"
+"                                                 \n\t"
+" fmul            z6.d, z6.d, z30.d               \n\t" // Non-unit alpha case.
+" fmul            z7.d, z7.d, z30.d               \n\t" // Scale all C change buffers.
+" fmul            z8.d, z8.d, z30.d               \n\t"
+" fmul            z9.d, z9.d, z30.d               \n\t"
+" fmul            z10.d, z10.d, z30.d             \n\t"
+" fmul            z11.d, z11.d, z30.d             \n\t"
+" fmul            z12.d, z12.d, z30.d             \n\t"
+" fmul            z13.d, z13.d, z30.d             \n\t"
+" fmul            z14.d, z14.d, z30.d             \n\t"
+" fmul            z15.d, z15.d, z30.d             \n\t"
+" fmul            z16.d, z16.d, z30.d             \n\t"
+" fmul            z17.d, z17.d, z30.d             \n\t"
+" fmul            z18.d, z18.d, z30.d             \n\t"
+" fmul            z19.d, z19.d, z30.d             \n\t"
+" fmul            z20.d, z20.d, z30.d             \n\t"
+" fmul            z21.d, z21.d, z30.d             \n\t"
+" fmul            z22.d, z22.d, z30.d             \n\t"
+" fmul            z23.d, z23.d, z30.d             \n\t"
+" fmul            z24.d, z24.d, z30.d             \n\t"
+" fmul            z25.d, z25.d, z30.d             \n\t"
+" fmul            z26.d, z26.d, z30.d             \n\t"
+" fmul            z27.d, z27.d, z30.d             \n\t"
+" fmul            z28.d, z28.d, z30.d             \n\t"
+" fmul            z29.d, z29.d, z30.d             \n\t"
+"                                                 \n\t"
+" UNIT_ALPHA:                                     \n\t" // Unit alpha case.
+" cmp             x20, #1                         \n\t"
+" b.ne            CS_CCOL                         \n\t"
+"                                                 \n\t"
+" CT_CCOL:                                        \n\t" // Contiguous columns.
+"                                                 \n\t" // X10=12 counter no longer used.
+"                                                 \n\t"
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 0
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z6.d         \n\t"
+" fmad            z1.d, p1/m, z31.d, z7.d         \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 1
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z8.d         \n\t"
+" fmad            z1.d, p1/m, z31.d, z9.d         \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 2
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z10.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z11.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 3
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z12.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z13.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 4
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z14.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z15.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 5
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z16.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z17.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 6
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z18.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z19.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 7
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z20.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z21.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 8
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z22.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z23.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 9
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z24.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z25.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 10
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z26.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z27.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+" madd            x16, x7, x12, x6                \n\t" // Next column
+" ld1d            z0.d, p0/z, [x6]                \n\t" // Column vector 11
+" ld1d            z1.d, p1/z, [x6, x11, lsl #3]   \n\t"
+" fmad            z0.d, p0/m, z31.d, z28.d        \n\t"
+" fmad            z1.d, p1/m, z31.d, z29.d        \n\t"
+" st1d            z0.d, p0, [x6]                  \n\t"
+" st1d            z1.d, p1, [x6, x11, lsl #3]     \n\t"
+" mov             x6, x16                         \n\t" // Move forward
+"                                                 \n\t"
+"                                                 \n\t"
+" b               END_WRITE_MEM                   \n\t"
+"                                                 \n\t"
+" CS_CCOL:                                        \n\t" // C has row-strides.
+" mul             x21, x20, x12                   \n\t" // Column stride in bytes
+" mul             x17, x21, x11                   \n\t" // Vector length in memory
+"                                                 \n\t"
+"                                                 \n\t" // Z30: index for loading C columns.
+" index           z30.d, xzr, x21                 \n\t" // Generate indices.
+"                                                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 0
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z6.d         \n\t"
+" fmad            z0.d, p1/m, z31.d, z7.d         \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 1
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z8.d         \n\t"
+" fmad            z0.d, p1/m, z31.d, z9.d         \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 2
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z10.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z11.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 3
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z12.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z13.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 4
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z14.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z15.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 5
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z16.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z17.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 6
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z18.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z19.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 7
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z20.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z21.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 8
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z22.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z23.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 9
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z24.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z25.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 10
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z26.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z27.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+" add             x16, x17, x6                    \n\t"
+" ld1d            z0.d, p0/z, [x6, z30.d]         \n\t" // Column vector 11
+" ld1d            z0.d, p1/z, [x16, z30.d]        \n\t"
+" fmad            z0.d, p0/m, z31.d, z28.d        \n\t"
+" fmad            z0.d, p1/m, z31.d, z29.d        \n\t"
+" st1d            z0.d, p0, [x6, z30.d]           \n\t"
+" st1d            z0.d, p1, [x16, z30.d]          \n\t"
+" madd            x6, x7, x12, x6                 \n\t"
+"                                                 \n\t"
+"                                                 \n\t"
+" END_WRITE_MEM:                                  \n\t" // End of computation.
+" mov             x0, #0                          \n\t" // Return normal.
+" b               END_EXEC                        \n\t"
+" END_ERROR:                                      \n\t"
+" mov             x0, #1                          \n\t" // Return error.
+" END_EXEC:                                       \n\t"
+:// output operands (none)
+:// input operands
+ [aaddr]  "m" (a),      // 0
+ [baddr]  "m" (b),      // 1
+ [caddr]  "m" (c),      // 2
+ [k_mker] "m" (k_mker), // 3
+ [k_left] "m" (k_left), // 4
+ [alpha]  "m" (alpha),  // 5
+ [beta]   "m" (beta),   // 6
+ [rs_c]   "m" (rs_c),   // 6
+ [cs_c]   "m" (cs_c),   // 7
+ [a_next] "m" (a_next), // 8
+ [b_next] "m" (b_next)  // 9
+:// Register clobber list
+ "x0","x1","x2","x3","x4","x5","x6","x7","x8",
+ "x9",/*"x10,"*/"x11","x12","x14","x15",
+ "x16","x17","x18","x19","x20","x21",
+ "z0","z1","z2","z3","z4","z5","z6","z7",
+ "z8","z9","z10","z11","z12","z13","z14","z15",
+ "z16","z17","z18","z19",
+ "z20","z21","z22","z23",
+ "z24","z25","z26","z27",
+ "z28","z29","z30","z31" );
+
+}

--- a/kernels/armsve/bli_kernels_armsve.h
+++ b/kernels/armsve/bli_kernels_armsve.h
@@ -33,5 +33,6 @@
 */
 
 GEMM_UKR_PROT( double,   d, gemm_armsve256_asm_8x8 )
+GEMM_UKR_PROT( double,   d, gemm_armsve512_asm_16x12 )
 
 PACKM_KER_PROT( double,   d, packm_armsve256_asm_8xk )


### PR DESCRIPTION
This pull request contains 2 parts:
- A new GEMM assembly for 512-bit vector length of Arm SVE;
- A new sub-configuration for Arm SVE that determines vector length at runtime with `incd` instruction and selects GEMM kernels accordingly.

The new PACKM kernel is not registered yet. Sorry for that.

As this pull request can be separated into 2 parts (with the sub-config depending on layout of kernels), I'm not sure if it was good to create pull request this way. If not, I'll close this and open another one with 512-bit assembly kernel only.