### PR TITLE
bli_pool: fix potential insufficient pool-growing

### DIFF
--- a/frame/base/bli_pool.c
+++ b/frame/base/bli_pool.c
@@ -373,7 +373,15 @@ void bli_pool_grow
 	{
 		// To prevent this from happening often, we double the current
 		// length of the block_ptrs array.
-		const siz_t block_ptrs_len_new = 2 * block_ptrs_len_cur;
+		// Sanity: make sure that the block_ptrs_len_new will be at least
+		// num_blocks_new, in case doubling the block_ptrs_len_cur is not enough.
+		// Example 1:
+		// - block_ptrs_len_cur == num_blocks_cur == 0 and num_blocks_add = 1
+		// - So doubling: 2 * block_ptrs_len_cur = 0, whereas 1 is expected
+		// Example 2:
+		// - block_ptrs_len_cur == num_blocks_cur == 10 and num_blocks_add = 30
+		// - So doubling: 2 * block_ptrs_len_cur = 20, whereas 40 is expected
+		const siz_t block_ptrs_len_new = bli_max( (2 * block_ptrs_len_cur), num_blocks_new );
 
 		#ifdef BLIS_ENABLE_MEM_TRACING
 		printf( "bli_pool_grow(): growing block_ptrs_len (%d -> %d): ",


### PR DESCRIPTION
- The current growing mechanism doubles the length of the block_ptrs array
everytime the array length needs to be re-adjusted, but did not take in account
the new total number of blocks, that in some cases, doubling the block_ptrs
array length is not enough.
- Two illustrating examples are given in the code.
- This commit fixes it by taking max with num_blocks_new, too.
- This commit also fixes incidentally the memory corruption of the growing
process of any empty-, hence ill-initialized pool (block_ptrs array length = 0).