### PR TITLE
Fixed double free in level1v example and freed a

### DIFF
--- a/examples/tapi/00level1v.c
+++ b/examples/tapi/00level1v.c
@@ -175,7 +175,7 @@ int main( int argc, char** argv )
 	free( y );
 	free( z );
 	free( w );
-	free( z );
+	free( a );
 
 	return 0;
 }


### PR DESCRIPTION
Pointer z was being freed twice and causing a crash.
Pointer a remained after the program terminates.