### PR TITLE
Typed API for GEMMT Inconsistent with Document?

### DIFF
--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -1295,7 +1295,8 @@ where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as 
 void bli_?her2k
      (
        uplo_t  uploc,
-       trans_t transab,
+       trans_t transa,
+       trans_t transb,
        dim_t   m,
        dim_t   k,
        ctype*  alpha,
@@ -1307,9 +1308,9 @@ void bli_?her2k
 ```
 Perform
 ```
-  C := beta * C + alpha * transab(A) * transab(B)^H + conj(alpha) * transab(B) * transab(A)^H
+  C := beta * C + alpha * transa(A) * transb(B)^H + conj(alpha) * transb(B) * transa(A)^H
 ```
-where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as specified by `uploc` and `transab(A)` and `transab(B)` are _m x k_ matrices.
+where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as specified by `uploc` and `transa(A)` and `transb(B)` are _m x k_ matrices.
 
 **Note:** The floating-point type of `beta` is always the real projection of the floating-point types of `A` and `C`.
 
@@ -1371,7 +1372,8 @@ where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as 
 void bli_?syr2k
      (
        uplo_t  uploc,
-       trans_t transab,
+       trans_t transa,
+       trans_t transb,
        dim_t   m,
        dim_t   k,
        ctype*  alpha,
@@ -1383,9 +1385,9 @@ void bli_?syr2k
 ```
 Perform
 ```
-  C := beta * C + alpha * transab(A) * transab(B)^T + alpha * transab(B) * transab(A)^T
+  C := beta * C + alpha * transa(A) * transb(B)^T + alpha * transb(B) * transa(A)^T
 ```
-where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as specified by `uploa` and `transab(A)` and `transab(B)` are _m x k_ matrices.
+where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as specified by `uploa` and `transa(A)` and `transb(B)` are _m x k_ matrices.
 
 ---
 

--- a/frame/3/bli_l3_tapi.c
+++ b/frame/3/bli_l3_tapi.c
@@ -100,7 +100,6 @@ void PASTEMAC2(ch,opname,EX_SUF) \
 }
 
 INSERT_GENTFUNC_BASIC0( gemm )
-INSERT_GENTFUNC_BASIC0( gemmt )
 
 #undef  GENTFUNC
 #define GENTFUNC( ctype, ch, opname, struca ) \
@@ -409,6 +408,7 @@ void PASTEMAC2(ch,opname,EX_SUF) \
 }
 
 INSERT_GENTFUNC_BASIC0( syr2k )
+INSERT_GENTFUNC_BASIC0( gemmt )
 
 
 #undef  GENTFUNC

--- a/frame/3/bli_l3_tapi.c
+++ b/frame/3/bli_l3_tapi.c
@@ -408,6 +408,67 @@ void PASTEMAC2(ch,opname,EX_SUF) \
 }
 
 INSERT_GENTFUNC_BASIC0( syr2k )
+
+
+#undef  GENTFUNC
+#define GENTFUNC( ctype, ch, opname ) \
+\
+void PASTEMAC2(ch,opname,EX_SUF) \
+     ( \
+       uplo_t  uploc, \
+       trans_t transa, \
+       trans_t transb, \
+       dim_t   m, \
+       dim_t   k, \
+       ctype*  alpha, \
+       ctype*  a, inc_t rs_a, inc_t cs_a, \
+       ctype*  b, inc_t rs_b, inc_t cs_b, \
+       ctype*  beta, \
+       ctype*  c, inc_t rs_c, inc_t cs_c  \
+       BLIS_TAPI_EX_PARAMS  \
+     ) \
+{ \
+	bli_init_once(); \
+\
+	BLIS_TAPI_EX_DECLS \
+\
+	const num_t dt = PASTEMAC(ch,type); \
+\
+	obj_t       alphao = BLIS_OBJECT_INITIALIZER_1X1; \
+	obj_t       ao     = BLIS_OBJECT_INITIALIZER; \
+	obj_t       bo     = BLIS_OBJECT_INITIALIZER; \
+	obj_t       betao  = BLIS_OBJECT_INITIALIZER_1X1; \
+	obj_t       co     = BLIS_OBJECT_INITIALIZER; \
+\
+	dim_t       m_a, n_a; \
+	dim_t       m_b, n_b; \
+\
+	bli_set_dims_with_trans( transa, m, k, &m_a, &n_a ); \
+	bli_set_dims_with_trans( transb, k, m, &m_b, &n_b ); \
+\
+	bli_obj_init_finish_1x1( dt, alpha, &alphao ); \
+	bli_obj_init_finish_1x1( dt, beta,  &betao  ); \
+\
+	bli_obj_init_finish( dt, m_a, n_a, a, rs_a, cs_a, &ao ); \
+	bli_obj_init_finish( dt, m_b, n_b, b, rs_b, cs_b, &bo ); \
+	bli_obj_init_finish( dt, m,   m,   c, rs_c, cs_c, &co ); \
+\
+	bli_obj_set_uplo( uploc, &co ); \
+	bli_obj_set_conjtrans( transa, &ao ); \
+	bli_obj_set_conjtrans( transb, &bo ); \
+\
+	PASTEMAC(opname,BLIS_OAPI_EX_SUF) \
+	( \
+	  &alphao, \
+	  &ao, \
+	  &bo, \
+	  &betao, \
+	  &co, \
+	  cntx, \
+	  rntm  \
+	); \
+}
+
 INSERT_GENTFUNC_BASIC0( gemmt )
 
 

--- a/frame/3/bli_l3_tapi.h
+++ b/frame/3/bli_l3_tapi.h
@@ -57,7 +57,6 @@ BLIS_EXPORT_BLIS void PASTEMAC2(ch,opname,EX_SUF) \
      );
 
 INSERT_GENTPROT_BASIC0( gemm )
-INSERT_GENTPROT_BASIC0( gemmt )
 
 #undef  GENTPROT
 #define GENTPROT( ctype, ch, opname ) \
@@ -160,6 +159,7 @@ BLIS_EXPORT_BLIS void PASTEMAC2(ch,opname,EX_SUF) \
      );
 
 INSERT_GENTPROT_BASIC0( syr2k )
+INSERT_GENTPROT_BASIC0( gemmt )
 
 
 #undef  GENTPROT


### PR DESCRIPTION
Hi.

I suspect that in `frame/3/bli_3_tapi.c` macro generation for typed-API `bli_?gemmt` should be placed in line 410 (after `syr2k`) instead of line 103 (after `gemm`) so that the API generated would be consistent with the document.

BTW the doc says that `syr2k` and `her2k` has `transab` as parameters but actually in the code they're separated as `transa` and `transb`. As typed-API wraps around object-API, I guess the latter should be correct?