### PR TITLE
Experimental version of obj_t using bit fields for the various flags.

### DIFF
--- a/frame/0/bli_l0_oapi.c
+++ b/frame/0/bli_l0_oapi.c
@@ -50,7 +50,7 @@ void PASTEMAC0(opname) \
 	bli_init_once(); \
 \
 	num_t     dt_chi; \
-	num_t     dt_absq_c  = bli_obj_dt_proj_to_complex( absq ); \
+	num_t     dt_absq_c  = bli_dt_proj_to_complex( bli_obj_dt( absq ) ); \
 \
 	void*     buf_chi; \
 	void*     buf_absq   = bli_obj_buffer_at_off( absq ); \
@@ -274,7 +274,7 @@ void PASTEMAC0(opname) \
 	bli_init_once(); \
 \
 	num_t     dt_chi; \
-	num_t     dt_zeta_c   = bli_obj_dt_proj_to_complex( zeta_r ); \
+	num_t     dt_zeta_c   = bli_dt_proj_to_complex( bli_obj_dt( zeta_r ) ); \
 \
 	void*     buf_chi; \
 \

--- a/frame/1m/packm/bli_packm_part.c
+++ b/frame/1m/packm/bli_packm_part.c
@@ -54,7 +54,7 @@ void bli_packm_acquire_mpart_t2b( subpart_t requested_part,
 
 	// Partitioning top-to-bottom through packed column panels (which are
 	// row-stored) is not yet supported.
-	if ( bli_obj_is_col_packed( obj ) )
+	if ( bli_is_col_packed( bli_obj_pack_schema( obj ) ) )
 	{
 		bli_check_error_code( BLIS_NOT_YET_IMPLEMENTED );
 	}
@@ -130,7 +130,7 @@ void bli_packm_acquire_mpart_l2r( subpart_t requested_part,
 
 	// Partitioning left-to-right through packed row panels (which are
 	// column-stored) is not yet supported.
-	if ( bli_obj_is_row_packed( obj ) )
+	if ( bli_is_row_packed( bli_obj_pack_schema( obj ) ) )
 	{
 		bli_check_error_code( BLIS_NOT_YET_IMPLEMENTED );
 	}

--- a/frame/3/bli_l3_blocksize.c
+++ b/frame/3/bli_l3_blocksize.c
@@ -139,13 +139,13 @@ dim_t PASTEMAC0(opname) \
 	   multiple of MR if A is Hermitian or symmetric, or NR if B is
 	   Hermitian or symmetric. If neither case applies, then we leave
 	   the blocksizes unchanged. */ \
-	if      ( bli_obj_root_is_herm_or_symm( a ) ) \
+	if      ( bli_is_herm_or_symm( bli_obj_struc( bli_obj_root( a ) ) ) ) \
 	{ \
 		mnr   = bli_cntx_get_blksz_def_dt( dt, BLIS_MR, cntx ); \
 		b_alg = bli_align_dim_to_mult( b_alg, mnr ); \
 		b_max = bli_align_dim_to_mult( b_max, mnr ); \
 	} \
-	else if ( bli_obj_root_is_herm_or_symm( b ) ) \
+	else if ( bli_is_herm_or_symm( bli_obj_struc( bli_obj_root( b ) ) ) ) \
 	{ \
 		mnr   = bli_cntx_get_blksz_def_dt( dt, BLIS_NR, cntx ); \
 		b_alg = bli_align_dim_to_mult( b_alg, mnr ); \
@@ -257,7 +257,7 @@ dim_t PASTEMAC0(opname) \
 	/* Nudge the default and maximum kc blocksizes up to the nearest
 	   multiple of MR if the triangular matrix is on the left, or NR
 	   if the triangular matrix is one the right. */ \
-	if ( bli_obj_root_is_triangular( a ) ) \
+	if ( bli_obj_is_triangular( bli_obj_root( a ) ) ) \
 		mnr = bli_cntx_get_blksz_def_dt( dt, BLIS_MR, cntx ); \
 	else \
 		mnr = bli_cntx_get_blksz_def_dt( dt, BLIS_NR, cntx ); \

--- a/frame/3/bli_l3_direct.c
+++ b/frame/3/bli_l3_direct.c
@@ -95,14 +95,14 @@ dir_t bli_trmm_direct
 	// - right,lower: forwards
 	// - right,upper: backwards
 
-	if ( bli_obj_root_is_triangular( a ) )
+	if ( bli_obj_is_triangular( bli_obj_root( a ) ) )
 	{
-		if ( bli_obj_root_is_lower( a ) ) direct = BLIS_BWD;
+		if ( bli_obj_is_lower( bli_obj_root( a ) ) ) direct = BLIS_BWD;
 		else                              direct = BLIS_FWD;
 	}
-	else // if ( bli_obj_root_is_triangular( b ) )
+	else // if ( bli_obj_is_triangular( bli_obj_root( b ) ) )
 	{
-		if ( bli_obj_root_is_lower( b ) ) direct = BLIS_FWD;
+		if ( bli_obj_is_lower( bli_obj_root( b ) ) ) direct = BLIS_FWD;
 		else                              direct = BLIS_BWD;
 	}
 
@@ -124,14 +124,14 @@ dir_t bli_trsm_direct
 	// - right,lower: backwards
 	// - right,upper: forwards
 
-	if ( bli_obj_root_is_triangular( a ) )
+	if ( bli_obj_is_triangular( bli_obj_root( a ) ) )
 	{
-		if ( bli_obj_root_is_lower( a ) ) direct = BLIS_FWD;
+		if ( bli_obj_is_lower( bli_obj_root( a ) ) ) direct = BLIS_FWD;
 		else                              direct = BLIS_BWD;
 	}
-	else // if ( bli_obj_root_is_triangular( b ) )
+	else // if ( bli_obj_is_triangular( bli_obj_root( b ) ) )
 	{
-		if ( bli_obj_root_is_lower( b ) ) direct = BLIS_BWD;
+		if ( bli_obj_is_lower( bli_obj_root( b ) ) ) direct = BLIS_BWD;
 		else                              direct = BLIS_FWD;
 	}
 

--- a/frame/3/gemm/bli_gemm_md.c
+++ b/frame/3/gemm/bli_gemm_md.c
@@ -740,7 +740,7 @@ void bli_gemm_md_zgemm
 		//num_t dt_c2 = bli_obj_dt( c );
 		//num_t dt_c1 = bli_dt_proj_to_complex( dt_c2 );
 		//num_t dt_c  = bli_dt_proj_to_double_prec( dt_c1 );
-		//num_t dt_c = bli_obj_dt_proj_to_complex( c );
+		//num_t dt_c = bli_dt_proj_to_complex( bli_obj_dt( c ) );
 		num_t dt_c = BLIS_DCOMPLEX;
 
 		if ( bli_obj_is_single_prec( c ) ) dt_c = BLIS_SCOMPLEX;

--- a/frame/3/gemm/bli_gemm_md.h
+++ b/frame/3/gemm/bli_gemm_md.h
@@ -101,7 +101,7 @@ BLIS_INLINE bool bli_gemm_md_is_crr( obj_t* a, obj_t* b, obj_t* c )
 	if ( bli_obj_is_complex( c ) &&
 	     bli_obj_is_real( a )    &&
 	     bli_obj_is_real( b )    &&
-	     bli_obj_exec_domain( c ) == BLIS_REAL )
+	     bli_is_real( bli_obj_exec_dt( c ) ) )
 		r_val = TRUE;
 
 	return r_val;
@@ -121,7 +121,7 @@ BLIS_INLINE bool bli_gemm_md_is_ccr( obj_t* a, obj_t* b, obj_t* c )
 	if ( bli_obj_is_complex( c ) &&
 	     bli_obj_is_complex( a ) &&
 	     bli_obj_is_real( b )    &&
-	     bli_obj_exec_domain( c ) == BLIS_COMPLEX )
+	     bli_is_complex( bli_obj_exec_dt( c ) ) )
 		r_val = TRUE;
 
 	return r_val;
@@ -141,7 +141,7 @@ BLIS_INLINE bool bli_gemm_md_is_crc( obj_t* a, obj_t* b, obj_t* c )
 	if ( bli_obj_is_complex( c ) &&
 	     bli_obj_is_real( a )    &&
 	     bli_obj_is_complex( b ) &&
-	     bli_obj_exec_domain( c ) == BLIS_COMPLEX )
+	     bli_is_complex( bli_obj_exec_dt( c ) ) )
 		r_val = TRUE;
 
 	return r_val;

--- a/frame/3/herk/bli_herk_x_ker_var2.c
+++ b/frame/3/herk/bli_herk_x_ker_var2.c
@@ -55,7 +55,7 @@ void bli_herk_x_ker_var2
 	gemm_var_oft f;
 
 	// Set a bool based on the uplo field of C's root object.
-	if ( bli_obj_root_is_lower( c ) ) uplo = 0;
+	if ( bli_obj_is_lower( bli_obj_root( c ) ) ) uplo = 0;
 	else                              uplo = 1;
 
 	// Index into the variant array to extract the correct function pointer.

--- a/frame/3/trmm/bli_trmm_xx_ker_var2.c
+++ b/frame/3/trmm/bli_trmm_xx_ker_var2.c
@@ -59,16 +59,16 @@ void bli_trmm_xx_ker_var2
 	// Set two bools: one based on the implied side parameter (the structure
 	// of the root object) and one based on the uplo field of the triangular
 	// matrix's root object (whether that is matrix A or matrix B).
-	if ( bli_obj_root_is_triangular( a ) )
+	if ( bli_obj_is_triangular( bli_obj_root( a ) ) )
 	{
 		side = 0;
-		if ( bli_obj_root_is_lower( a ) ) uplo = 0;
+		if ( bli_obj_is_lower( bli_obj_root( a ) ) ) uplo = 0;
 		else                              uplo = 1;
 	}
-	else // if ( bli_obj_root_is_triangular( b ) )
+	else // if ( bli_obj_is_triangular( bli_obj_root( b ) ) )
 	{
 		side = 1;
-		if ( bli_obj_root_is_lower( b ) ) uplo = 0;
+		if ( bli_obj_is_lower( bli_obj_root( b ) ) ) uplo = 0;
 		else                              uplo = 1;
 	}
 

--- a/frame/3/trsm/bli_trsm_int.c
+++ b/frame/3/trsm/bli_trsm_int.c
@@ -99,7 +99,7 @@ void bli_trsm_int
 	// Set two bools: one based on the implied side parameter (the structure
 	// of the root object) and one based on the uplo field of the triangular
 	// matrix's root object (whether that is matrix A or matrix B).
-	if ( bli_obj_root_is_triangular( a ) )
+	if ( bli_obj_is_triangular( bli_obj_root( a ) ) )
 	{
 		// If alpha is non-unit, typecast and apply it to the scalar
 		// attached to B (the non-triangular matrix).
@@ -108,7 +108,7 @@ void bli_trsm_int
 			bli_obj_scalar_apply_scalar( alpha, &b_local );
 		}
 	}
-	else // if ( bli_obj_root_is_triangular( b ) )
+	else // if ( bli_obj_is_triangular( bli_obj_root( b ) ) )
 	{
 		// If alpha is non-unit, typecast and apply it to the scalar
 		// attached to A (the non-triangular matrix).

--- a/frame/3/trsm/bli_trsm_xx_ker_var2.c
+++ b/frame/3/trsm/bli_trsm_xx_ker_var2.c
@@ -59,16 +59,16 @@ void bli_trsm_xx_ker_var2
 	// Set two bools: one based on the implied side parameter (the structure
 	// of the root object) and one based on the uplo field of the triangular
 	// matrix's root object (whether that is matrix A or matrix B).
-	if ( bli_obj_root_is_triangular( a ) )
+	if ( bli_obj_is_triangular( bli_obj_root( a ) ) )
 	{
 		side = 0;
-		if ( bli_obj_root_is_lower( a ) ) uplo = 0;
+		if ( bli_obj_is_lower( bli_obj_root( a ) ) ) uplo = 0;
 		else                              uplo = 1;
 	}
-	else // if ( bli_obj_root_is_triangular( b ) )
+	else // if ( bli_obj_is_triangular( bli_obj_root( b ) ) )
 	{
 		side = 1;
-		if ( bli_obj_root_is_lower( b ) ) uplo = 0;
+		if ( bli_obj_is_lower( bli_obj_root( b ) ) ) uplo = 0;
 		else                              uplo = 1;
 	}
 

--- a/frame/base/bli_obj.c
+++ b/frame/base/bli_obj.c
@@ -356,21 +356,21 @@ void bli_obj_free
 
 	buf_a = bli_obj_buffer_at_off( a );
 
-	bli_zzsets( 0.0, 0.0, value ); 
+	bli_zzsets( 0.0, 0.0, value );
 
-	if ( bli_obj_is_float( a ) )
+	if ( bli_obj_dt( a ) == BLIS_FLOAT )
 	{
 		bli_szcopys( *(( float*    )buf_a), value );
 	}
-	else if ( bli_obj_is_double( a ) )
+	else if ( bli_obj_dt( a ) == BLIS_DOUBLE )
 	{
 		bli_dzcopys( *(( double*   )buf_a), value );
 	}
-	else if ( bli_obj_is_scomplex( a ) )
+	else if ( bli_obj_dt( a ) == BLIS_SCOMPLEX )
 	{
 		bli_czcopys( *(( scomplex* )buf_a), value );
 	}
-	else if ( bli_obj_is_dcomplex( a ) )
+	else if ( bli_obj_dt( a ) == BLIS_DCOMPLEX )
 	{
 		bli_zzcopys( *(( dcomplex* )buf_a), value );
 	}
@@ -500,7 +500,7 @@ void bli_adjust_strides
 			// Set the column stride to indicate that this is a column vector
 			// stored in column-major order. This is done for legacy reasons,
 			// because we at one time we had to satisify the error checking
-			// in the underlying BLAS library, which expects the leading 
+			// in the underlying BLAS library, which expects the leading
 			// dimension to be set to at least m, even if it will never be
 			// used for indexing since it is a vector and thus only has one
 			// column of data.
@@ -664,9 +664,9 @@ void bli_obj_print
 	fprintf( file, " ps              %lu\n", ( unsigned long )bli_obj_panel_stride( obj ) );
 	fprintf( file, "\n" );
 
-	fprintf( file, " info            %lX\n", ( unsigned long )(*obj).info );
+	fprintf( file, " info               \n" );
 	fprintf( file, " - is complex    %lu\n", ( unsigned long )bli_obj_is_complex( obj ) );
-	fprintf( file, " - is d. prec    %lu\n", ( unsigned long )bli_obj_is_double_prec( obj ) );
+	fprintf( file, " - is d. prec    %lu\n", ( unsigned long )bli_is_double_prec( bli_obj_dt( obj ) ) );
 	fprintf( file, " - datatype      %lu\n", ( unsigned long )bli_obj_dt( obj ) );
 	fprintf( file, " - target dt     %lu\n", ( unsigned long )bli_obj_target_dt( obj ) );
 	fprintf( file, " - exec dt       %lu\n", ( unsigned long )bli_obj_exec_dt( obj ) );
@@ -675,16 +675,16 @@ void bli_obj_print
 	fprintf( file, " - has trans     %lu\n", ( unsigned long )bli_obj_has_trans( obj ) );
 	fprintf( file, " - has conj      %lu\n", ( unsigned long )bli_obj_has_conj( obj ) );
 	fprintf( file, " - unit diag?    %lu\n", ( unsigned long )bli_obj_has_unit_diag( obj ) );
-	fprintf( file, " - struc type    %lu\n", ( unsigned long )bli_obj_struc( obj ) >> BLIS_STRUC_SHIFT );
-	fprintf( file, " - uplo type     %lu\n", ( unsigned long )bli_obj_uplo( obj ) >> BLIS_UPLO_SHIFT );
+	fprintf( file, " - struc type    %lu\n", ( unsigned long )bli_obj_struc( obj ) );
+	fprintf( file, " - uplo type     %lu\n", ( unsigned long )bli_obj_uplo( obj ) );
 	fprintf( file, "   - is upper    %lu\n", ( unsigned long )bli_obj_is_upper( obj ) );
 	fprintf( file, "   - is lower    %lu\n", ( unsigned long )bli_obj_is_lower( obj ) );
 	fprintf( file, "   - is dense    %lu\n", ( unsigned long )bli_obj_is_dense( obj ) );
-	fprintf( file, " - pack schema   %lu\n", ( unsigned long )bli_obj_pack_schema( obj ) >> BLIS_PACK_SCHEMA_SHIFT );
+	fprintf( file, " - pack schema   %lu\n", ( unsigned long )bli_obj_pack_schema( obj ) );
 	fprintf( file, " - packinv diag? %lu\n", ( unsigned long )bli_obj_has_inverted_diag( obj ) );
 	fprintf( file, " - pack ordifup  %lu\n", ( unsigned long )bli_obj_is_pack_rev_if_upper( obj ) );
 	fprintf( file, " - pack ordiflo  %lu\n", ( unsigned long )bli_obj_is_pack_rev_if_lower( obj ) );
-	fprintf( file, " - packbuf type  %lu\n", ( unsigned long )bli_obj_pack_buffer_type( obj ) >> BLIS_PACK_BUFFER_SHIFT );
+	fprintf( file, " - packbuf type  %lu\n", ( unsigned long )bli_obj_pack_buffer_type( obj ) );
 	fprintf( file, "\n" );
 }
 

--- a/frame/base/bli_part.c
+++ b/frame/base/bli_part.c
@@ -131,7 +131,7 @@ void bli_acquire_mpart_mdim
 	// object is packed to row or column storage, as such objects can be
 	// partitioned through normally.) Note that the function called below
 	// assumes forward partitioning.
-	if ( bli_obj_is_panel_packed( obj ) )
+	if ( bli_is_panel_packed( bli_obj_pack_schema( obj ) ) )
 	{
 		bli_packm_acquire_mpart_t2b( req_part, i, b, obj, sub_obj );
 		return;
@@ -266,7 +266,7 @@ void bli_acquire_mpart_mdim
 	// diagonal, then set the subpartition structure to "general"; otherwise
 	// we let the subpartition inherit the storage structure of its immediate
 	// parent.
-	if ( !bli_obj_root_is_general( sub_obj ) && 
+	if ( !bli_obj_is_general( bli_obj_root( sub_obj ) ) &&
 	      bli_obj_is_outside_diag( sub_obj ) )
 	{
 		// NOTE: This comment may be out-of-date since we now distinguish
@@ -287,16 +287,16 @@ void bli_acquire_mpart_mdim
 		// matrix is triangular, the subpartition should be marked as zero.
 		if ( bli_obj_is_unstored_subpart( sub_obj ) )
 		{
-			if ( bli_obj_root_is_hermitian( sub_obj ) )
+			if ( bli_obj_is_hermitian( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_reflect_about_diag( sub_obj );
 				bli_obj_toggle_conj( sub_obj );
 			}
-			else if ( bli_obj_root_is_symmetric( sub_obj ) )
+			else if ( bli_obj_is_symmetric( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_reflect_about_diag( sub_obj );
 			}
-			else if ( bli_obj_root_is_triangular( sub_obj ) )
+			else if ( bli_obj_is_triangular( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_set_uplo( BLIS_ZEROS, sub_obj );
 			}
@@ -355,7 +355,7 @@ void bli_acquire_mpart_ndim
 	// object is packed to row or column storage, as such objects can be
 	// partitioned through normally.) Note that the function called below
 	// assumes forward partitioning.
-	if ( bli_obj_is_panel_packed( obj ) )
+	if ( bli_is_panel_packed( bli_obj_pack_schema( obj ) ) )
 	{
 		bli_packm_acquire_mpart_l2r( req_part, j, b, obj, sub_obj );
 		return;
@@ -489,7 +489,7 @@ void bli_acquire_mpart_ndim
 	// diagonal), and the subpartition does not intersect the root matrix's
 	// diagonal, then we might need to modify some of the subpartition's
 	// properties, depending on its structure type.
-	if ( !bli_obj_root_is_general( sub_obj ) && 
+	if ( !bli_obj_is_general( bli_obj_root( sub_obj ) ) &&
 	      bli_obj_is_outside_diag( sub_obj ) )
 	{
 		// NOTE: This comment may be out-of-date since we now distinguish
@@ -510,16 +510,16 @@ void bli_acquire_mpart_ndim
 		// matrix is triangular, the subpartition should be marked as zero.
 		if ( bli_obj_is_unstored_subpart( sub_obj ) )
 		{
-			if ( bli_obj_root_is_hermitian( sub_obj ) )
+			if ( bli_obj_is_hermitian( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_reflect_about_diag( sub_obj );
 				bli_obj_toggle_conj( sub_obj );
 			}
-			else if ( bli_obj_root_is_symmetric( sub_obj ) )
+			else if ( bli_obj_is_symmetric( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_reflect_about_diag( sub_obj );
 			}
-			else if ( bli_obj_root_is_triangular( sub_obj ) )
+			else if ( bli_obj_is_triangular( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_set_uplo( BLIS_ZEROS, sub_obj );
 			}
@@ -579,7 +579,7 @@ void bli_acquire_mpart_mndim
 	// object is packed to row or column storage, as such objects can be
 	// partitioned through normally.) Note that the function called below
 	// assumes forward partitioning.
-	if ( bli_obj_is_panel_packed( obj ) )
+	if ( bli_is_panel_packed( bli_obj_pack_schema( obj ) ) )
 	{
 		bli_packm_acquire_mpart_tl2br( req_part, ij, b, obj, sub_obj );
 		return;
@@ -742,7 +742,7 @@ void bli_acquire_mpart_mndim
 	// diagonal, then set the subpartition structure to "general"; otherwise
 	// we let the subpartition inherit the storage structure of its immediate
 	// parent.
-	if ( !bli_obj_root_is_general( sub_obj ) && 
+	if ( !bli_obj_is_general( bli_obj_root( sub_obj ) ) &&
 	     req_part != BLIS_SUBPART00 &&
 	     req_part != BLIS_SUBPART11 &&
 	     req_part != BLIS_SUBPART22 )
@@ -775,16 +775,16 @@ void bli_acquire_mpart_mndim
 		// matrix is triangular, the subpartition should be marked as zero.
 		if ( bli_obj_is_unstored_subpart( sub_obj ) )
 		{
-			if ( bli_obj_root_is_hermitian( sub_obj ) )
+			if ( bli_obj_is_hermitian( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_reflect_about_diag( sub_obj );
 				bli_obj_toggle_conj( sub_obj );
 			}
-			else if ( bli_obj_root_is_symmetric( sub_obj ) )
+			else if ( bli_obj_is_symmetric( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_reflect_about_diag( sub_obj );
 			}
-			else if ( bli_obj_root_is_triangular( sub_obj ) )
+			else if ( bli_obj_is_triangular( bli_obj_root( sub_obj ) ) )
 			{
 				bli_obj_set_uplo( BLIS_ZEROS, sub_obj );
 			}

--- a/frame/base/bli_prune.c
+++ b/frame/base/bli_prune.c
@@ -129,8 +129,8 @@ void bli_prune_unref_mparts( obj_t* p, mdim_t mdim_p,
 		// Only update the affected offset fields if the object in question
 		// is NOT a packed object. Otherwise, bli_obj_buffer_at_off() will
 		// compute the wrong address within the macro-kernel object wrapper.
-		if ( !bli_obj_is_packed( p ) ) { bli_obj_inc_off( mdim_p, off_inc, p ); }
-		if ( !bli_obj_is_packed( s ) ) { bli_obj_inc_off( mdim_s, off_inc, s ); }
+		if ( !bli_is_packed( bli_obj_pack_schema( p ) ) ) { bli_obj_inc_off( mdim_p, off_inc, p ); }
+		if ( !bli_is_packed( bli_obj_pack_schema( s ) ) ) { bli_obj_inc_off( mdim_s, off_inc, s ); }
 	}
 }
 

--- a/frame/base/bli_setri.c
+++ b/frame/base/bli_setri.c
@@ -51,7 +51,7 @@ void bli_setrm
 
 	// Initialize a local scalar, alpha_real, using the real projection
 	// of the datatype of b.
-	bli_obj_scalar_init_detached( bli_obj_dt_proj_to_real( b ),
+	bli_obj_scalar_init_detached( bli_dt_proj_to_real( bli_obj_dt( b ) ),
 	                              &alpha_real );
 
 	// Copy/typecast alpha to alpha_real. This discards the imaginary
@@ -80,7 +80,7 @@ void bli_setrv
 
 	// Initialize a local scalar, alpha_real, using the real projection
 	// of the datatype of x.
-	bli_obj_scalar_init_detached( bli_obj_dt_proj_to_real( x ),
+	bli_obj_scalar_init_detached( bli_dt_proj_to_real( bli_obj_dt( x ) ),
 	                              &alpha_real );
 
 	// Copy/typecast alpha to alpha_real. This discards the imaginary
@@ -114,7 +114,7 @@ void bli_setim
 
 	// Initialize a local scalar, alpha_real, using the real projection
 	// of the datatype of b.
-	bli_obj_scalar_init_detached( bli_obj_dt_proj_to_real( b ),
+	bli_obj_scalar_init_detached( bli_dt_proj_to_real( bli_obj_dt( b ) ),
 	                              &alpha_real );
 
 	// Copy/typecast alpha to alpha_real. This discards the imaginary
@@ -146,7 +146,7 @@ void bli_setiv
 
 	// Initialize a local scalar, alpha_real, using the real projection
 	// of the datatype of x.
-	bli_obj_scalar_init_detached( bli_obj_dt_proj_to_real( x ),
+	bli_obj_scalar_init_detached( bli_dt_proj_to_real( bli_obj_dt( x ) ),
 	                              &alpha_real );
 
 	// Copy/typecast alpha to alpha_real. This discards the imaginary

--- a/frame/include/bli_obj_macro_defs.h
+++ b/frame/include/bli_obj_macro_defs.h
@@ -44,541 +44,199 @@
 
 BLIS_INLINE num_t bli_obj_dt( obj_t* obj )
 {
-	return ( num_t )
-	       ( obj->info & BLIS_DATATYPE_BITS );
-}
-
-BLIS_INLINE bool bli_obj_is_float( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_dt( obj ) == BLIS_BITVAL_FLOAT_TYPE );
-}
-
-BLIS_INLINE bool bli_obj_is_double( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_dt( obj ) == BLIS_BITVAL_DOUBLE_TYPE );
-}
-
-BLIS_INLINE bool bli_obj_is_scomplex( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_dt( obj ) == BLIS_BITVAL_SCOMPLEX_TYPE );
-}
-
-BLIS_INLINE bool bli_obj_is_dcomplex( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_dt( obj ) == BLIS_BITVAL_DCOMPLEX_TYPE );
-}
-
-BLIS_INLINE bool bli_obj_is_int( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_dt( obj ) == BLIS_BITVAL_INT_TYPE );
-}
-
-BLIS_INLINE bool bli_obj_is_const( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_dt( obj ) == BLIS_BITVAL_CONST_TYPE );
-}
-
-BLIS_INLINE dom_t bli_obj_domain( obj_t* obj )
-{
-	return ( dom_t )
-	       ( obj->info & BLIS_DOMAIN_BIT );
+	return ( num_t ) obj->dt;
 }
 
 BLIS_INLINE prec_t bli_obj_prec( obj_t* obj )
 {
-	return ( prec_t )
-	       ( obj->info & BLIS_PRECISION_BIT );
+	return bli_dt_prec( bli_obj_dt( obj ) );
 }
 
-BLIS_INLINE bool bli_obj_is_single_prec( obj_t* obj )
+BLIS_INLINE dom_t bli_obj_domain( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_prec( obj ) == BLIS_BITVAL_SINGLE_PREC );
+	return bli_dt_domain( bli_obj_dt( obj ) );
 }
 
-BLIS_INLINE bool bli_obj_is_double_prec( obj_t* obj )
+BLIS_INLINE bool bli_obj_is_const( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_prec( obj ) == BLIS_BITVAL_DOUBLE_PREC );
-}
-
-BLIS_INLINE num_t bli_obj_dt_proj_to_single_prec( obj_t* obj )
-{
-	return ( num_t )
-	       ( bli_obj_dt( obj ) & ~BLIS_BITVAL_SINGLE_PREC );
-}
-
-BLIS_INLINE num_t bli_obj_dt_proj_to_double_prec( obj_t* obj )
-{
-	return ( num_t )
-	       ( bli_obj_dt( obj ) | BLIS_BITVAL_DOUBLE_PREC );
+	return bli_obj_dt( obj ) == BLIS_CONSTANT;
 }
 
 BLIS_INLINE bool bli_obj_is_real( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_domain( obj ) == BLIS_BITVAL_REAL &&
-	         !bli_obj_is_const( obj ) );
+	return bli_is_real( bli_obj_dt( obj ) );
 }
 
 BLIS_INLINE bool bli_obj_is_complex( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_domain( obj ) == BLIS_BITVAL_COMPLEX &&
-	         !bli_obj_is_const( obj ) );
-}
-
-BLIS_INLINE num_t bli_obj_dt_proj_to_real( obj_t* obj )
-{
-	return ( num_t )
-	       ( bli_obj_dt( obj ) & ~BLIS_BITVAL_COMPLEX );
-}
-
-BLIS_INLINE num_t bli_obj_dt_proj_to_complex( obj_t* obj )
-{
-	return ( num_t )
-	       ( bli_obj_dt( obj ) | BLIS_BITVAL_COMPLEX );
+	return bli_is_complex( bli_obj_dt( obj ) );
 }
 
 BLIS_INLINE num_t bli_obj_target_dt( obj_t* obj )
 {
-	return ( num_t )
-	       ( ( obj->info & BLIS_TARGET_DT_BITS ) >> BLIS_TARGET_DT_SHIFT );
-}
-
-BLIS_INLINE dom_t bli_obj_target_domain( obj_t* obj )
-{
-	return ( dom_t )
-	       ( ( obj->info & BLIS_TARGET_DOMAIN_BIT ) >> BLIS_TARGET_DT_SHIFT );
-}
-
-BLIS_INLINE prec_t bli_obj_target_prec( obj_t* obj )
-{
-	return ( prec_t )
-	       ( ( obj->info & BLIS_TARGET_PREC_BIT ) >> BLIS_TARGET_DT_SHIFT );
+	return ( num_t ) obj->target_dt;
 }
 
 BLIS_INLINE num_t bli_obj_exec_dt( obj_t* obj )
 {
-	return ( num_t )
-	       ( ( obj->info & BLIS_EXEC_DT_BITS ) >> BLIS_EXEC_DT_SHIFT );
-}
-
-BLIS_INLINE dom_t bli_obj_exec_domain( obj_t* obj )
-{
-	return ( dom_t )
-	       ( ( obj->info & BLIS_EXEC_DOMAIN_BIT ) >> BLIS_EXEC_DT_SHIFT );
-}
-
-BLIS_INLINE prec_t bli_obj_exec_prec( obj_t* obj )
-{
-	return ( prec_t )
-	       ( ( obj->info & BLIS_EXEC_PREC_BIT ) >> BLIS_EXEC_DT_SHIFT );
+	return ( num_t ) obj->exec_dt;
 }
 
 BLIS_INLINE num_t bli_obj_comp_dt( obj_t* obj )
 {
-	return ( num_t )
-	       ( ( obj->info & BLIS_COMP_DT_BITS ) >> BLIS_COMP_DT_SHIFT );
-}
-
-BLIS_INLINE dom_t bli_obj_comp_domain( obj_t* obj )
-{
-	return ( dom_t )
-	       ( ( obj->info & BLIS_COMP_DOMAIN_BIT ) >> BLIS_COMP_DT_SHIFT );
+	return ( num_t ) obj->comp_dt;
 }
 
 BLIS_INLINE prec_t bli_obj_comp_prec( obj_t* obj )
 {
-	return ( prec_t )
-	       ( ( obj->info & BLIS_COMP_PREC_BIT ) >> BLIS_COMP_DT_SHIFT );
+	return bli_dt_prec( bli_obj_comp_dt( obj ) );
 }
 
-// NOTE: This function queries info2.
 BLIS_INLINE num_t bli_obj_scalar_dt( obj_t* obj )
 {
-	return ( num_t )
-	       ( ( obj->info2 & BLIS_SCALAR_DT_BITS ) >> BLIS_SCALAR_DT_SHIFT );
-}
-
-// NOTE: This function queries info2.
-BLIS_INLINE dom_t bli_obj_scalar_domain( obj_t* obj )
-{
-	return ( dom_t )
-	       ( ( obj->info2 & BLIS_SCALAR_DOMAIN_BIT ) >> BLIS_SCALAR_DT_SHIFT );
-}
-
-// NOTE: This function queries info2.
-BLIS_INLINE prec_t bli_obj_scalar_prec( obj_t* obj )
-{
-	return ( prec_t )
-	       ( ( obj->info2 & BLIS_SCALAR_PREC_BIT ) >> BLIS_SCALAR_DT_SHIFT );
+	return ( num_t ) obj->scalar_dt;
 }
 
 BLIS_INLINE trans_t bli_obj_conjtrans_status( obj_t* obj )
 {
-	return ( trans_t )
-	       ( obj->info & BLIS_CONJTRANS_BITS );
+	return ( trans_t ) obj->conjtrans;
 }
 
 BLIS_INLINE trans_t bli_obj_onlytrans_status( obj_t* obj )
 {
-	return ( trans_t )
-	       ( obj->info & BLIS_TRANS_BIT );
-}
-
-BLIS_INLINE bool bli_obj_has_trans( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_onlytrans_status( obj ) == BLIS_BITVAL_TRANS );
-}
-
-BLIS_INLINE bool bli_obj_has_notrans( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_onlytrans_status( obj ) == BLIS_BITVAL_NO_TRANS );
+	return bli_extract_trans( bli_obj_conjtrans_status( obj ) );
 }
 
 BLIS_INLINE conj_t bli_obj_conj_status( obj_t* obj )
 {
-	return ( conj_t )
-	       ( obj->info & BLIS_CONJ_BIT );
+	return bli_extract_conj( bli_obj_conjtrans_status( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_has_trans( obj_t* obj )
+{
+	return bli_does_trans( bli_obj_conjtrans_status( obj ) );
 }
 
 BLIS_INLINE bool bli_obj_has_conj( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_conj_status( obj ) == BLIS_BITVAL_CONJ );
+	return bli_does_conj( bli_obj_conjtrans_status( obj ) );
 }
 
-BLIS_INLINE bool bli_obj_has_noconj( obj_t* obj )
+BLIS_INLINE bool bli_obj_has_notrans( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_conj_status( obj ) == BLIS_BITVAL_NO_CONJ );
+	return !bli_obj_has_trans( obj );
 }
 
 BLIS_INLINE uplo_t bli_obj_uplo( obj_t* obj )
 {
-	return ( uplo_t )
-	       ( obj->info & BLIS_UPLO_BITS );
-}
-
-BLIS_INLINE bool bli_obj_is_upper( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_uplo( obj ) == BLIS_BITVAL_UPPER );
-}
-
-BLIS_INLINE bool bli_obj_is_lower( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_uplo( obj ) == BLIS_BITVAL_LOWER );
-}
-
-BLIS_INLINE bool bli_obj_is_upper_or_lower( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_upper( obj ) ||
-	         bli_obj_is_lower( obj ) );
-}
-
-BLIS_INLINE bool bli_obj_is_dense( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_uplo( obj ) == BLIS_BITVAL_DENSE );
+	return ( uplo_t ) obj->uplo;
 }
 
 BLIS_INLINE bool bli_obj_is_zeros( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_uplo( obj ) == BLIS_BITVAL_ZEROS );
+	return bli_is_zeros( bli_obj_uplo( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_dense( obj_t* obj )
+{
+	return bli_is_dense( bli_obj_uplo( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_upper( obj_t* obj )
+{
+	return bli_is_upper( bli_obj_uplo( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_lower( obj_t* obj )
+{
+	return bli_is_lower( bli_obj_uplo( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_upper_or_lower( obj_t* obj )
+{
+	return bli_is_upper_or_lower( bli_obj_uplo( obj ) );
 }
 
 BLIS_INLINE diag_t bli_obj_diag( obj_t* obj )
 {
-	return ( diag_t )
-	       ( obj->info & BLIS_UNIT_DIAG_BIT );
+	return ( diag_t ) obj->diag;
 }
 
 BLIS_INLINE bool bli_obj_has_nonunit_diag( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_diag( obj ) == BLIS_BITVAL_NONUNIT_DIAG );
+	return bli_obj_diag( obj ) == BLIS_NONUNIT_DIAG;
 }
 
 BLIS_INLINE bool bli_obj_has_unit_diag( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_diag( obj ) == BLIS_BITVAL_UNIT_DIAG );
+	return bli_obj_diag( obj ) == BLIS_UNIT_DIAG;
 }
 
 BLIS_INLINE bool bli_obj_has_inverted_diag( obj_t* obj )
 {
-	return ( bool )
-	       ( ( obj->info & BLIS_INVERT_DIAG_BIT ) == BLIS_BITVAL_INVERT_DIAG );
+	return ( bool ) obj->invert_diag;
 }
 
 BLIS_INLINE bool bli_obj_is_pack_rev_if_upper( obj_t* obj )
 {
-	return ( bool )
-	       ( ( obj->info & BLIS_PACK_REV_IF_UPPER_BIT ) == BLIS_BITVAL_PACK_REV_IF_UPPER );
+	return ( bool ) obj->pack_rev_if_upper;
 }
 
 BLIS_INLINE bool bli_obj_is_pack_rev_if_lower( obj_t* obj )
 {
-	return ( bool )
-	       ( ( obj->info & BLIS_PACK_REV_IF_LOWER_BIT ) == BLIS_BITVAL_PACK_REV_IF_LOWER );
+	return ( bool ) obj->pack_rev_if_lower;
 }
 
 BLIS_INLINE pack_t bli_obj_pack_schema( obj_t* obj )
 {
-	return ( pack_t )
-	       ( obj->info & BLIS_PACK_SCHEMA_BITS );
-}
-
-BLIS_INLINE bool bli_obj_is_packed( obj_t* obj )
-{
-	return ( bool )
-	       ( obj->info & BLIS_PACK_BIT );
-}
-
-BLIS_INLINE bool bli_obj_is_row_packed( obj_t* obj )
-{
-	return ( bool )
-	       ( ( obj->info & BLIS_PACK_RC_BIT ) == ( BLIS_BITVAL_PACKED_UNSPEC ^
-                                                   BLIS_BITVAL_PACKED_ROWS    ) );
-}
-
-BLIS_INLINE bool bli_obj_is_col_packed( obj_t* obj )
-{
-	return ( bool )
-	       ( ( obj->info & BLIS_PACK_RC_BIT ) == ( BLIS_BITVAL_PACKED_UNSPEC ^
-                                                   BLIS_BITVAL_PACKED_COLUMNS ) );
-}
-
-BLIS_INLINE bool bli_obj_is_panel_packed( obj_t* obj )
-{
-	return ( bool )
-	       ( obj->info & BLIS_PACK_PANEL_BIT );
-}
-
-BLIS_INLINE packbuf_t bli_obj_pack_buffer_type( obj_t* obj )
-{
-	return ( packbuf_t )
-	       ( obj->info & BLIS_PACK_BUFFER_BITS );
+	return ( pack_t ) obj->pack_schema;
 }
 
 BLIS_INLINE struc_t bli_obj_struc( obj_t* obj )
 {
-	return ( struc_t )
-	       ( obj->info & BLIS_STRUC_BITS );
-}
-
-BLIS_INLINE bool bli_obj_is_general( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_struc( obj ) == BLIS_BITVAL_GENERAL );
-}
-
-BLIS_INLINE bool bli_obj_is_hermitian( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_struc( obj ) == BLIS_BITVAL_HERMITIAN );
-}
-
-BLIS_INLINE bool bli_obj_is_symmetric( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_struc( obj ) == BLIS_BITVAL_SYMMETRIC );
+	return ( struc_t ) obj->struc;
 }
 
 BLIS_INLINE bool bli_obj_is_triangular( obj_t* obj )
 {
-	return ( bool )
-	       ( bli_obj_struc( obj ) == BLIS_BITVAL_TRIANGULAR );
+	return bli_is_triangular( bli_obj_struc( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_general( obj_t* obj )
+{
+	return bli_is_general( bli_obj_struc( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_hermitian( obj_t* obj )
+{
+	return bli_is_hermitian( bli_obj_struc( obj ) );
+}
+
+BLIS_INLINE bool bli_obj_is_symmetric( obj_t* obj )
+{
+	return bli_is_symmetric( bli_obj_struc( obj ) );
+}
+
+BLIS_INLINE packbuf_t bli_obj_pack_buffer_type( obj_t* obj )
+{
+	return ( packbuf_t ) obj->pack_buffer;
 }
 
 // Info modification
 
+BLIS_INLINE void bli_obj_set_conjtrans( trans_t conjtrans, obj_t* obj )
+{
+	obj->conjtrans = conjtrans;
+}
+
 BLIS_INLINE void bli_obj_apply_trans( trans_t trans, obj_t* obj )
 {
-	obj->info = ( objbits_t )
-	            ( obj->info ^ trans );
+	bli_obj_set_conjtrans( bli_apply_trans( trans, bli_obj_conjtrans_status( obj ) ), obj );
 }
 
 BLIS_INLINE void bli_obj_apply_conj( conj_t conj, obj_t* obj )
 {
-	obj->info = ( objbits_t )
-	            ( obj->info ^ conj );
-}
-
-BLIS_INLINE void bli_obj_set_conjtrans( trans_t trans, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_CONJTRANS_BITS ) | trans );
-}
-
-BLIS_INLINE void bli_obj_set_onlytrans( trans_t trans, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_TRANS_BIT ) | trans );
-}
-
-BLIS_INLINE void bli_obj_set_conj( conj_t conj, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_CONJ_BIT ) | conj );
-}
-
-BLIS_INLINE void bli_obj_set_uplo( uplo_t uplo, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_UPLO_BITS ) | uplo );
-}
-
-BLIS_INLINE void bli_obj_set_diag( diag_t diag, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_UNIT_DIAG_BIT ) | diag );
-}
-
-BLIS_INLINE void bli_obj_set_invert_diag( invdiag_t invdiag, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_INVERT_DIAG_BIT ) | invdiag );
-}
-
-BLIS_INLINE void bli_obj_set_dt( num_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_DATATYPE_BITS ) | dt );
-}
-
-BLIS_INLINE void bli_obj_set_target_dt( num_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_TARGET_DT_BITS ) |
-	              ( dt << BLIS_TARGET_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_target_domain( dom_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_TARGET_DOMAIN_BIT ) |
-	              ( dt << BLIS_TARGET_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_target_prec( prec_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_TARGET_PREC_BIT ) |
-	              ( dt << BLIS_TARGET_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_exec_dt( num_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_EXEC_DT_BITS ) |
-	              ( dt << BLIS_EXEC_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_exec_domain( dom_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_EXEC_DOMAIN_BIT ) |
-	              ( dt << BLIS_EXEC_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_exec_prec( prec_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_EXEC_PREC_BIT ) |
-	              ( dt << BLIS_EXEC_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_comp_dt( num_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_COMP_DT_BITS ) |
-	              ( dt << BLIS_COMP_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_comp_domain( dom_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_COMP_DOMAIN_BIT ) |
-	              ( dt << BLIS_COMP_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_comp_prec( prec_t dt, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_COMP_PREC_BIT ) |
-	              ( dt << BLIS_COMP_DT_SHIFT ) );
-}
-
-// NOTE: This function queries and modifies info2.
-BLIS_INLINE void bli_obj_set_scalar_dt( num_t dt, obj_t* obj )
-{
-	obj->info2 = ( objbits_t )
-	             ( ( obj->info2 & ~BLIS_SCALAR_DT_BITS ) |
-	               ( dt << BLIS_SCALAR_DT_SHIFT ) );
-}
-
-// NOTE: This function queries and modifies info2.
-BLIS_INLINE void bli_obj_set_scalar_domain( dom_t dt, obj_t* obj )
-{
-	obj->info2 = ( objbits_t )
-	             ( ( obj->info2 & ~BLIS_SCALAR_DOMAIN_BIT ) |
-	               ( dt << BLIS_SCALAR_DT_SHIFT ) );
-}
-
-// NOTE: This function queries and modifies info2.
-BLIS_INLINE void bli_obj_set_scalar_prec( prec_t dt, obj_t* obj )
-{
-	obj->info2 = ( objbits_t )
-	             ( ( obj->info2 & ~BLIS_SCALAR_PREC_BIT ) |
-	               ( dt << BLIS_SCALAR_DT_SHIFT ) );
-}
-
-BLIS_INLINE void bli_obj_set_pack_schema( pack_t schema, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_PACK_SCHEMA_BITS ) | schema );
-}
-
-BLIS_INLINE void bli_obj_set_pack_order_if_upper( packord_t ordif, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_PACK_REV_IF_UPPER_BIT ) | ordif );
-}
-
-BLIS_INLINE void bli_obj_set_pack_order_if_lower( packord_t ordif, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_PACK_REV_IF_LOWER_BIT ) | ordif );
-}
-
-// NOTE: The packbuf_t bitfield in the obj_t is currently unused. Instead,
-// packbuf_t is stored/used from the context in order to support various
-// induced methods. (Though ideally the packbuf_t field would only be
-// present in the control tree).
-BLIS_INLINE void bli_obj_set_pack_buffer_type( packbuf_t buf_type, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_PACK_BUFFER_BITS ) | buf_type );
-}
-
-BLIS_INLINE void bli_obj_set_struc( struc_t struc, obj_t* obj )
-{
-	obj->info = ( objbits_t )
-	            ( ( obj->info & ~BLIS_STRUC_BITS ) | struc );
+	bli_obj_apply_trans ( (trans_t)conj, obj );
 }
 
 BLIS_INLINE void bli_obj_toggle_trans( obj_t* obj )
@@ -591,10 +249,118 @@ BLIS_INLINE void bli_obj_toggle_conj( obj_t* obj )
 	bli_obj_apply_conj( BLIS_CONJUGATE, obj );
 }
 
+BLIS_INLINE void bli_obj_set_onlytrans( trans_t trans, obj_t* obj )
+{
+	obj->conjtrans = ( obj->conjtrans & ~BLIS_BITVAL_TRANS ) | trans;
+}
+
+BLIS_INLINE void bli_obj_set_conj( conj_t conj, obj_t* obj )
+{
+	obj->conjtrans = ( obj->conjtrans & ~BLIS_BITVAL_CONJ ) | conj;
+}
+
 BLIS_INLINE void bli_obj_toggle_uplo( obj_t* obj )
 {
-	obj->info = ( objbits_t )
-	            ( obj->info ^ BLIS_LOWER_BIT ) ^ BLIS_UPPER_BIT;
+	obj->uplo = bli_uplo_toggled( obj-> uplo );
+}
+
+BLIS_INLINE void bli_obj_set_uplo( uplo_t uplo, obj_t* obj )
+{
+	obj->uplo = uplo;
+}
+
+BLIS_INLINE void bli_obj_set_diag( diag_t diag, obj_t* obj )
+{
+	obj->diag = diag;
+}
+
+BLIS_INLINE void bli_obj_set_invert_diag( invdiag_t invdiag, obj_t* obj )
+{
+	obj->invert_diag = invdiag;
+}
+
+BLIS_INLINE void bli_obj_set_dt( num_t dt, obj_t* obj )
+{
+	obj->dt = dt;
+}
+
+BLIS_INLINE void bli_obj_set_target_dt( num_t dt, obj_t* obj )
+{
+	obj->target_dt = dt;
+}
+
+BLIS_INLINE void bli_obj_set_target_domain( dom_t dt, obj_t* obj )
+{
+	obj->target_dt = ( obj->target_dt & ~BLIS_BITVAL_COMPLEX ) | dt;
+}
+
+BLIS_INLINE void bli_obj_set_target_prec( prec_t dt, obj_t* obj )
+{
+	obj->target_dt = ( obj->target_dt & ~BLIS_BITVAL_DOUBLE_PREC ) | dt;
+}
+
+BLIS_INLINE void bli_obj_set_exec_dt( num_t dt, obj_t* obj )
+{
+	obj->exec_dt = dt;
+}
+
+BLIS_INLINE void bli_obj_set_exec_domain( dom_t dt, obj_t* obj )
+{
+	obj->exec_dt = ( obj->exec_dt & ~BLIS_BITVAL_COMPLEX ) | dt;
+}
+
+BLIS_INLINE void bli_obj_set_exec_prec( prec_t dt, obj_t* obj )
+{
+	obj->exec_dt = ( obj->exec_dt & ~BLIS_BITVAL_DOUBLE_PREC ) | dt;
+}
+
+BLIS_INLINE void bli_obj_set_comp_dt( num_t dt, obj_t* obj )
+{
+	obj->comp_dt = dt;
+}
+
+BLIS_INLINE void bli_obj_set_comp_domain( dom_t dt, obj_t* obj )
+{
+	obj->comp_dt = ( obj->comp_dt & ~BLIS_BITVAL_COMPLEX ) | dt;
+}
+
+BLIS_INLINE void bli_obj_set_comp_prec( prec_t dt, obj_t* obj )
+{
+	obj->comp_dt = ( obj->comp_dt & ~BLIS_BITVAL_DOUBLE_PREC ) | dt;
+}
+
+BLIS_INLINE void bli_obj_set_scalar_dt( num_t dt, obj_t* obj )
+{
+	obj->scalar_dt = dt;
+}
+
+BLIS_INLINE void bli_obj_set_pack_schema( pack_t schema, obj_t* obj )
+{
+	obj->pack_schema = schema;
+}
+
+BLIS_INLINE void bli_obj_set_pack_order_if_upper( packord_t ordif, obj_t* obj )
+{
+	obj->pack_rev_if_upper = ( ordif == BLIS_PACK_REV_IF_UPPER );
+}
+
+BLIS_INLINE void bli_obj_set_pack_order_if_lower( packord_t ordif, obj_t* obj )
+{
+	obj->pack_rev_if_lower = ( ordif == BLIS_PACK_REV_IF_LOWER );
+}
+
+// NOTE: The packbuf_t bitfield in the obj_t is currently unused. Instead,
+// packbuf_t is stored/used from the context in order to support various
+// induced methods. (Though ideally the packbuf_t field would only be
+// present in the control tree).
+BLIS_INLINE void bli_obj_set_pack_buffer_type( packbuf_t buf_type, obj_t* obj )
+{
+	obj->pack_buffer = buf_type;
+}
+
+BLIS_INLINE void bli_obj_set_struc( struc_t struc, obj_t* obj )
+{
+	obj->struc = struc;
 }
 
 // Root matrix query
@@ -602,49 +368,6 @@ BLIS_INLINE void bli_obj_toggle_uplo( obj_t* obj )
 BLIS_INLINE obj_t* bli_obj_root( obj_t* obj )
 {
 	return ( obj_t* )( obj->root );
-}
-
-BLIS_INLINE bool bli_obj_root_is_general( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_general( bli_obj_root( obj ) ) );
-}
-
-BLIS_INLINE bool bli_obj_root_is_hermitian( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_hermitian( bli_obj_root( obj ) ) );
-}
-
-BLIS_INLINE bool bli_obj_root_is_symmetric( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_symmetric( bli_obj_root( obj ) ) );
-}
-
-BLIS_INLINE bool bli_obj_root_is_triangular( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_triangular( bli_obj_root( obj ) ) );
-}
-
-BLIS_INLINE bool bli_obj_root_is_herm_or_symm( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_hermitian( bli_obj_root( obj ) ) ||
-	         bli_obj_is_symmetric( bli_obj_root( obj ) ) );
-}
-
-BLIS_INLINE bool bli_obj_root_is_upper( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_upper( bli_obj_root( obj ) ) );
-}
-
-BLIS_INLINE bool bli_obj_root_is_lower( obj_t* obj )
-{
-	return ( bool )
-	       ( bli_obj_is_lower( bli_obj_root( obj ) ) );
 }
 
 // Root matrix modification
@@ -665,8 +388,9 @@ BLIS_INLINE doff_t bli_obj_diag_offset( obj_t* obj )
 BLIS_INLINE doff_t bli_obj_diag_offset_after_trans( obj_t* obj )
 {
 	return ( doff_t )
-	       ( bli_obj_has_trans( obj ) ? -bli_obj_diag_offset( obj )
-	                                  :  bli_obj_diag_offset( obj ) );
+           ( bli_obj_has_trans( obj )
+             ? -bli_obj_diag_offset( obj )
+	         :  bli_obj_diag_offset( obj ) );
 }
 
 // Diagonal offset modification
@@ -1020,8 +744,8 @@ BLIS_INLINE bool bli_obj_intersects_diag( obj_t* obj )
 BLIS_INLINE bool bli_obj_is_unstored_subpart( obj_t* obj )
 {
 	return ( bool )
-	       ( ( bli_obj_root_is_lower( obj ) && bli_obj_is_strictly_above_diag( obj ) ) ||
-	         ( bli_obj_root_is_upper( obj ) && bli_obj_is_strictly_below_diag( obj ) ) );
+	       ( ( bli_obj_is_lower( bli_obj_root( obj ) ) && bli_obj_is_strictly_above_diag( obj ) ) ||
+	         ( bli_obj_is_upper( bli_obj_root( obj ) ) && bli_obj_is_strictly_below_diag( obj ) ) );
 }
 
 // Buffer address query
@@ -1262,8 +986,20 @@ BLIS_INLINE void bli_obj_toggle_uplo_if_trans( trans_t trans, obj_t* obj )
 
 BLIS_INLINE void bli_obj_set_defaults( obj_t* obj )
 {
-	obj->info = 0x0;
-	obj->info = obj->info | BLIS_BITVAL_DENSE | BLIS_BITVAL_GENERAL;
+    obj->dt = BLIS_SINGLE_PREC;
+    obj->target_dt = BLIS_SINGLE_PREC;
+    obj->exec_dt = BLIS_SINGLE_PREC;
+    obj->comp_dt = BLIS_SINGLE_PREC;
+    obj->scalar_dt = BLIS_SINGLE_PREC;
+    obj->conjtrans = BLIS_NO_TRANSPOSE;
+    obj->uplo = BLIS_DENSE;
+    obj->diag = BLIS_NONUNIT_DIAG;
+    obj->invert_diag = BLIS_NO_INVERT_DIAG;
+    obj->pack_schema = BLIS_NOT_PACKED;
+    obj->pack_rev_if_upper = BLIS_PACK_FWD_IF_UPPER;
+    obj->pack_rev_if_lower = BLIS_PACK_FWD_IF_LOWER;
+    obj->pack_buffer = BLIS_BUFFER_FOR_A_BLOCK;
+    obj->struc = BLIS_GENERAL;
 }
 
 // Acquire buffer at object's submatrix offset (offset-aware buffer query).

--- a/frame/include/bli_param_macro_defs.h
+++ b/frame/include/bli_param_macro_defs.h
@@ -129,37 +129,33 @@ BLIS_INLINE bool bli_is_double_prec( num_t dt )
 BLIS_INLINE dom_t bli_dt_domain( num_t dt )
 {
 	return ( dom_t )
-	       ( dt & BLIS_DOMAIN_BIT );
+	       ( dt & BLIS_BITVAL_COMPLEX );
 }
 
 BLIS_INLINE bool bli_dt_dom_is_real( num_t dt )
 {
-	return ( bool )
-	       ( ( dt & BLIS_DOMAIN_BIT ) == BLIS_REAL );
+	return bli_dt_domain( dt ) == BLIS_REAL;
 }
 
 BLIS_INLINE bool bli_dt_dom_is_complex( num_t dt )
 {
-	return ( bool )
-	       ( ( dt & BLIS_DOMAIN_BIT ) == BLIS_COMPLEX );
+	return bli_dt_domain( dt ) == BLIS_COMPLEX;
 }
 
 BLIS_INLINE prec_t bli_dt_prec( num_t dt )
 {
 	return ( prec_t )
-	       ( dt & BLIS_PRECISION_BIT );
+	       ( dt & BLIS_BITVAL_DOUBLE_PREC );
 }
 
 BLIS_INLINE bool bli_dt_prec_is_single( num_t dt )
 {
-	return ( bool )
-	       ( ( dt & BLIS_PRECISION_BIT ) == BLIS_SINGLE_PREC );
+	return bli_dt_prec( dt ) == BLIS_SINGLE_PREC;
 }
 
 BLIS_INLINE bool bli_dt_prec_is_double( num_t dt )
 {
-	return ( bool )
-	       ( ( dt & BLIS_PRECISION_BIT ) == BLIS_DOUBLE_PREC );
+	return bli_dt_prec( dt ) == BLIS_DOUBLE_PREC;
 }
 
 BLIS_INLINE num_t bli_dt_proj_to_real( num_t dt )
@@ -213,58 +209,54 @@ BLIS_INLINE bool bli_is_conjtrans( trans_t trans )
 	       ( trans == BLIS_CONJ_TRANSPOSE );
 }
 
-BLIS_INLINE bool bli_does_notrans( trans_t trans )
-{
-	return ( bool )
-	       ( (~trans & BLIS_TRANS_BIT ) == BLIS_BITVAL_TRANS );
-}
-
 BLIS_INLINE bool bli_does_trans( trans_t trans )
 {
 	return ( bool )
-	       ( ( trans & BLIS_TRANS_BIT ) == BLIS_BITVAL_TRANS );
+           ( trans & BLIS_BITVAL_TRANS );
 }
 
-BLIS_INLINE bool bli_does_noconj( trans_t trans )
+BLIS_INLINE bool bli_does_notrans( trans_t trans )
 {
-	return ( bool )
-	       ( (~trans & BLIS_CONJ_BIT ) == BLIS_BITVAL_CONJ );
+	return !bli_does_trans( trans );
 }
 
 BLIS_INLINE bool bli_does_conj( trans_t trans )
 {
 	return ( bool )
-	       ( ( trans & BLIS_CONJ_BIT ) == BLIS_BITVAL_CONJ );
+	       ( trans & BLIS_BITVAL_CONJ );
+}
+
+BLIS_INLINE bool bli_does_noconj( trans_t trans )
+{
+	return !bli_does_conj( trans );
 }
 
 BLIS_INLINE trans_t bli_extract_trans( trans_t trans )
 {
 	return ( trans_t )
-	       ( trans & BLIS_TRANS_BIT );
+	       ( trans & BLIS_BITVAL_TRANS );
 }
 
 BLIS_INLINE conj_t bli_extract_conj( trans_t trans )
 {
 	return ( conj_t )
-	       ( trans & BLIS_CONJ_BIT );
-}
-
-BLIS_INLINE trans_t bli_trans_toggled( trans_t trans )
-{
-	return ( trans_t )
-	       ( trans ^ BLIS_TRANS_BIT );
-}
-
-BLIS_INLINE trans_t bli_trans_toggled_conj( trans_t trans )
-{
-	return ( trans_t )
-	       ( trans ^ BLIS_CONJ_BIT );
+	       ( trans & BLIS_BITVAL_CONJ );
 }
 
 BLIS_INLINE trans_t bli_apply_trans( trans_t transapp, trans_t trans )
 {
 	return ( trans_t )
 	       ( trans ^ transapp );
+}
+
+BLIS_INLINE trans_t bli_trans_toggled( trans_t trans )
+{
+	return bli_apply_trans( BLIS_TRANSPOSE, trans );
+}
+
+BLIS_INLINE trans_t bli_trans_toggled_conj( trans_t trans )
+{
+	return bli_apply_trans( (trans_t)BLIS_CONJUGATE, trans );
 }
 
 BLIS_INLINE void bli_toggle_trans( trans_t* trans )
@@ -335,8 +327,8 @@ BLIS_INLINE uplo_t bli_uplo_toggled( uplo_t uplo )
 {
 	return ( uplo_t )
 	       ( bli_is_upper_or_lower( uplo )
-	         ? ( ( uplo ^ BLIS_LOWER_BIT ) ^ BLIS_UPPER_BIT )
-	         :     uplo
+	         ? uplo ^ ( BLIS_BITVAL_STRICT_LOWER | BLIS_BITVAL_STRICT_UPPER )
+	         : uplo
 	       );
 }
 
@@ -382,28 +374,26 @@ BLIS_INLINE bool bli_is_herm_or_symm( struc_t struc )
 
 // conj
 
-BLIS_INLINE bool bli_is_noconj( conj_t conj )
-{
-	return ( bool )
-	       ( conj == BLIS_NO_CONJUGATE );
-}
-
 BLIS_INLINE bool bli_is_conj( conj_t conj )
 {
 	return ( bool )
 	       ( conj == BLIS_CONJUGATE );
 }
 
-BLIS_INLINE conj_t bli_conj_toggled( conj_t conj )
+BLIS_INLINE bool bli_is_noconj( conj_t conj )
 {
-	return ( conj_t )
-	       ( conj ^ BLIS_CONJ_BIT );
+	return !bli_is_conj( conj );
 }
 
 BLIS_INLINE conj_t bli_apply_conj( conj_t conjapp, conj_t conj )
 {
 	return ( conj_t )
-	       ( conj ^ conjapp );
+	       bli_apply_trans( (trans_t)conjapp, (trans_t)conj );
+}
+
+BLIS_INLINE conj_t bli_conj_toggled( conj_t conj )
+{
+	return bli_apply_conj( BLIS_CONJUGATE, conj );
 }
 
 BLIS_INLINE void bli_toggle_conj( conj_t* conj )
@@ -754,7 +744,7 @@ BLIS_INLINE void bli_prune_unstored_region_bottom_u( doff_t* diagoff, dim_t* m, 
 	*offm_inc = 0;
 
 	// If the diagonal intersects the right side of the matrix,
-	// ignore the area below that intersection. 
+	// ignore the area below that intersection.
 	if ( *m > -(*diagoff) + *n )
 	{
 		*m = -(*diagoff) + *n;
@@ -956,8 +946,7 @@ BLIS_INLINE bool bli_is_last_iter( dim_t i, dim_t end_iter, dim_t tid, dim_t nth
 
 BLIS_INLINE guint_t bli_packbuf_index( packbuf_t buf_type )
 {
-	return ( guint_t )
-	       ( ( buf_type & BLIS_PACK_BUFFER_BITS ) >> BLIS_PACK_BUFFER_SHIFT );
+	return ( guint_t )buf_type;
 }
 
 // pack_t-related
@@ -965,27 +954,24 @@ BLIS_INLINE guint_t bli_packbuf_index( packbuf_t buf_type )
 BLIS_INLINE bool bli_is_packed( pack_t schema )
 {
 	return ( bool )
-	       ( schema & BLIS_PACK_BIT );
-}
-
-BLIS_INLINE bool bli_is_row_packed( pack_t schema )
-{
-	return ( bool )
-	       ( ( schema & BLIS_PACK_RC_BIT ) == ( BLIS_BITVAL_PACKED_UNSPEC ^
-	                                            BLIS_BITVAL_PACKED_ROWS ) );
+	       ( schema & BLIS_BITVAL_PACKED );
 }
 
 BLIS_INLINE bool bli_is_col_packed( pack_t schema )
 {
 	return ( bool )
-	       ( ( schema & BLIS_PACK_RC_BIT ) == ( BLIS_BITVAL_PACKED_UNSPEC ^
-	                                            BLIS_BITVAL_PACKED_COLUMNS ) );
+	       ( schema & BLIS_BITVAL_COLUMNS );
+}
+
+BLIS_INLINE bool bli_is_row_packed( pack_t schema )
+{
+	return !bli_is_col_packed( schema );
 }
 
 BLIS_INLINE bool bli_is_panel_packed( pack_t schema )
 {
 	return ( bool )
-	       ( schema & BLIS_PACK_PANEL_BIT );
+	       ( schema & BLIS_BITVAL_PANEL );
 }
 
 BLIS_INLINE bool bli_is_4mi_packed( pack_t schema )
@@ -1065,8 +1051,7 @@ BLIS_INLINE bool bli_is_ind_packed( pack_t schema )
 
 BLIS_INLINE guint_t bli_pack_schema_index( pack_t schema )
 {
-	return ( guint_t )
-	       ( ( schema & BLIS_PACK_FORMAT_BITS ) >> BLIS_PACK_FORMAT_SHIFT );
+	return ( guint_t )( schema & BLIS_PACK_FORMAT_BITS );
 }
 
 

--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -43,6 +43,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
@@ -121,6 +122,26 @@
   //#include <sys/time.h>
 
   #include <time.h>
+#endif
+
+// Standard integer types
+#ifdef __cplusplus
+  // For C++, include stdint.h.
+  #include <stdint.h>
+#elif __STDC_VERSION__ >= 199901L
+  // For C99 (or later), include stdint.h.
+  #include <stdint.h>
+  #include <stdbool.h>
+#else
+  // When stdint.h is not available, manually typedef the types we will use.
+  #ifdef _WIN32
+    typedef          __int32  int32_t;
+    typedef unsigned __int32 uint32_t;
+    typedef          __int64  int64_t;
+    typedef unsigned __int64 uint64_t;
+  #else
+    #error "Attempting to compile on pre-C99 system without stdint.h."
+  #endif
 #endif
 
 

--- a/frame/include/blis.h
+++ b/frame/include/blis.h
@@ -38,21 +38,21 @@
 #define BLIS_H
 
 
+// NOTE: PLEASE DON'T CHANGE THE ORDER IN WHICH HEADERS ARE INCLUDED UNLESS
+// YOU ARE SURE THAT IT DOESN'T BREAK INTER-HEADER MACRO DEPENDENCIES.
+
+// -- System headers --
+// NOTE: This header must be included before bli_config_macro_defs.h,
+//       and also before extern "C".
+
+#include "bli_system.h"
+
 // Allow C++ users to include this header file in their source code. However,
 // we make the extern "C" conditional on whether we're using a C++ compiler,
 // since regular C compilers don't understand the extern "C" construct.
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// NOTE: PLEASE DON'T CHANGE THE ORDER IN WHICH HEADERS ARE INCLUDED UNLESS
-// YOU ARE SURE THAT IT DOESN'T BREAK INTER-HEADER MACRO DEPENDENCIES.
-
-// -- System headers --
-// NOTE: This header must be included before bli_config_macro_defs.h.
-
-#include "bli_system.h"
-
 
 // -- configure definitions --
 

--- a/frame/thread/bli_thread.c
+++ b/frame/thread/bli_thread.c
@@ -661,7 +661,7 @@ siz_t bli_thread_range_mdim
 	// packing A and B.
 	if ( family == BLIS_TRSM )
 	{
-		if ( bli_obj_root_is_triangular( a ) ) bszid = BLIS_MR;
+		if ( bli_obj_is_triangular( bli_obj_root( a ) ) ) bszid = BLIS_MR;
 		else                                   bszid = BLIS_NR;
 	}
 
@@ -720,7 +720,7 @@ siz_t bli_thread_range_ndim
 	// packing A and B.
 	if ( family == BLIS_TRSM )
 	{
-		if ( bli_obj_root_is_triangular( b ) ) bszid = BLIS_MR;
+		if ( bli_obj_is_triangular( bli_obj_root( b ) ) ) bszid = BLIS_MR;
 		else                                   bszid = BLIS_NR;
 	}
 

--- a/test/mixeddt/test_gemm.c
+++ b/test/mixeddt/test_gemm.c
@@ -275,7 +275,7 @@ void blas_gemm_md( obj_t* alpha, obj_t* a, obj_t* b, obj_t* beta, obj_t* c )
 	bool    force_proj_a = FALSE;
 	bool    force_proj_b = FALSE;
 
-	
+
 
 	if      (    bli_is_real( dtc ) &&    bli_is_real( dta ) &&    bli_is_real( dtb ) )
 	{
@@ -410,7 +410,7 @@ void blas_gemm_md( obj_t* alpha, obj_t* a, obj_t* b, obj_t* beta, obj_t* c )
 		inc_t ma  = bli_obj_length( ao );
 		inc_t na  = bli_obj_width( ao );
 		siz_t ela = bli_obj_elem_size( ao );
-		num_t dtap = bli_obj_dt_proj_to_real( ao );
+		num_t dtap = bli_dt_proj_to_real( bli_obj_dt( ao ) );
 
 		bli_obj_alias_to( ao, &ar ); ao = &ar;
 		bli_obj_set_strides( rsa, 2*csa, ao );
@@ -423,7 +423,7 @@ void blas_gemm_md( obj_t* alpha, obj_t* a, obj_t* b, obj_t* beta, obj_t* c )
 		inc_t mc  = bli_obj_length( co );
 		inc_t nc  = bli_obj_width( co );
 		siz_t elc = bli_obj_elem_size( co );
-		num_t dtcp = bli_obj_dt_proj_to_real( co );
+		num_t dtcp = bli_dt_proj_to_real( bli_obj_dt( co ) );
 
 		bli_obj_alias_to( co, &cr ); co = &cr;
 		bli_obj_set_strides( rsc, 2*csc, co );

--- a/testsuite/src/test_addm.c
+++ b/testsuite/src/test_addm.c
@@ -249,7 +249,7 @@ void libblis_test_addm_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 	dim_t  m       = bli_obj_length( y );
 	dim_t  n       = bli_obj_width( y );
 

--- a/testsuite/src/test_addv.c
+++ b/testsuite/src/test_addv.c
@@ -187,7 +187,7 @@ void libblis_test_addv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Disable repeats since bli_copyv() is not yet tested. 
+	// Disable repeats since bli_copyv() is not yet tested.
 	//for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -245,7 +245,7 @@ void libblis_test_addv_check
      )
 {
 	num_t  dt      = bli_obj_dt( x );
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 	dim_t  m       = bli_obj_vector_dim( x );
 
 	conj_t conjx   = bli_obj_conj_status( x );

--- a/testsuite/src/test_axpbyv.c
+++ b/testsuite/src/test_axpbyv.c
@@ -209,7 +209,7 @@ void libblis_test_axpbyv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -273,7 +273,7 @@ void libblis_test_axpbyv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_axpy2v.c
+++ b/testsuite/src/test_axpy2v.c
@@ -220,7 +220,7 @@ void libblis_test_axpy2v_experiment
 	bli_obj_set_conj( conjx, &x );
 	bli_obj_set_conj( conjy, &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &z_save, &z );
@@ -290,7 +290,7 @@ void libblis_test_axpy2v_check
      )
 {
 	num_t  dt      = bli_obj_dt( z );
-	num_t  dt_real = bli_obj_dt_proj_to_real( z );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( z ) );
 
 	dim_t  m       = bli_obj_vector_dim( z );
 

--- a/testsuite/src/test_axpyf.c
+++ b/testsuite/src/test_axpyf.c
@@ -223,7 +223,7 @@ void libblis_test_axpyf_experiment
 	bli_obj_set_conj( conja, &a );
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -291,7 +291,7 @@ void libblis_test_axpyf_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 	dim_t  b_n     = bli_obj_width( a );

--- a/testsuite/src/test_axpym.c
+++ b/testsuite/src/test_axpym.c
@@ -203,7 +203,7 @@ void libblis_test_axpym_experiment
 	// Apply the parameters.
 	bli_obj_set_conjtrans( transx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -265,7 +265,7 @@ void libblis_test_axpym_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_length( y );
 	dim_t  n       = bli_obj_width( y );

--- a/testsuite/src/test_axpyv.c
+++ b/testsuite/src/test_axpyv.c
@@ -201,7 +201,7 @@ void libblis_test_axpyv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -263,7 +263,7 @@ void libblis_test_axpyv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_copym.c
+++ b/testsuite/src/test_copym.c
@@ -236,7 +236,7 @@ void libblis_test_copym_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 
 	obj_t  norm_y_r;
 

--- a/testsuite/src/test_copyv.c
+++ b/testsuite/src/test_copyv.c
@@ -178,7 +178,7 @@ void libblis_test_copyv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Disable repeats since bli_copyv() is not yet tested. 
+	// Disable repeats since bli_copyv() is not yet tested.
 	//for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -233,7 +233,7 @@ void libblis_test_copyv_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 
 	obj_t  norm_y_r;
 

--- a/testsuite/src/test_dotaxpyv.c
+++ b/testsuite/src/test_dotaxpyv.c
@@ -222,7 +222,7 @@ void libblis_test_dotaxpyv_experiment
 	bli_obj_alias_to( &x, &xt );
 
 	// Determine whether to make a copy of x with or without conjugation.
-	// 
+	//
 	//  conjx conjy  ~conjx^conjy   y is initialized as
 	//  n     n      c              y = conj(x)
 	//  n     c      n              y = x
@@ -239,7 +239,7 @@ void libblis_test_dotaxpyv_experiment
 	bli_obj_set_conj( conjx,  &x );
 	bli_obj_set_conj( conjy,  &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copysc( &BLIS_MINUS_ONE, &rho );
@@ -312,7 +312,7 @@ void libblis_test_dotaxpyv_check
      )
 {
 	num_t  dt      = bli_obj_dt( z );
-	num_t  dt_real = bli_obj_dt_proj_to_real( z );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( z ) );
 
 	dim_t  m       = bli_obj_vector_dim( z );
 

--- a/testsuite/src/test_dotv.c
+++ b/testsuite/src/test_dotv.c
@@ -184,7 +184,7 @@ void libblis_test_dotv_experiment
 	libblis_test_vobj_randomize( params, TRUE, &x );
 
 	// Determine whether to make a copy of x with or without conjugation.
-	// 
+	//
 	//  conjx conjy  ~conjx^conjy   y is initialized as
 	//  n     n      c              y = conj(x)
 	//  n     c      n              y = x
@@ -200,7 +200,7 @@ void libblis_test_dotv_experiment
 	bli_obj_set_conj( conjx, &x );
 	bli_obj_set_conj( conjy, &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copysc( &BLIS_MINUS_ONE, &rho );
@@ -259,7 +259,7 @@ void libblis_test_dotv_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	obj_t  rho_r, rho_i;
 	obj_t  norm_x, norm_xy;

--- a/testsuite/src/test_dotxaxpyf.c
+++ b/testsuite/src/test_dotxaxpyf.c
@@ -251,7 +251,7 @@ void libblis_test_dotxaxpyf_experiment
 	bli_obj_set_conj( conjw, &w );
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -333,7 +333,7 @@ void libblis_test_dotxaxpyf_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( z );
 	dim_t  b_n     = bli_obj_vector_dim( y );

--- a/testsuite/src/test_dotxf.c
+++ b/testsuite/src/test_dotxf.c
@@ -228,7 +228,7 @@ void libblis_test_dotxf_experiment
 	bli_obj_set_conj( conjat, &a );
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -298,7 +298,7 @@ void libblis_test_dotxf_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  b_n     = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_dotxv.c
+++ b/testsuite/src/test_dotxv.c
@@ -199,7 +199,7 @@ void libblis_test_dotxv_experiment
 	libblis_test_vobj_randomize( params, TRUE, &x );
 
 	// Determine whether to make a copy of x with or without conjugation.
-	// 
+	//
 	//  conjx conjy  ~conjx^conjy   y is initialized as
 	//  n     n      c              y = conj(x)
 	//  n     c      n              y = x
@@ -215,7 +215,7 @@ void libblis_test_dotxv_experiment
 	bli_obj_set_conj( conjx, &x );
 	bli_obj_set_conj( conjy, &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copysc( &rho_save, &rho );
@@ -279,7 +279,7 @@ void libblis_test_dotxv_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	obj_t  rho_r, rho_i;
 	obj_t  norm_x_r, norm_xy_r;

--- a/testsuite/src/test_gemm.c
+++ b/testsuite/src/test_gemm.c
@@ -270,7 +270,7 @@ void libblis_test_gemm_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -399,7 +399,7 @@ void libblis_test_gemm_md
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -483,8 +483,8 @@ void libblis_test_gemm_md_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
-	num_t  dt_comp = bli_obj_dt_proj_to_complex( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
+	num_t  dt_comp = bli_dt_proj_to_complex( bli_obj_dt( c ) );
 	num_t  dt;
 
 	dim_t  m       = bli_obj_length( c );
@@ -542,9 +542,9 @@ void libblis_test_gemm_md_check
 	bli_gemv( &BLIS_ONE, &c0, &t, &BLIS_ZERO, &v );
 
 #if 0
-if ( bli_obj_is_scomplex( c ) &&
-     bli_obj_is_float( a ) &&
-     bli_obj_is_float( b ) )
+if ( bli_obj_dt( c ) == BLIS_SCOMPLEX &&
+     bli_obj_dt( a ) == BLIS_FLOAT &&
+     bli_obj_dt( b ) == BLIS_FLOAT )
 {
 bli_printm( "test_gemm.c: a", a, "%7.3f", "" );
 bli_printm( "test_gemm.c: b", b, "%7.3f", "" );
@@ -594,7 +594,7 @@ void libblis_test_gemm_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  n       = bli_obj_width( c );

--- a/testsuite/src/test_gemm_ukr.c
+++ b/testsuite/src/test_gemm_ukr.c
@@ -297,7 +297,7 @@ void libblis_test_gemm_ukr_experiment
 	bli_packm_blk_var1( &a, &ap, cntx, NULL, &BLIS_PACKM_SINGLE_THREADED );
 	bli_packm_blk_var1( &b, &bp, cntx, NULL, &BLIS_PACKM_SINGLE_THREADED );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -378,7 +378,7 @@ void libblis_test_gemm_ukr_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  n       = bli_obj_width( c );

--- a/testsuite/src/test_gemmt.c
+++ b/testsuite/src/test_gemmt.c
@@ -243,7 +243,7 @@ void libblis_test_gemmt_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -325,7 +325,7 @@ void libblis_test_gemmt_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 	uplo_t uploc   = bli_obj_uplo( c );
 
 	dim_t  m       = bli_obj_length( c );

--- a/testsuite/src/test_gemmtrsm_ukr.c
+++ b/testsuite/src/test_gemmtrsm_ukr.c
@@ -375,7 +375,7 @@ bli_printm( "a", &a, "%5.2f", "" );
 bli_printm( "ap", &ap, "%5.2f", "" );
 #endif
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c11_save, &c11 );
@@ -487,7 +487,7 @@ void libblis_test_gemmtrsm_ukr_check
      )
 {
 	num_t  dt      = bli_obj_dt( b11 );
-	num_t  dt_real = bli_obj_dt_proj_to_real( b11 );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( b11 ) );
 
 	dim_t  m       = bli_obj_length( b11 );
 	dim_t  n       = bli_obj_width( b11 );

--- a/testsuite/src/test_gemv.c
+++ b/testsuite/src/test_gemv.c
@@ -226,7 +226,7 @@ void libblis_test_gemv_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -294,7 +294,7 @@ void libblis_test_gemv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	conj_t conja   = bli_obj_conj_status( a );
 
@@ -340,11 +340,11 @@ void libblis_test_gemv_check
 	bli_copyv( x,      &x_temp );
 	bli_copyv( y_orig, &y_temp );
 
-	bli_acquire_vpart_f2b( BLIS_SUBPART1, 0, min_m_n, 
+	bli_acquire_vpart_f2b( BLIS_SUBPART1, 0, min_m_n,
 	                       &x_temp, &xT_temp );
-	bli_acquire_vpart_f2b( BLIS_SUBPART1, 0, min_m_n, 
+	bli_acquire_vpart_f2b( BLIS_SUBPART1, 0, min_m_n,
 	                       &y_temp, &yT_temp );
-	bli_acquire_vpart_f2b( BLIS_SUBPART1, 0, min_m_n, 
+	bli_acquire_vpart_f2b( BLIS_SUBPART1, 0, min_m_n,
 	                       y, &yT );
 
 	bli_scalv( &kappac, &xT_temp );

--- a/testsuite/src/test_ger.c
+++ b/testsuite/src/test_ger.c
@@ -213,7 +213,7 @@ void libblis_test_ger_experiment
 	bli_obj_set_conj( conjx, &x );
 	bli_obj_set_conj( conjy, &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &a_save, &a );
@@ -278,7 +278,7 @@ void libblis_test_ger_check
      )
 {
 	num_t  dt      = bli_obj_dt( a );
-	num_t  dt_real = bli_obj_dt_proj_to_real( a );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( a ) );
 
 	dim_t  m_a     = bli_obj_length( a );
 	dim_t  n_a     = bli_obj_width( a );

--- a/testsuite/src/test_hemm.c
+++ b/testsuite/src/test_hemm.c
@@ -241,7 +241,7 @@ void libblis_test_hemm_experiment
 	bli_obj_set_conj( conja, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -312,7 +312,7 @@ void libblis_test_hemm_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  n       = bli_obj_width( c );
@@ -387,7 +387,7 @@ void libblis_test_hemm_check
 	}
 
 	bli_gemv( beta, c_orig, &t, &BLIS_ONE, &z );
-	
+
 	bli_subv( &z, &v );
 	bli_normfv( &v, &norm );
 	bli_getsc( &norm, resid, &junk );

--- a/testsuite/src/test_hemv.c
+++ b/testsuite/src/test_hemv.c
@@ -231,7 +231,7 @@ void libblis_test_hemv_experiment
 	bli_obj_set_conj( conja, &a );
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -298,7 +298,7 @@ void libblis_test_hemv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_her.c
+++ b/testsuite/src/test_her.c
@@ -217,7 +217,7 @@ void libblis_test_her_experiment
 	// Apply the remaining parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &a_save, &a );
@@ -279,7 +279,7 @@ void libblis_test_her_check
      )
 {
 	num_t  dt      = bli_obj_dt( a );
-	num_t  dt_real = bli_obj_dt_proj_to_real( a );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( a ) );
 
 	dim_t  m_a     = bli_obj_length( a );
 

--- a/testsuite/src/test_her2.c
+++ b/testsuite/src/test_her2.c
@@ -224,7 +224,7 @@ void libblis_test_her2_experiment
 	bli_obj_set_conj( conjx, &x );
 	bli_obj_set_conj( conjy, &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &a_save, &a );
@@ -289,7 +289,7 @@ void libblis_test_her2_check
      )
 {
 	num_t  dt      = bli_obj_dt( a );
-	num_t  dt_real = bli_obj_dt_proj_to_real( a );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( a ) );
 
 	dim_t  m_a     = bli_obj_length( a );
 

--- a/testsuite/src/test_her2k.c
+++ b/testsuite/src/test_her2k.c
@@ -240,7 +240,7 @@ void libblis_test_her2k_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -309,7 +309,7 @@ void libblis_test_her2k_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  k       = bli_obj_width_after_trans( a );

--- a/testsuite/src/test_herk.c
+++ b/testsuite/src/test_herk.c
@@ -233,7 +233,7 @@ void libblis_test_herk_experiment
 	// Apply the remaining parameters.
 	bli_obj_set_conjtrans( transa, &a );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -299,7 +299,7 @@ void libblis_test_herk_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  k       = bli_obj_width_after_trans( a );

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -667,7 +667,7 @@ void libblis_test_read_op_info( test_ops_t*  ops,
 	int   i, p;
 
 	// Initialize the operation type field.
-	op->opid = opid; 
+	op->opid = opid;
 
 	// Read the line for the overall operation switch.
 	libblis_test_read_next_line( buffer, input_stream );
@@ -702,7 +702,7 @@ void libblis_test_read_op_info( test_ops_t*  ops,
 			//printf( "buffer[p]:       %s\n", &buffer[p] );
 
 			// Advance until we hit non-whitespace (ie: the next number).
-			for ( ; isspace( buffer[p] ); ++p ) ; 
+			for ( ; isspace( buffer[p] ); ++p ) ;
 
 			//printf( "buffer[p] after: %s\n", &buffer[p] );
 
@@ -711,7 +711,7 @@ void libblis_test_read_op_info( test_ops_t*  ops,
 			//printf( "dim[%d] = %d\n", i, op->dim_spec[i] );
 
 			// Advance until we hit whitespace (ie: the space before the next number).
-			for ( ; !isspace( buffer[p] ); ++p ) ; 
+			for ( ; !isspace( buffer[p] ); ++p ) ;
 		}
 	}
 
@@ -809,11 +809,11 @@ void libblis_test_output_params_struct( FILE* os, test_params_t* params )
 	// convert these values into strings, with "unset" being used if the
 	// value returned was -1 (indicating the environment variable was unset).
 	dim_t nt    = bli_thread_get_num_threads();
-	dim_t jc_nt = bli_thread_get_jc_nt(); 
-	dim_t pc_nt = bli_thread_get_pc_nt(); 
-	dim_t ic_nt = bli_thread_get_ic_nt(); 
-	dim_t jr_nt = bli_thread_get_jr_nt(); 
-	dim_t ir_nt = bli_thread_get_ir_nt(); 
+	dim_t jc_nt = bli_thread_get_jc_nt();
+	dim_t pc_nt = bli_thread_get_pc_nt();
+	dim_t ic_nt = bli_thread_get_ic_nt();
+	dim_t jr_nt = bli_thread_get_jr_nt();
+	dim_t ir_nt = bli_thread_get_ir_nt();
 
 	if (    nt == -1 ) sprintf(    nt_str, "unset" );
 	else               sprintf(    nt_str, "%d", ( int )   nt );
@@ -1775,7 +1775,7 @@ void libblis_test_op_driver
 				= ( char* ) malloc( ( n_operands + 1 ) * sizeof( char ) );
 
 				for ( o = 0; o < n_operands; ++o )
-				{ 
+				{
 					unsigned int ij;
 					operand_t    operand_type
 					= libblis_test_get_operand_type_for_char( o_types[o] );
@@ -2217,7 +2217,7 @@ void libblis_test_op_driver
 				ind_str = bli_ind_oper_get_avail_impl_string( op->opid, datatype );
 
 				// Loop over the requested parameter combinations.
-				for ( pci = 0; pci < n_param_combos; ++pci )	
+				for ( pci = 0; pci < n_param_combos; ++pci )
 				{
 					// Loop over the requested problem sizes.
 					for ( p_cur = p_first, pi = 1; p_cur <= p_max; p_cur += p_inc, ++pi )
@@ -2435,7 +2435,7 @@ void libblis_test_build_function_string
 	if ( strlen( funcname_str ) > MAX_FUNC_STRING_LENGTH )
 		libblis_test_printf_error( "Function name string length (%d) exceeds maximum (%d).\n",
 		                           strlen( funcname_str ), MAX_FUNC_STRING_LENGTH );
-		
+
 }
 
 
@@ -2577,7 +2577,7 @@ void libblis_test_mobj_create( test_params_t* params, num_t dt, trans_t trans, c
 	dim_t  n_trans   = n;
 	dim_t  rs        = 1; // Initialization avoids a compiler warning.
 	dim_t  cs        = 1; // Initialization avoids a compiler warning.
-	
+
 	// Apply the trans parameter to the dimensions (if needed).
 	bli_set_dims_with_trans( trans, m, n, &m_trans, &n_trans );
 
@@ -2695,7 +2695,7 @@ void libblis_test_vobj_randomize( test_params_t* params, bool normalize, obj_t* 
 	if ( normalize )
 	{
 		num_t dt   = bli_obj_dt( x );
-		num_t dt_r = bli_obj_dt_proj_to_real( x );
+		num_t dt_r = bli_dt_proj_to_real( bli_obj_dt( x ) );
 		obj_t kappa;
 		obj_t kappa_r;
 
@@ -2735,7 +2735,7 @@ void libblis_test_mobj_randomize( test_params_t* params, bool normalize, obj_t* 
 		bli_scalm( &kappa, a );
 #endif
 		num_t dt   = bli_obj_dt( a );
-		num_t dt_r = bli_obj_dt_proj_to_real( a );
+		num_t dt_r = bli_dt_proj_to_real( bli_obj_dt( a ) );
 		obj_t kappa;
 		obj_t kappa_r;
 
@@ -3007,7 +3007,7 @@ void libblis_test_parse_message( FILE* output_stream, char* message, va_list arg
 	char*         the_string;
 	char          the_char;
 
-	// Begin looping over message to insert variables wherever there are 
+	// Begin looping over message to insert variables wherever there are
 	// format specifiers.
 	for ( c = 0; message[c] != '\0'; )
 	{

--- a/testsuite/src/test_normfm.c
+++ b/testsuite/src/test_normfm.c
@@ -187,7 +187,7 @@ void libblis_test_normfm_experiment
 	// Set all elements of x to beta.
 	bli_setm( &beta, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -242,7 +242,7 @@ void libblis_test_normfm_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 	dim_t  m       = bli_obj_length( x );
 	dim_t  n       = bli_obj_width( x );
 

--- a/testsuite/src/test_normfv.c
+++ b/testsuite/src/test_normfv.c
@@ -185,7 +185,7 @@ void libblis_test_normfv_experiment
 	// Set all elements of x to beta.
 	bli_setv( &beta, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -240,7 +240,7 @@ void libblis_test_normfv_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 	dim_t  m       = bli_obj_vector_dim( x );
 
 	obj_t  m_r, temp_r;

--- a/testsuite/src/test_randm.c
+++ b/testsuite/src/test_randm.c
@@ -172,7 +172,7 @@ void libblis_test_randm_experiment
 	// Create the test objects.
 	libblis_test_mobj_create( params, datatype, BLIS_NO_TRANSPOSE, x_store, m, n, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -228,7 +228,7 @@ void libblis_test_randm_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 	dim_t  m_x     = bli_obj_length( x );
 	dim_t  n_x     = bli_obj_width( x );
 	obj_t  sum;
@@ -245,7 +245,7 @@ void libblis_test_randm_check
 	bli_obj_scalar_init_detached( dt_real, &sum );
 
 	bli_absumm( x, &sum );
-	
+
 	if ( bli_is_float( dt_real ) )
 	{
 		float*  sum_x = bli_obj_buffer_at_off( &sum );

--- a/testsuite/src/test_randv.c
+++ b/testsuite/src/test_randv.c
@@ -172,7 +172,7 @@ void libblis_test_randv_experiment
 	// Create the test objects.
 	libblis_test_vobj_create( params, datatype, x_store, m, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -228,7 +228,7 @@ void libblis_test_randv_check
        double*        resid
      )
 {
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 	dim_t  m_x     = bli_obj_vector_dim( x );
 	obj_t  sum;
 

--- a/testsuite/src/test_scal2m.c
+++ b/testsuite/src/test_scal2m.c
@@ -202,7 +202,7 @@ void libblis_test_scal2m_experiment
 	// Apply the parameters.
 	bli_obj_set_conjtrans( transx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -264,7 +264,7 @@ void libblis_test_scal2m_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_length( y );
 	dim_t  n       = bli_obj_width( y );

--- a/testsuite/src/test_scal2v.c
+++ b/testsuite/src/test_scal2v.c
@@ -200,7 +200,7 @@ void libblis_test_scal2v_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -262,7 +262,7 @@ void libblis_test_scal2v_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_scalm.c
+++ b/testsuite/src/test_scalm.c
@@ -196,7 +196,7 @@ void libblis_test_scalm_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjbeta, &beta );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -255,7 +255,7 @@ void libblis_test_scalm_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_length( y );
 	dim_t  n       = bli_obj_width( y );
@@ -296,7 +296,7 @@ void libblis_test_scalm_check
 
 	bli_scalm( &nbeta, &y2 );
 	bli_addm( &y2, y );
-	
+
 	bli_normfm( y, &norm_y_r );
 
 	bli_getsc( &norm_y_r, resid, &junk );

--- a/testsuite/src/test_scalv.c
+++ b/testsuite/src/test_scalv.c
@@ -193,7 +193,7 @@ void libblis_test_scalv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjbeta, &beta );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -252,7 +252,7 @@ void libblis_test_scalv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_setm.c
+++ b/testsuite/src/test_setm.c
@@ -181,7 +181,7 @@ void libblis_test_setm_experiment
 	// Randomize x.
 	libblis_test_mobj_randomize( params, FALSE, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -251,7 +251,7 @@ void libblis_test_setm_check
 	// that each element of x is equal to beta.
 	//
 
-	if      ( bli_obj_is_float( x ) )
+	if      ( bli_obj_dt( x ) == BLIS_FLOAT )
 	{
 		float*    beta_cast  = buf_beta;
 		float*    buf_x_cast = buf_x;
@@ -267,7 +267,7 @@ void libblis_test_setm_check
 			}
 		}
 	}
-	else if ( bli_obj_is_double( x ) )
+	else if ( bli_obj_dt( x ) == BLIS_DOUBLE )
 	{
 		double*   beta_cast  = buf_beta;
 		double*   buf_x_cast = buf_x;
@@ -283,7 +283,7 @@ void libblis_test_setm_check
 			}
 		}
 	}
-	else if ( bli_obj_is_scomplex( x ) )
+	else if ( bli_obj_dt( x ) == BLIS_SCOMPLEX )
 	{
 		scomplex* beta_cast  = buf_beta;
 		scomplex* buf_x_cast = buf_x;
@@ -299,7 +299,7 @@ void libblis_test_setm_check
 			}
 		}
 	}
-	else // if ( bli_obj_is_dcomplex( x ) )
+	else // if ( bli_obj_dt( x ) == BLIS_DCOMPLEX )
 	{
 		dcomplex* beta_cast  = buf_beta;
 		dcomplex* buf_x_cast = buf_x;

--- a/testsuite/src/test_setv.c
+++ b/testsuite/src/test_setv.c
@@ -179,7 +179,7 @@ void libblis_test_setv_experiment
 	// Randomize x.
 	libblis_test_vobj_randomize( params, FALSE, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -247,7 +247,7 @@ void libblis_test_setv_check
 	// that each element of x is equal to beta.
 	//
 
-	if      ( bli_obj_is_float( x ) )
+	if      ( bli_obj_dt( x ) == BLIS_FLOAT )
 	{
 		float*    chi1      = buf_x;
 		float*    beta_cast = buf_beta;
@@ -255,11 +255,11 @@ void libblis_test_setv_check
 		for ( i = 0; i < m_x; ++i )
 		{
 			if ( !bli_seq( *chi1, *beta_cast ) ) { *resid = 1.0; return; }
-			
+
 			chi1 += inc_x;
 		}
 	}
-	else if ( bli_obj_is_double( x ) )
+	else if ( bli_obj_dt( x ) == BLIS_DOUBLE )
 	{
 		double*   chi1      = buf_x;
 		double*   beta_cast = buf_beta;
@@ -267,11 +267,11 @@ void libblis_test_setv_check
 		for ( i = 0; i < m_x; ++i )
 		{
 			if ( !bli_deq( *chi1, *beta_cast ) ) { *resid = 1.0; return; }
-			
+
 			chi1 += inc_x;
 		}
 	}
-	else if ( bli_obj_is_scomplex( x ) )
+	else if ( bli_obj_dt( x ) == BLIS_SCOMPLEX )
 	{
 		scomplex* chi1      = buf_x;
 		scomplex* beta_cast = buf_beta;
@@ -279,11 +279,11 @@ void libblis_test_setv_check
 		for ( i = 0; i < m_x; ++i )
 		{
 			if ( !bli_ceq( *chi1, *beta_cast ) ) { *resid = 1.0; return; }
-			
+
 			chi1 += inc_x;
 		}
 	}
-	else // if ( bli_obj_is_dcomplex( x ) )
+	else // if ( bli_obj_dt( x ) == BLIS_DCOMPLEX )
 	{
 		dcomplex* chi1      = buf_x;
 		dcomplex* beta_cast = buf_beta;
@@ -291,7 +291,7 @@ void libblis_test_setv_check
 		for ( i = 0; i < m_x; ++i )
 		{
 			if ( !bli_zeq( *chi1, *beta_cast ) ) { *resid = 1.0; return; }
-			
+
 			chi1 += inc_x;
 		}
 	}

--- a/testsuite/src/test_subm.c
+++ b/testsuite/src/test_subm.c
@@ -249,7 +249,7 @@ void libblis_test_subm_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 	dim_t  m       = bli_obj_length( y );
 	dim_t  n       = bli_obj_width( y );
 

--- a/testsuite/src/test_subv.c
+++ b/testsuite/src/test_subv.c
@@ -188,7 +188,7 @@ void libblis_test_subv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Disable repeats since bli_copyv() is not yet tested. 
+	// Disable repeats since bli_copyv() is not yet tested.
 	//for ( i = 0; i < n_repeats; ++i )
 	{
 		time = bli_clock();
@@ -246,7 +246,7 @@ void libblis_test_subv_check
      )
 {
 	num_t  dt      = bli_obj_dt( x );
-	num_t  dt_real = bli_obj_dt_proj_to_real( x );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 	dim_t  m       = bli_obj_vector_dim( x );
 
 	conj_t conjx   = bli_obj_conj_status( x );

--- a/testsuite/src/test_symm.c
+++ b/testsuite/src/test_symm.c
@@ -241,7 +241,7 @@ void libblis_test_symm_experiment
 	bli_obj_set_conj( conja, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -312,7 +312,7 @@ void libblis_test_symm_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  n       = bli_obj_width( c );
@@ -387,7 +387,7 @@ void libblis_test_symm_check
 	}
 
 	bli_gemv( beta, c_orig, &t, &BLIS_ONE, &z );
-	
+
 	bli_subv( &z, &v );
 	bli_normfv( &v, &norm );
 	bli_getsc( &norm, resid, &junk );

--- a/testsuite/src/test_symv.c
+++ b/testsuite/src/test_symv.c
@@ -231,7 +231,7 @@ void libblis_test_symv_experiment
 	bli_obj_set_conj( conja, &a );
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -298,7 +298,7 @@ void libblis_test_symv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 

--- a/testsuite/src/test_syr.c
+++ b/testsuite/src/test_syr.c
@@ -216,7 +216,7 @@ void libblis_test_syr_experiment
 	// Apply the remaining parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &a_save, &a );
@@ -278,7 +278,7 @@ void libblis_test_syr_check
      )
 {
 	num_t  dt      = bli_obj_dt( a );
-	num_t  dt_real = bli_obj_dt_proj_to_real( a );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( a ) );
 
 	dim_t  m_a     = bli_obj_length( a );
 

--- a/testsuite/src/test_syr2.c
+++ b/testsuite/src/test_syr2.c
@@ -223,7 +223,7 @@ void libblis_test_syr2_experiment
 	bli_obj_set_conj( conjx, &x );
 	bli_obj_set_conj( conjy, &y );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &a_save, &a );
@@ -288,7 +288,7 @@ void libblis_test_syr2_check
      )
 {
 	num_t  dt      = bli_obj_dt( a );
-	num_t  dt_real = bli_obj_dt_proj_to_real( a );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( a ) );
 
 	dim_t  m_a     = bli_obj_length( a );
 

--- a/testsuite/src/test_syr2k.c
+++ b/testsuite/src/test_syr2k.c
@@ -240,7 +240,7 @@ void libblis_test_syr2k_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -309,7 +309,7 @@ void libblis_test_syr2k_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  k       = bli_obj_width_after_trans( a );

--- a/testsuite/src/test_syrk.c
+++ b/testsuite/src/test_syrk.c
@@ -233,7 +233,7 @@ void libblis_test_syrk_experiment
 	// Apply the remaining parameters.
 	bli_obj_set_conjtrans( transa, &a );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -299,7 +299,7 @@ void libblis_test_syrk_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  k       = bli_obj_width_after_trans( a );

--- a/testsuite/src/test_trmm.c
+++ b/testsuite/src/test_trmm.c
@@ -229,7 +229,7 @@ void libblis_test_trmm_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_diag( diaga, &a );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &b_save, &b );
@@ -295,7 +295,7 @@ void libblis_test_trmm_check
      )
 {
 	num_t  dt      = bli_obj_dt( b );
-	num_t  dt_real = bli_obj_dt_proj_to_real( b );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( b ) );
 
 	dim_t  m       = bli_obj_length( b );
 	dim_t  n       = bli_obj_width( b );

--- a/testsuite/src/test_trmm3.c
+++ b/testsuite/src/test_trmm3.c
@@ -242,7 +242,7 @@ void libblis_test_trmm3_experiment
 	bli_obj_set_diag( diaga, &a );
 	bli_obj_set_conjtrans( transb, &b );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &c_save, &c );
@@ -313,7 +313,7 @@ void libblis_test_trmm3_check
      )
 {
 	num_t  dt      = bli_obj_dt( c );
-	num_t  dt_real = bli_obj_dt_proj_to_real( c );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( c ) );
 
 	dim_t  m       = bli_obj_length( c );
 	dim_t  n       = bli_obj_width( c );
@@ -390,7 +390,7 @@ void libblis_test_trmm3_check
 	}
 
 	bli_gemv( beta, c_orig, &t, &BLIS_ONE, &z );
-	
+
 	bli_subv( &z, &v );
 	bli_normfv( &v, &norm );
 	bli_getsc( &norm, resid, &junk );

--- a/testsuite/src/test_trmv.c
+++ b/testsuite/src/test_trmv.c
@@ -216,7 +216,7 @@ void libblis_test_trmv_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_diag( diaga, &a );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &x_save, &x );
@@ -278,7 +278,7 @@ void libblis_test_trmv_check
      )
 {
 	num_t   dt      = bli_obj_dt( x );
-	num_t   dt_real = bli_obj_dt_proj_to_real( x );
+	num_t   dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 
 	dim_t   m       = bli_obj_vector_dim( x );
 

--- a/testsuite/src/test_trsm.c
+++ b/testsuite/src/test_trsm.c
@@ -230,7 +230,7 @@ void libblis_test_trsm_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_diag( diaga, &a );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &b_save, &b );
@@ -302,7 +302,7 @@ void libblis_test_trsm_check
      )
 {
 	num_t  dt      = bli_obj_dt( b );
-	num_t  dt_real = bli_obj_dt_proj_to_real( b );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( b ) );
 
 	dim_t  m       = bli_obj_length( b );
 	dim_t  n       = bli_obj_width( b );

--- a/testsuite/src/test_trsm_ukr.c
+++ b/testsuite/src/test_trsm_ukr.c
@@ -311,7 +311,7 @@ bli_printm( "a", &a, "%5.2f", "" );
 bli_printm( "ap", &ap, "%5.2f", "" );
 #endif
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		// Re-pack the contents of b to bp.
@@ -393,7 +393,7 @@ void libblis_test_trsm_ukr_check
      )
 {
 	num_t  dt      = bli_obj_dt( b );
-	num_t  dt_real = bli_obj_dt_proj_to_real( b );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( b ) );
 
 	dim_t  m       = bli_obj_length( b );
 	dim_t  n       = bli_obj_width( b );

--- a/testsuite/src/test_trsv.c
+++ b/testsuite/src/test_trsv.c
@@ -216,7 +216,7 @@ void libblis_test_trsv_experiment
 	bli_obj_set_conjtrans( transa, &a );
 	bli_obj_set_diag( diaga, &a );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &x_save, &x );
@@ -278,7 +278,7 @@ void libblis_test_trsv_check
      )
 {
 	num_t   dt      = bli_obj_dt( x );
-	num_t   dt_real = bli_obj_dt_proj_to_real( x );
+	num_t   dt_real = bli_dt_proj_to_real( bli_obj_dt( x ) );
 
 	dim_t   m       = bli_obj_vector_dim( x );
 

--- a/testsuite/src/test_xpbym.c
+++ b/testsuite/src/test_xpbym.c
@@ -202,7 +202,7 @@ void libblis_test_xpbym_experiment
 	// Apply the parameters.
 	bli_obj_set_conjtrans( transx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copym( &y_save, &y );
@@ -264,7 +264,7 @@ void libblis_test_xpbym_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_length( y );
 	dim_t  n       = bli_obj_width( y );

--- a/testsuite/src/test_xpbyv.c
+++ b/testsuite/src/test_xpbyv.c
@@ -198,7 +198,7 @@ void libblis_test_xpbyv_experiment
 	// Apply the parameters.
 	bli_obj_set_conj( conjx, &x );
 
-	// Repeat the experiment n_repeats times and record results. 
+	// Repeat the experiment n_repeats times and record results.
 	for ( i = 0; i < n_repeats; ++i )
 	{
 		bli_copyv( &y_save, &y );
@@ -260,7 +260,7 @@ void libblis_test_xpbyv_check
      )
 {
 	num_t  dt      = bli_obj_dt( y );
-	num_t  dt_real = bli_obj_dt_proj_to_real( y );
+	num_t  dt_real = bli_dt_proj_to_real( bli_obj_dt( y ) );
 
 	dim_t  m       = bli_obj_vector_dim( y );
 


### PR DESCRIPTION
- Removed the info and info2 fields and replaced with bitfield entries for each distinct flag/property.
- Simplified and rearranged the bitwise definitions of the various enumerations.
- Removed many unused/underused functions from the obj_t API.