### PR TITLE
Fix installation from out-of-tree builds

### DIFF
--- a/configure
+++ b/configure
@@ -3629,6 +3629,23 @@ main()
 			exit 1
 		fi
 
+		# If 'blis.pc.in' symlink does not already exist in the current
+		# directory, create a symbolic link to it. If one does exist, we
+		# use -f to force creation of a new link.
+		if [ ! -e "./blis.pc.in" ]; then
+
+			echo "${script_name}: creating symbolic link to blis.pc.in."
+			ln -s "${dist_path}/blis.pc.in"
+
+		elif [ -h "./blis.pc.in" ]; then
+			echo "${script_name}: symbolic link to blis.pc.in already exists; forcing creation of new link."
+			ln -sf "${dist_path}/blis.pc.in"
+		else
+			echo "${script_name}: Non-symbolic link file or directory 'blis.pc.in' blocks creation of symlink."
+			echo "${script_name}: *** Please remove this entity and re-run configure."
+			exit 1
+		fi
+
 		# If 'common.mk' symlink does not already exist in the current
 		# directory, create a symbolic link to it. If one does exist, we
 		# use -f to force creation of a new link.


### PR DESCRIPTION
# Issue
Currently, installing from out of source builds fails, since the Makefile can't find the `blis.pc.in` file. This can be reproduced with:
```
git clone https://github.com/flame/blis.git
mkdir blis-build && cd blis-build
../blis/configure x86_64
make
make install
```
which will fail with a message such as:
```
make: *** No rule to make target `blis.pc.in', needed by `<path/to/install/location>/share/pkgconfig'.  Stop.
```

# Fix
This PR fixes this issue by creating a symlink to `blis.pc.in` in the case of an out of source build in the same fashion as the symlinks for the `Makefile` and `common.mk` files.