### PR TITLE
Define `bli_pthread_switch_t` + matching API

### DIFF
--- a/frame/thread/bli_pthread.h
+++ b/frame/thread/bli_pthread.h
@@ -270,4 +270,29 @@ BLIS_EXPORT_BLIS int bli_pthread_barrier_wait
        bli_pthread_barrier_t* barrier
      );
 
+// -- Non-standard extensions --------------------------------------------------
+
+// -- pthread_switch --
+
+typedef struct
+{
+    int                 status;
+    bli_pthread_mutex_t mutex;
+} bli_pthread_switch_t;
+
+#define BLIS_PTHREAD_SWITCH_INIT { .status = 0, \
+                                   .mutex  = BLIS_PTHREAD_MUTEX_INITIALIZER }
+
+int bli_pthread_switch_on
+     (
+       bli_pthread_switch_t* sw,
+       int                 (*init)(void)
+     );
+
+int bli_pthread_switch_off
+     (
+       bli_pthread_switch_t* sw,
+       int                 (*deinit)(void)
+     );
+
 #endif // BLIS_PTHREAD_H


### PR DESCRIPTION
This PR implements a pthread-like switch type that can be used to safely move between two states. Similar to `pthread_once()`, the user-supplied init function will never be invoked in immediate succession, even if the caller attempts to turn the switch "on" repeatedly. However, unlike `pthread_once()`, a switch may be re-initialized (turned on) as long as it is first *de-initialized* (turned off).

@devinamatthews Let me know if you see anything problematic.