### PR TITLE
Add checks so that s390x is detected as 64-bit.

### DIFF
--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -63,7 +63,7 @@
 
 // Determine if we are on a 64-bit or 32-bit architecture.
 #if defined(_M_X64) || defined(__x86_64) || defined(__aarch64__) || \
-    defined(_ARCH_PPC64)
+    defined(_ARCH_PPC64) || defined(__s390x__) || defined(_LP64)
   #define BLIS_ARCH_64
 #else
   #define BLIS_ARCH_32


### PR DESCRIPTION
Fixes #423.