### PR TITLE
bli_error: more cleanup on the error strings array

### DIFF
--- a/frame/base/bli_error.c
+++ b/frame/base/bli_error.c
@@ -36,7 +36,7 @@
 #include "blis.h"
 
 // Internal array to hold error strings.
-static char bli_error_string[BLIS_MAX_NUM_ERR_MSGS][BLIS_MAX_ERR_MSG_LENGTH] =
+static char *bli_error_string[-BLIS_ERROR_CODE_MAX] =
 {
 	[-BLIS_INVALID_ERROR_CHECKING_LEVEL]         = "Invalid error checking level.",
 	[-BLIS_UNDEFINED_ERROR_CODE]                 = "Undefined error code.",

--- a/frame/include/bli_error_macro_defs.h
+++ b/frame/include/bli_error_macro_defs.h
@@ -35,12 +35,6 @@
 #ifndef BLIS_ERROR_MACRO_DEFS_H
 #define BLIS_ERROR_MACRO_DEFS_H
 
-// -- Error-related macros --
-
-// Used to determine the size of the array of error strings.
-#define BLIS_MAX_NUM_ERR_MSGS    200
-#define BLIS_MAX_ERR_MSG_LENGTH  200
-
 // Used to insert filenames and line numbers into error-checking code.
 #define bli_check_error_code( code ) \
         bli_check_error_code_helper( code, __FILE__, __LINE__ )


### PR DESCRIPTION
- There was redundance between the macro BLIS_MAX_NUM_ERR_MSGS (=200) and
  the enum BLIS_ERROR_CODE_MAX (-170), while they both mean the same thing:
  the maximal number of error codes/messages.
- The previous initialization of error messages at compile time ignored that
  the 'bli_error_string' array still occupies useless memory due to 2D char[][]
  declaration. Instead, it should be just an array of pointers, pointing at
  strings in .rodata section.
- This commit does the two modifications:
   * retired macros BLIS_MAX_NUM_ERR_MSGS and BLIS_MAX_ERR_MSG_LENGTH everywhere
   * switch bli_error_string from char[][] to char *[] to reduce its footprint
     from 40KB (200*200) to 1.3KB (170*sizeof(char*)).
     (No problem to use the enum BLIS_ERROR_CODE_MAX at compile-time,
     since compiler is smart enough to determine its value is 170.)