### PR TITLE
Fix kernel-to-config mapping for intel64

### DIFF
--- a/configure
+++ b/configure
@@ -2593,11 +2593,11 @@ main()
 
 			reducedclist="${kernel}"
 
-		# Otherwise, use the first name.
+		# Otherwise, use the last name.
 		else
 
-			first_config=${configs%% *}
-			reducedclist="${first_config}"
+			last_config=${configs##* }
+			reducedclist="${last_config}"
 		fi
 
 		# Create a new "kernel:subconfig" pair and add it to the kconfig_map


### PR DESCRIPTION
Choose last sub-config in the kernel-to-config map if the config list doesn't contain the name of the kernel set. E.g. for "zen: skx knl haswell" pick "haswell" instead of "skx" which was chosen previously. Fixes #470.