### PR TITLE
the Apple local label thing is required by Clang in general

### DIFF
--- a/kernels/armv8a/3/armv8a_asm_utils.h
+++ b/kernels/armv8a/3/armv8a_asm_utils.h
@@ -35,7 +35,7 @@
 */
 
 // Apple's local label requirements.
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__clang__)
 #define LABEL(str) "   L" #str"%=: \n\t"
 #define BEQ(str) "b.eq L" #str"%=  \n\t"
 #define BNE(str) "b.ne L" #str"%=  \n\t"


### PR DESCRIPTION
@egaudry and I both [saw](https://github.com/flame/blis/issues/588#issuecomment-1012161338) this issue on Linux with Clang 10.

```
Compiling obj/thunderx2/kernels/armv8a/3/sup/bli_gemmsup_rv_armv8a_asm_d4x8m.o ('thunderx2' CFLAGS for kernels)
kernels/armv8a/3/bli_gemm_armv8a_asm_d6x8.c:171:49: fatal error: invalid symbol redefinition
        "                                            \n\t"
                                                       ^
<inline asm>:90:5: note: instantiated into assembly here
           .SLOOPKITER:
           ^
1 error generated.
```

Signed-off-by: Jeff Hammond <jehammond@nvidia.com>