### PR TITLE
Update bli_type_defs.h

### DIFF
--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -985,7 +985,7 @@ typedef enum
 typedef enum
 {
 	// Intel
-	BLIS_ARCH_SKX = 0,
+	BLIS_ARCH_SKX,
 	BLIS_ARCH_KNL,
 	BLIS_ARCH_KNC,
 	BLIS_ARCH_HASWELL,
@@ -1013,13 +1013,12 @@ typedef enum
 	BLIS_ARCH_BGQ,
 
 	// Generic architecture/configuration
-	BLIS_ARCH_GENERIC
+	BLIS_ARCH_GENERIC,
+	
+	// Number of architectures, must be last
+	BLIS_NUM_ARCHS
 
 } arch_t;
-
-// NOTE: This value must be updated to reflect the number of enum values
-// listed above for arch_t!
-#define BLIS_NUM_ARCHS 21
 
 
 //


### PR DESCRIPTION
Set BLIS_NUM_ARCHS automatically by inserting it as the last member in the enum. Also remove `=0` on first enum member since it is guaranteed by the standard. This make is easier and less error-prone to reorder enum entries.

This change was also included in changes I made to #344 and #345 in remerging them, but I thought it important to make this change earlier rather than later.