### PR TITLE
Make reference ukernels MR/NR sizes configurable

### DIFF
--- a/docs/ConfigurationHowTo.md
+++ b/docs/ConfigurationHowTo.md
@@ -239,6 +239,29 @@ The value `BLIS_HEAP_STRIDE_ALIGN_SIZE` defines the alignment used for so-called
 
 The value `BLIS_POOL_ADDR_ALIGN_SIZE` defines the alignment used when allocating blocks to the memory pools used to manage internal packing buffers. Any block of memory returned by the memory allocator is guaranteed to be aligned to this value. Aligning these blocks to the virtual memory page size (usually 4096 bytes) is standard practice.
 
+_**Reference micro-kernel sizes.**_ Using pre-implemented reference micro-kernels could be useful to port and get BLIS running quickly on a new architecture, without spending time implementing a set of optimized kernels, yet.
+
+For performance reason, reference micro-kernels (typically _gemm_ ones) are statically generated with some default hardcoded values of _MR_ and _NR_ for each precision. The developer who wants to tune these micro-sizes can override the default ones by adding in the `bli_family_<arch>.h` file:
+```c
+#define BLIS_MR_REF_S   ...
+#define BLIS_NR_REF_S   ...
+
+#define BLIS_MR_REF_D   ...
+#define BLIS_NR_REF_D   ...
+
+#define BLIS_MR_REF_C   ...
+#define BLIS_NR_REF_C   ...
+
+#define BLIS_MR_REF_Z   ...
+#define BLIS_NR_REF_Z   ...
+```
+and in `bli_cntx_init_<arch>.c`:
+```c
+    bli_blksz_init_easy( &blkszs[ BLIS_MR ], BLIS_MR_REF_S, BLIS_MR_REF_D, BLIS_MR_REF_C, BLIS_MR_REF_Z );
+    bli_blksz_init_easy( &blkszs[ BLIS_NR ], BLIS_NR_REF_S, BLIS_NR_REF_D, BLIS_NR_REF_C, BLIS_NR_REF_Z );
+```
+
+**Note:** It is important to keep consistency between the micro-size macros (`BLIS_[MR|NR]_REF_[S|D|C|Z]`) and `blkszs` settings in `cntx`, hence the additional `bli_blksz_init_easy()` in `bli_cntx_init_<arch>.c`.
 
 
 ### make_defs.mk

--- a/frame/include/bli_kernel_macro_defs.h
+++ b/frame/include/bli_kernel_macro_defs.h
@@ -36,6 +36,58 @@
 #define BLIS_KERNEL_MACRO_DEFS_H
 
 
+// -- Define default reference micro-kernel sizes --------------------------------------
+
+// NOTE: In case a developer wants to port BLIS on a new architecture and
+// does not afford yet implementing associated optimized micro-kernels,
+// (s)he can use the pre-implemented reference ones.
+//
+// A possible circumstance is when the user wants to tune these micro-sizes
+// (MR/NR), while still using the reference implementation.
+// That would be possible at one condition: these macros below must be
+// pre-defined (e.g. in bli_family_<arch>.h) and used to set the blocksizes
+// (bli_blksz_init_easy()) in bli_cntx_init_<arch>.c, in order to produce a
+// consistent context (match between micro-sizes and micro-kernels).
+//
+// PS: We currently only ensure consistency of micro-sizes MR/NR, since
+// they are directly correlated to generated micro-kernels.
+// Macro-sizes (MC/NC/KC) are not taken in account for the moment, since they
+// are more related to data-path and Goto's algorithm and can be safely changed
+// by user without impacting computation results (but bear in mind that they
+// always need to be multiple of MR/NR).
+#ifndef BLIS_MR_REF_S
+#define BLIS_MR_REF_S         4
+#endif
+
+#ifndef BLIS_NR_REF_S
+#define BLIS_NR_REF_S        16
+#endif
+
+#ifndef BLIS_MR_REF_D
+#define BLIS_MR_REF_D         4
+#endif
+
+#ifndef BLIS_NR_REF_D
+#define BLIS_NR_REF_D         8
+#endif
+
+#ifndef BLIS_MR_REF_C
+#define BLIS_MR_REF_C         4
+#endif
+
+#ifndef BLIS_NR_REF_C
+#define BLIS_NR_REF_C         8
+#endif
+
+#ifndef BLIS_MR_REF_Z
+#define BLIS_MR_REF_Z         4
+#endif
+
+#ifndef BLIS_NR_REF_Z
+#define BLIS_NR_REF_Z         4
+#endif
+
+
 // -- Define default threading parameters --------------------------------------
 
 // -- Conventional (large code path) values --

--- a/ref_kernels/3/bli_gemm_ref.c
+++ b/ref_kernels/3/bli_gemm_ref.c
@@ -34,7 +34,8 @@
 
 #include "blis.h"
 
-#if 1
+// Sanity: #pragma omp simd is only available on BLIS_ENABLE_PRAGMA_OMP_SIMD
+#if defined(BLIS_ENABLE_PRAGMA_OMP_SIMD)
 
 // An implementation that attempts to facilitate emission of vectorized
 // instructions via constant loop bounds + #pragma omp simd directives.
@@ -156,10 +157,10 @@ void PASTEMAC3(ch,opname,arch,suf) \
 }
 
 //INSERT_GENTFUNC_BASIC2( gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX )
-GENTFUNC( float,    s, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, 4, 16 )
-GENTFUNC( double,   d, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, 4, 8 )
-GENTFUNC( scomplex, c, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, 4, 8 )
-GENTFUNC( dcomplex, z, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, 4, 4 )
+GENTFUNC( float,    s, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, BLIS_MR_REF_S, BLIS_NR_REF_S )
+GENTFUNC( double,   d, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, BLIS_MR_REF_D, BLIS_NR_REF_D )
+GENTFUNC( scomplex, c, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, BLIS_MR_REF_C, BLIS_NR_REF_C )
+GENTFUNC( dcomplex, z, gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, BLIS_MR_REF_Z, BLIS_NR_REF_Z )
 
 #else
 

--- a/ref_kernels/bli_cntx_ref.c
+++ b/ref_kernels/bli_cntx_ref.c
@@ -360,8 +360,8 @@ void GENBARNAME(cntx_init)
 
 	//                                          s     d     c     z
 	bli_blksz_init_easy( &blkszs[ BLIS_KR ],    1,    1,    1,    1 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],    4,    4,    4,    4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],   16,    8,    8,    4 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ], BLIS_MR_REF_S, BLIS_MR_REF_D, BLIS_MR_REF_C, BLIS_MR_REF_Z );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ], BLIS_NR_REF_S, BLIS_NR_REF_D, BLIS_NR_REF_C, BLIS_NR_REF_Z );
 	bli_blksz_init_easy( &blkszs[ BLIS_MC ],  256,  128,  128,   64 );
 	bli_blksz_init_easy( &blkszs[ BLIS_KC ],  256,  256,  256,  256 );
 	bli_blksz_init_easy( &blkszs[ BLIS_NC ], 4096, 4096, 4096, 4096 );


### PR DESCRIPTION
- Those reference micro-sizes are hardcoded for some performance purposes
(#pragma omp simd). They may work most of the time, except when user begins
tuning the MR/NR sizes.
- This commit exposes them as configurable by user in bli_family_<arch>.h,
makes generation of reference ukernels more robust/consistent. Some explanation
is added to put future developers on guard (should be added in wiki as well).