### PR TITLE
Fixed configure script bug.

### DIFF
--- a/configure
+++ b/configure
@@ -775,7 +775,8 @@ read_registry_file()
 					# canonicalize whitespace, and then remove duplicate kernel
 					# set names, if they exist. Finally, update the kernel registry
 					# with the new kernel list.
-					newklist=$(echo -e "${klisttmp}" | sed -e "s/${ker}/${kers_ker}/g")
+					#newklist=$(echo -e "${klisttmp}" | sed -e "s/${ker}/${kers_ker}/g")
+                    newklist=$(substitute_words "${ker}" "${kers_ker}" "${klisttmp}")
 					newklist=$(canonicalize_ws "${newklist}")
 					newklist=$(rm_duplicate_words "${newklist}")
 
@@ -795,6 +796,26 @@ read_registry_file()
 			done
 		done
 	done
+}
+
+substitute_words()
+{
+    local word new_words list newlist
+
+    word="$1"
+    new_words="$2"
+    list="$3"
+
+    for str in ${list}; do
+
+        if [ "${str}" == "${word}" ]; then
+            newlist="${newlist} ${new_words}"
+        else
+            newlist="${newlist} ${str}"
+        fi
+    done
+
+    echo "${newlist}"
 }
 
 build_kconfig_registry()


### PR DESCRIPTION
Details:
- Fixed kernel list string substitution error by adding function substitute_words in configure script.
- For example: zen in zen2 would be replaced by other strings, resulting in the wrong name and not containing the correct kernel header file.