### PR TITLE
Add possibility to reduce pool-block size upon micro-kernel behavior

### DIFF
--- a/frame/base/bli_membrk.c
+++ b/frame/base/bli_membrk.c
@@ -574,10 +574,17 @@ void bli_membrk_compute_pool_block_sizes_dt
 	// Compute pool block sizes
 	//
 
+	// If defined in architectural configuration (bli_kernel.h), it means
+	// that their micro-kernels will not perform any invalid speculative
+	// prefetch, thus we can skip this padding to reduce memory footprint.
+#ifdef BLIS_UKERNELS_NO_SPECULATIVE_PREFETCH
+	max_packmnr_dt = 0;
+#else
 	// We add an extra micro-panel of space to the block sizes for A and B
 	// just to be sure any pre-loading performed by the micro-kernel does
 	// not cause a segmentation fault.
 	max_packmnr_dt = bli_max( packmr_dt, packnr_dt );
+#endif  // BLIS_UKERNELS_NO_SPECULATIVE_PREFETCH
 
 	*bs_a = ( pool_mc_dt + max_packmnr_dt ) * pool_kc_dt * size_dt;
 	*bs_b = ( pool_nc_dt + max_packmnr_dt ) * pool_kc_dt * size_dt;


### PR DESCRIPTION
- Currently, MC (or NC) size of of pool-block is extended by max(MR, NR)
to cover possible invalid prefetch (speculative) of micro-kernels, typically
for their convenience in the last KC-iteration.

- This commit adds a macro BLIS_UKERNELS_NO_SPECULATIVE_PREFETCH to leave a
possibility to any architecture which, in exchange of carefull prefetching in
their micro-kernels to avoid invalid loads, to save some memory space.