### PR TITLE
blis.h: re-enable 8e0c425 and reorder include order to compile non-system mode

### DIFF
--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -70,7 +70,7 @@
 #endif
 
 // Determine the target operating system.
-//#if defined(BLIS_ENABLE_SYSTEM)
+#if defined(BLIS_ENABLE_SYSTEM)
   #if defined(_WIN32) || defined(__CYGWIN__)
     #define BLIS_OS_WINDOWS 1
   #elif defined(__gnu_hurd__)
@@ -94,9 +94,9 @@
   #else
     #error "Cannot determine operating system"
   #endif
-//#else // #if defined(BLIS_DISABLE_SYSTEM)
-//  #define BLIS_OS_NONE
-//#endif
+#else // #if defined(BLIS_DISABLE_SYSTEM)
+  #define BLIS_OS_NONE
+#endif
 
 // A few changes that may be necessary in Windows environments.
 #if BLIS_OS_WINDOWS

--- a/frame/include/blis.h
+++ b/frame/include/blis.h
@@ -48,6 +48,15 @@ extern "C" {
 // NOTE: PLEASE DON'T CHANGE THE ORDER IN WHICH HEADERS ARE INCLUDED UNLESS
 // YOU ARE SURE THAT IT DOESN'T BREAK INTER-HEADER MACRO DEPENDENCIES.
 
+// -- configure definitions --
+
+// NOTE: bli_config.h header must be included before any BLIS header.
+// It is bootstrapped by ./configure and does not depend on later
+// headers. Moreover, these configuration variables are necessary to change
+// some default behaviors (e.g. disable OS-detection in bli_system.h in case
+// of --disable-system).
+#include "bli_config.h"
+
 // -- System and language-related headers --
 
 // NOTE: bli_system.h header must be included before bli_config_macro_defs.h.
@@ -55,9 +64,8 @@ extern "C" {
 #include "bli_lang_defs.h"
 
 
-// -- configure definitions --
+// -- configure default definitions --
 
-#include "bli_config.h"
 #include "bli_config_macro_defs.h"
 
 


### PR DESCRIPTION
- Before, OS-detection is always done even with --disable-system, because
bli_system.h is included before bli_config.h. This may explain why
8e0c425 has been reverted in 2be78fc.
- This commit swaps their order (/!\\) : bli_config.h before bli_system.h.
- Also better support future non-system platforms (#532)
```
// NOTE: bli_config.h header must be included before any BLIS header.
// It is bootstrapped by ./configure and does not depend on later
// headers. Moreover, these configuration variables are necessary to change
// some default behaviors (e.g. disable OS-detection in bli_system.h in case
// of --disable-system).
```