### PR TITLE
Fix bug in storing POWER10 DGEMM microkernel result

### DIFF
--- a/kernels/power10/3/bli_dgemm_power10_mma.c
+++ b/kernels/power10/3/bli_dgemm_power10_mma.c
@@ -168,25 +168,25 @@ void bli_dgemm_power10_mma_8x8
     // handle beta cases
     if (beta_ != 0.0)
     {
-        SAVE_ACC(dv4sf_t, &acc0, rs_c, 0      );
-        SAVE_ACC(dv4sf_t, &acc1, rs_c, 4      );
-        SAVE_ACC(dv4sf_t, &acc2, rs_c, 8      );
-        SAVE_ACC(dv4sf_t, &acc3, rs_c, 12     );
-        SAVE_ACC(dv4sf_t, &acc4, rs_c,    4*rs_c);
-        SAVE_ACC(dv4sf_t, &acc5, rs_c,  4+4*rs_c);
-        SAVE_ACC(dv4sf_t, &acc6, rs_c,  8+4*rs_c);
-        SAVE_ACC(dv4sf_t, &acc7, rs_c, 12+4*rs_c);
+        SAVE_ACC(dv4sf_t, &acc0, rs_c, 0       );
+        SAVE_ACC(dv4sf_t, &acc1, rs_c, 2       );
+        SAVE_ACC(dv4sf_t, &acc2, rs_c, 4       );
+        SAVE_ACC(dv4sf_t, &acc3, rs_c, 6       );
+        SAVE_ACC(dv4sf_t, &acc4, rs_c,   4*rs_c);
+        SAVE_ACC(dv4sf_t, &acc5, rs_c, 2+4*rs_c);
+        SAVE_ACC(dv4sf_t, &acc6, rs_c, 4+4*rs_c);
+        SAVE_ACC(dv4sf_t, &acc7, rs_c, 6+4*rs_c);
     }
     else
     {
-        SAVE_ACC_bz(dv4sf_t, &acc0, rs_c,  0     );
-        SAVE_ACC_bz(dv4sf_t, &acc1, rs_c,  4     );
-        SAVE_ACC_bz(dv4sf_t, &acc2, rs_c,  8     );
-        SAVE_ACC_bz(dv4sf_t, &acc3, rs_c, 12     );
-        SAVE_ACC_bz(dv4sf_t, &acc4, rs_c,    4*rs_c);
-        SAVE_ACC_bz(dv4sf_t, &acc5, rs_c,  4+4*rs_c);
-        SAVE_ACC_bz(dv4sf_t, &acc6, rs_c,  8+4*rs_c);
-        SAVE_ACC_bz(dv4sf_t, &acc7, rs_c, 12+4*rs_c);
+        SAVE_ACC_bz(dv4sf_t, &acc0, rs_c, 0       );
+        SAVE_ACC_bz(dv4sf_t, &acc1, rs_c, 2       );
+        SAVE_ACC_bz(dv4sf_t, &acc2, rs_c, 4       );
+        SAVE_ACC_bz(dv4sf_t, &acc3, rs_c, 6       );
+        SAVE_ACC_bz(dv4sf_t, &acc4, rs_c,   4*rs_c);
+        SAVE_ACC_bz(dv4sf_t, &acc5, rs_c, 2+4*rs_c);
+        SAVE_ACC_bz(dv4sf_t, &acc6, rs_c, 4+4*rs_c);
+        SAVE_ACC_bz(dv4sf_t, &acc7, rs_c, 6+4*rs_c);
     }
 
 }


### PR DESCRIPTION
There was a bug in the DGEMM P10 kernel that did not store the result of the microkernel correctly. The behavior of the bug was that when the result was being stored, it stored further than the allocated amount for the matrix buffer. This caused the user to see an error when using free(). The reason was due to the wrong index calculation 😞. 
