### PR TITLE
Added _self() and _equal() to bli_pthread API.

### DIFF
--- a/frame/thread/bli_pthread.c
+++ b/frame/thread/bli_pthread.c
@@ -169,6 +169,14 @@ void bli_pthread_once
 	init();
 }
 
+#if 0
+// NOTE: This part of the API is disabled because (1) we don't actually need
+// _self() or _equal() yet, and (2) when we do try to include these functions,
+// AppVeyor for some reason fails on all the Windows/clang builds with the
+// error:
+//    libblis.a(bli_pthread.o) : error LNK2019: unresolved external symbol
+//     __imp_CompareObjectHandles referenced in function bli_pthread_equal
+
 // -- pthread_self() --
 
 bli_pthread_t bli_pthread_self
@@ -192,6 +200,7 @@ int bli_pthread_equal
 	// system.
 	return 1;
 }
+#endif
 
 #elif defined(_MSC_VER) // !defined(BLIS_DISABLE_SYSTEM)
 
@@ -359,6 +368,14 @@ void bli_pthread_once
 	InitOnceExecuteOnce( once, bli_init_once_wrapper, init, NULL );
 }
 
+#if 0
+// NOTE: This part of the API is disabled because (1) we don't actually need
+// _self() or _equal() yet, and (2) when we do try to include these functions,
+// AppVeyor for some reason fails on all the Windows/clang builds with the
+// error:
+//    libblis.a(bli_pthread.o) : error LNK2019: unresolved external symbol
+//     __imp_CompareObjectHandles referenced in function bli_pthread_equal
+
 // -- pthread_self() --
 
 bli_pthread_t bli_pthread_self
@@ -387,6 +404,7 @@ int bli_pthread_equal
 {
 	return ( int )CompareObjectHandles( t1.handle, t2.handle );
 }
+#endif
 
 #else // !defined(BLIS_DISABLE_SYSTEM) && !defined(_MSC_VER)
 
@@ -508,6 +526,14 @@ void bli_pthread_once
 	pthread_once( once, init );
 }
 
+#if 0
+// NOTE: This part of the API is disabled because (1) we don't actually need
+// _self() or _equal() yet, and (2) when we do try to include these functions,
+// AppVeyor for some reason fails on all the Windows/clang builds with the
+// error:
+//    libblis.a(bli_pthread.o) : error LNK2019: unresolved external symbol
+//     __imp_CompareObjectHandles referenced in function bli_pthread_equal
+
 // -- pthread_self() --
 
 bli_pthread_t bli_pthread_self
@@ -528,8 +554,9 @@ int bli_pthread_equal
 {
 	return pthread_equal( t1, t2 );
 }
+#endif
 
-#endif // _MSC_VER
+#endif // !defined(BLIS_DISABLE_SYSTEM) && !defined(_MSC_VER)
 
 
 

--- a/frame/thread/bli_pthread.c
+++ b/frame/thread/bli_pthread.c
@@ -169,6 +169,30 @@ void bli_pthread_once
 	init();
 }
 
+// -- pthread_self() --
+
+bli_pthread_t bli_pthread_self
+     (
+       void
+     )
+{
+	return 0;
+}
+
+// -- pthread_equal() --
+
+int bli_pthread_equal
+     (
+       bli_pthread_t t1,
+       bli_pthread_t t2
+     )
+{
+	// We don't bother comparing t1 and t2 since we must, by definition, be
+	// executing the same thread if there is not threading mechanism on the
+	// system.
+	return 1;
+}
+
 #elif defined(_MSC_VER) // !defined(BLIS_DISABLE_SYSTEM)
 
 #include <errno.h>
@@ -335,6 +359,35 @@ void bli_pthread_once
 	InitOnceExecuteOnce( once, bli_init_once_wrapper, init, NULL );
 }
 
+// -- pthread_self() --
+
+bli_pthread_t bli_pthread_self
+     (
+       void
+     )
+{
+	bli_pthread_t t;
+
+	// Note: BLIS will only ever use bli_pthread_self() in conjunction with
+	// bli_pthread_equal(), and thus setting the .retval field is unnecessary.
+	// Despite this, we set it to NULL anyway.
+	t.handle = GetCurrentThread();
+	t.retval = NULL;
+
+	return t;
+}
+
+// -- pthread_equal() --
+
+int bli_pthread_equal
+     (
+       bli_pthread_t t1,
+       bli_pthread_t t2
+     )
+{
+	return ( int )CompareObjectHandles( t1.handle, t2.handle );
+}
+
 #else // !defined(BLIS_DISABLE_SYSTEM) && !defined(_MSC_VER)
 
 // This branch defines a pthreads-like API, bli_pthreads_*(), and implements it
@@ -453,6 +506,27 @@ void bli_pthread_once
      )
 {
 	pthread_once( once, init );
+}
+
+// -- pthread_self() --
+
+bli_pthread_t bli_pthread_self
+     (
+       void
+     )
+{
+	return pthread_self();
+}
+
+// -- pthread_equal() --
+
+int bli_pthread_equal
+     (
+       bli_pthread_t t1,
+       bli_pthread_t t2
+     )
+{
+	return pthread_equal( t1, t2 );
 }
 
 #endif // _MSC_VER

--- a/frame/thread/bli_pthread.h
+++ b/frame/thread/bli_pthread.h
@@ -219,12 +219,27 @@ BLIS_EXPORT_BLIS int bli_pthread_cond_broadcast
        bli_pthread_cond_t* cond
      );
 
-// -- pthread_once_*() --
+// -- pthread_once() --
 
 BLIS_EXPORT_BLIS void bli_pthread_once
      (
        bli_pthread_once_t* once,
        void              (*init)(void)
+     );
+
+// -- pthread_self() --
+
+BLIS_EXPORT_BLIS bli_pthread_t bli_pthread_self
+     (
+       void
+     );
+
+// -- pthread_equal() --
+
+BLIS_EXPORT_BLIS int bli_pthread_equal
+     (
+       bli_pthread_t t1,
+       bli_pthread_t t2
      );
 
 // -- pthread_barrier_*() --

--- a/frame/thread/bli_pthread.h
+++ b/frame/thread/bli_pthread.h
@@ -227,6 +227,14 @@ BLIS_EXPORT_BLIS void bli_pthread_once
        void              (*init)(void)
      );
 
+#if 0
+// NOTE: This part of the API is disabled because (1) we don't actually need
+// _self() or _equal() yet, and (2) when we do try to include these functions,
+// AppVeyor for some reason fails on all the Windows/clang builds with the
+// error:
+//    libblis.a(bli_pthread.o) : error LNK2019: unresolved external symbol
+//     __imp_CompareObjectHandles referenced in function bli_pthread_equal
+
 // -- pthread_self() --
 
 BLIS_EXPORT_BLIS bli_pthread_t bli_pthread_self
@@ -241,6 +249,7 @@ BLIS_EXPORT_BLIS int bli_pthread_equal
        bli_pthread_t t1,
        bli_pthread_t t2
      );
+#endif
 
 // -- pthread_barrier_*() --
 


### PR DESCRIPTION
Details:
- Expanded the bli_pthread API to include equivalents to pthread_self()
  and pthread_equal(). Implemented these two functions for all three cpp
  branches present within bli_pthread.c: systemless, Windows, and
  Linux/BSD.

@isuruf: Can you double-check my Windows implementations?
@devinamatthews: Please also check the Windows stuff. (Surely I did something wrong.) Thanks.