### PR TITLE
Add armsve to arm64 Metaconfig

### DIFF
--- a/config/arm64/bli_family_arm64.h
+++ b/config/arm64/bli_family_arm64.h
@@ -39,7 +39,18 @@
 // -- MEMORY ALLOCATION --------------------------------------------------------
 
 #define BLIS_SIMD_ALIGN_SIZE 16
+#define BLIS_SIMD_MAX_NUM_REGISTERS 32
 
+// SVE-specific configs.
+#define N_L1_SVE_DEFAULT 64
+#define W_L1_SVE_DEFAULT 4
+#define C_L1_SVE_DEFAULT 256
+#define N_L2_SVE_DEFAULT 2048
+#define W_L2_SVE_DEFAULT 16
+#define C_L2_SVE_DEFAULT 256
+#define N_L3_SVE_DEFAULT 8192
+#define W_L3_SVE_DEFAULT 16
+#define C_L3_SVE_DEFAULT 256
 
 
 //#endif

--- a/config/armsve/bli_cntx_init_armsve.c
+++ b/config/armsve/bli_cntx_init_armsve.c
@@ -35,9 +35,12 @@
 #include "blis.h"
 #include <sys/auxv.h>
 
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1 << 22)
+#endif
+
 void bli_cntx_init_armsve( cntx_t* cntx )
 {
-	const int HWCAP_SVE = 1 << 22;
 	if (!(getauxval( AT_HWCAP ) & HWCAP_SVE))
 		return;
 

--- a/config/armsve/bli_cntx_init_armsve.c
+++ b/config/armsve/bli_cntx_init_armsve.c
@@ -33,9 +33,14 @@
 */
 
 #include "blis.h"
+#include <sys/auxv.h>
 
 void bli_cntx_init_armsve( cntx_t* cntx )
 {
+	const int HWCAP_SVE = 1 << 22;
+	if (!(getauxval( AT_HWCAP ) & HWCAP_SVE))
+		return;
+
 	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
 #if 0
 	blksz_t thresh[ BLIS_NUM_THRESH ];

--- a/config_registry
+++ b/config_registry
@@ -12,7 +12,7 @@ x86_64:         intel64 amd64 amd64_legacy
 intel64:        skx knl haswell sandybridge penryn generic
 amd64_legacy:   excavator steamroller piledriver bulldozer generic
 amd64:          zen3 zen2 zen generic
-arm64:          firestorm thunderx2 cortexa57 cortexa53 generic
+arm64:          armsve firestorm thunderx2 cortexa57 cortexa53 generic
 arm32:          cortexa15 cortexa9 generic
 
 # Intel architectures.

--- a/kernels/armsve/1m/bli_dpackm_armsve256_int_8xk.c
+++ b/kernels/armsve/1m/bli_dpackm_armsve256_int_8xk.c
@@ -35,7 +35,7 @@
 
 #include "blis.h"
 
-#if (defined(BLIS_FAMILY_ARMSVE) && !defined(BLIS_FAMILY_A64FX))
+#if !defined(BLIS_FAMILY_A64FX)
 #include <arm_sve.h>
 
 // assumption:

--- a/kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c
+++ b/kernels/armsve/1m/old/bli_dpackm_armsve512_int_12xk.c
@@ -36,7 +36,7 @@
 #include "blis.h"
 #include <stdio.h>
 
-#if (defined(BLIS_FAMILY_ARMSVE) && !defined(BLIS_FAMILY_A64FX))
+#if !defined(BLIS_FAMILY_A64FX)
 #include <arm_sve.h>
 
 // assumption:

--- a/kernels/armsve/bli_kernels_armsve.h
+++ b/kernels/armsve/bli_kernels_armsve.h
@@ -45,7 +45,7 @@ GEMM_UKR_PROT( dcomplex, z, gemm_armsve_asm_2vx10_unindexed )
 //GEMMSUP_KER_PROT( double,   d, gemmsup_rv_armsve_10x2v_unindexed )
 
 // Use SVE intrinsics only for referred cases.
-#if (defined(BLIS_FAMILY_ARMSVE) && !defined(BLIS_FAMILY_A64FX))
+#if !defined(BLIS_FAMILY_A64FX)
 PACKM_KER_PROT( double,   d, packm_armsve256_int_8xk )
 PACKM_KER_PROT( double,   d, packm_armsve512_int_12xk )
 #endif


### PR DESCRIPTION
Can be blocked w/ the current `./configure` file if unsupported by the compiler.

Resolves #612