### PR TITLE
Add an option to use an @rpath-dependent install_name on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -725,19 +725,13 @@ else
 	@$(RANLIB) $@
 endif
 
-# first argument: the base name of the BLAS test driver.
-define make-blat-rule
-$(BASE_OBJ_BLASTEST_PATH)/$(1).x: $(BASE_OBJ_BLASTEST_PATH)/$(1).o $(BLASTEST_F2C_LIB) $(LIBBLIS_LINK)
+$(BASE_OBJ_BLASTEST_PATH)/%.x: $(BASE_OBJ_BLASTEST_PATH)/%.o $(BLASTEST_F2C_LIB) $(LIBBLIS_LINK)
 ifeq ($(ENABLE_VERBOSE),yes)
-	$(LINKER) $(BASE_OBJ_BLASTEST_PATH)/$(1).o $(BLASTEST_F2C_LIB) $(LIBBLIS_LINK) $(LDFLAGS) -o $$@
+	$(LINKER) $< $(BLASTEST_F2C_LIB) $(LIBBLIS_LINK) $(LDFLAGS) -o $@
 else
-	@echo "Linking $$(@F) against '$(notdir $(BLASTEST_F2C_LIB)) $(LIBBLIS_LINK) $(LDFLAGS)'"
-	@$(LINKER) $(BASE_OBJ_BLASTEST_PATH)/$(1).o $(BLASTEST_F2C_LIB) $(LIBBLIS_LINK) $(LDFLAGS) -o $$@
+	@echo "Linking $@ against '$(notdir $(BLASTEST_F2C_LIB)) $(LIBBLIS_LINK) "$(LDFLAGS)"'"
+	@$(LINKER) $< $(BLASTEST_F2C_LIB) $(LIBBLIS_LINK) $(LDFLAGS) -o $@
 endif
-endef
-
-# Instantiate the rule above for each driver file.
-$(foreach name, $(BLASTEST_DRV_BASES), $(eval $(call make-blat-rule,$(name))))
 
 # A rule to run ?blat1.x driver files.
 define make-run-blat1-rule
@@ -806,7 +800,7 @@ $(TESTSUITE_BIN): $(MK_TESTSUITE_OBJS) $(LIBBLIS_LINK)
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(LINKER) $(MK_TESTSUITE_OBJS) $(LIBBLIS_LINK) $(LDFLAGS) -o $@
 else
-	@echo "Linking $@ against '$(LIBBLIS_LINK) $(LDFLAGS)'"
+	@echo "Linking $@ against '$(LIBBLIS_LINK) "$(LDFLAGS)"'"
 	@$(LINKER) $(MK_TESTSUITE_OBJS) $(LIBBLIS_LINK) $(LDFLAGS) -o $@
 endif
 

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -171,6 +171,9 @@ ARG_MAX_HACK      := @enable_arg_max_hack@
 MK_ENABLE_STATIC  := @enable_static@
 MK_ENABLE_SHARED  := @enable_shared@
 
+# Whether to use an install_name based on @rpath.
+MK_ENABLE_RPATH   := @enable_rpath@
+
 # Whether to export all symbols within the shared library, even those symbols
 # that are considered to be for internal use only.
 EXPORT_SHARED     := @export_shared@

--- a/common.mk
+++ b/common.mk
@@ -518,7 +518,11 @@ endif
 ifeq ($(OS_NAME),Darwin)
 # OS X shared library link flags.
 SOFLAGS    := -dynamiclib
+ifeq ($(MK_ENABLE_RPATH),yes)
 SOFLAGS    += -Wl,-install_name,@rpath/$(LIBBLIS_SONAME)
+else
+SOFLAGS    += -Wl,-install_name,$(libdir)/$(LIBBLIS_SONAME)
+endif
 else
 SOFLAGS    := -shared
 ifeq ($(IS_WIN),yes)

--- a/common.mk
+++ b/common.mk
@@ -551,7 +551,10 @@ LDFLAGS        += -Wl,-rpath,@executable_path/$(BASE_LIB_PATH)
 # rpath for BLAS tests
 LDFLAGS        += -Wl,-rpath,@executable_path/../../../$(BASE_LIB_PATH)
 else
-LDFLAGS        += "\'-Wl,-rpath,$$ORIGIN/$(BASE_LIB_PATH)\'"
+# rpath for test_libblis.x
+LDFLAGS        += -Wl,-rpath,'$$ORIGIN/$(BASE_LIB_PATH)'
+# rpath for BLAS tests
+LDFLAGS        += -Wl,-rpath,'$$ORIGIN/../../../$(BASE_LIB_PATH)'
 endif
 endif
 endif

--- a/common.mk
+++ b/common.mk
@@ -518,7 +518,7 @@ endif
 ifeq ($(OS_NAME),Darwin)
 # OS X shared library link flags.
 SOFLAGS    := -dynamiclib
-SOFLAGS    += -Wl,-install_name,$(libdir)/$(LIBBLIS_SONAME)
+SOFLAGS    += -Wl,-install_name,@rpath/$(LIBBLIS_SONAME)
 else
 SOFLAGS    := -shared
 ifeq ($(IS_WIN),yes)
@@ -545,7 +545,14 @@ LIBBLIS_L      := $(LIBBLIS_SO)
 LIBBLIS_LINK   := $(LIBBLIS_SO_PATH)
 ifeq ($(IS_WIN),no)
 # For Linux and OS X: set rpath property of shared object.
-LDFLAGS        += -Wl,-rpath,$(BASE_LIB_PATH)
+ifeq ($(OS_NAME),Darwin)
+# rpath for test_libblis.x
+LDFLAGS        += -Wl,-rpath,@executable_path/$(BASE_LIB_PATH)
+# rpath for BLAS tests
+LDFLAGS        += -Wl,-rpath,@executable_path/../../../$(BASE_LIB_PATH)
+else
+LDFLAGS        += "\'-Wl,-rpath,$$ORIGIN/$(BASE_LIB_PATH)\'"
+endif
 endif
 endif
 # On windows, use the shared library even if static is created.

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -143,6 +143,12 @@ print_usage()
 	echo "                 Disable (enabled by default) building BLIS as a shared"
 	echo "                 library. If the shared library build is disabled, the"
 	echo "                 static library build must remain enabled."
+	echo " "
+	echo "   --enable-rpath, --disable-rpath"
+	echo " "
+	echo "                 Enable (disabled by default) setting an install_name for"
+    echo "                 dynamic libraries on macOS which starts with @rpath rather"
+    echo "                 than the absolute install path."
 	echo " "
 	echo "   -e SYMBOLS, --export-shared[=SYMBOLS]"
 	echo " "
@@ -852,7 +858,7 @@ build_kconfig_registry()
 			assign_key_value "kconfig_registry" "${kernel}" "${newvalue}"
 
 		done
-		
+
 	done
 }
 
@@ -2048,6 +2054,7 @@ main()
 	enable_arg_max_hack='no'
 	enable_static='yes'
 	enable_shared='yes'
+    enable_rpath='no'
 	export_shared='public'
 	enable_pba_pools='yes'
 	enable_sba_pools='yes'
@@ -2172,6 +2179,12 @@ main()
 							;;
 						disable-shared)
 							enable_shared='no'
+							;;
+						enable-rpath)
+							enable_rpath='yes'
+							;;
+						disable-rpath)
+							enable_rpath='no'
 							;;
 						export-shared=*)
 							export_shared=${OPTARG#*=}
@@ -2402,7 +2415,7 @@ main()
 	fi
 
 	echo "${script_name}: using '${found_cc}' C compiler."
-	
+
 	# Also check the compiler to see if we are (cross-)compiling for Windows
 	if ${found_cc} -dM -E - < /dev/null 2> /dev/null | grep -q _WIN32; then
 		is_win=yes
@@ -3160,7 +3173,7 @@ main()
 
 		enable_sandbox_01=0
 	fi
-	
+
 	# Check the method used for returning complex numbers
 	if [ "x${complex_return}" = "xdefault" ]; then
 		if [ -n "${FC}" ]; then
@@ -3191,7 +3204,7 @@ main()
 			complex_return='gnu'
 		fi
 	fi
-	
+
 	if [ "x${complex_return}" = "xgnu"  ]; then
 		complex_return_intel01='0'
 	elif [ "x${complex_return}" = "xintel" ]; then
@@ -3344,6 +3357,7 @@ main()
 		| sed -e "s/@enable_arg_max_hack@/${enable_arg_max_hack}/g" \
 		| sed -e "s/@enable_static@/${enable_static}/g" \
 		| sed -e "s/@enable_shared@/${enable_shared}/g" \
+		| sed -e "s/@enable_rpath@/${enable_rpath}/g" \
 		| sed -e "s/@export_shared@/${export_shared}/g" \
 		| sed -e "s/@enable_blas@/${enable_blas}/g" \
 		| sed -e "s/@enable_cblas@/${enable_cblas}/g" \
@@ -3351,7 +3365,7 @@ main()
 		| sed -e "s/@pragma_omp_simd@/${pragma_omp_simd}/g" \
 		| sed -e "s/@sandbox@/${sandbox}/g" \
 		> "${config_mk_out_path}"
-		
+
 
 	# Begin substituting information into the bli_config_h_in file, outputting
 	# to bli_config_h_out. NOTE: We use perl instead of sed because the version


### PR DESCRIPTION
This PR does the following:

1. Adds an option `--enable-rpath/--disable--rpath` (default disabled) to use an install_name starting with @rpath/. Otherwise, set the install_name to the absolute path of the install library, which was the previous behavior. The new behavior is more like Linux where the library is relocatable but users must specify an RPATH entry in their binaries or set LD_LIBRARY_PATH/DYLD_LIBRARY_PATH.
2. Fixes an issue where the testsuite binaries would not run on macOS with `--disable-static` before installation. E.g. now one can do "make test" or "make check" with `--disable-static --enable-rpath` on macOS before or without installing.
3. Makes the testsuite binaries relocatable (as part of the build tree). Might be helpful.
