### PR TITLE
Use BLIS_ENABLE_COMPLEX_RETURN_INTEL in blastest files

### DIFF
--- a/blastest/src/cblat1.c
+++ b/blastest/src/cblat1.c
@@ -475,11 +475,23 @@ static real c_b52 = 0.f;
     integer mx, my;
     complex cdot[1];
     integer lenx, leny;
-    extern /* Complex */ complex cdotc_(integer *, complex *, integer 
+    extern /* Complex */
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+ void cdotc_(complex *,
+#else
+complex cdotc_(
+#endif
+ integer *, complex *, integer 
 	    *, complex *, integer *);
     extern /* Subroutine */ int ccopy_(integer *, complex *, integer *, 
 	    complex *, integer *);
-    extern /* Complex */ complex cdotu_(integer *, complex *, integer 
+    extern /* Complex */
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+ void cdotu_(complex *,
+#else
+complex cdotu_(
+#endif
+ integer *, complex *, integer 
 	    *, complex *, integer *);
     extern /* Subroutine */ int cswap_(integer *, complex *, integer *, 
 	    complex *, integer *), ctest_(integer *, complex *, complex *, 
@@ -526,14 +538,26 @@ static real c_b52 = 0.f;
 	    }
 	    if (combla_1.icase == 1) {
 /*              .. CDOTC .. */
-		q__1 = cdotc_(&combla_1.n, cx, &combla_1.incx, cy, &
+
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+		cdotc_(&q__1,
+#else
+		q__1 = cdotc_(
+#endif
+		 &combla_1.n, cx, &combla_1.incx, cy, &
 			combla_1.incy);
 		cdot[0].r = q__1.r, cdot[0].i = q__1.i;
 		ctest_(&c__1, cdot, &ct6[kn + (ki << 2) - 5], &csize1[kn - 1],
 			 sfac);
 	    } else if (combla_1.icase == 2) {
 /*              .. CDOTU .. */
-		q__1 = cdotu_(&combla_1.n, cx, &combla_1.incx, cy, &
+
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+		cdotu_(&q__1,
+#else
+		q__1 = cdotu_(
+#endif
+		 &combla_1.n, cx, &combla_1.incx, cy, &
 			combla_1.incy);
 		cdot[0].r = q__1.r, cdot[0].i = q__1.i;
 		ctest_(&c__1, cdot, &ct7[kn + (ki << 2) - 5], &csize1[kn - 1],

--- a/blastest/src/fortran/run-f2c.sh
+++ b/blastest/src/fortran/run-f2c.sh
@@ -50,13 +50,15 @@ recursive-sed.sh -c "s/-4.f };/-4.f }};/g" -p "s*1.c"
 
 # Convert from brain-dead f2c complex calling conventions to normal
 # return-based conventions.
-recursive-sed.sh -c "s/void cdotc_(complex \*, /complex cdotc_(/g" -p "c*1.c"
-recursive-sed.sh -c "s/void cdotu_(complex \*, /complex cdotu_(/g" -p "c*1.c"
-recursive-sed.sh -c "s/cdotc_(&q__1, /q__1 = cdotc_(/g" -p "c*1.c"
-recursive-sed.sh -c "s/cdotu_(&q__1, /q__1 = cdotu_(/g" -p "c*1.c"
+subst1='\n#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL\n&\n#else\n'
+subst2='\n#endif\n'
+recursive-sed.sh -c "s/ void cdotc_(complex \*,/${subst1}complex cdotc_(${subst2}/g" -p "c*1.c"
+recursive-sed.sh -c "s/ void cdotu_(complex \*,/${subst1}complex cdotu_(${subst2}/g" -p "c*1.c"
+recursive-sed.sh -c "s/\(.*\)cdotc_(&q__1,/${subst1}\1q__1 = cdotc_(${subst2}\1/g" -p "c*1.c"
+recursive-sed.sh -c "s/\(.*\)cdotu_(&q__1,/${subst1}\1q__1 = cdotu_(${subst2}\1/g" -p "c*1.c"
 
-recursive-sed.sh -c "s/void zdotc_(doublecomplex \*, /doublecomplex zdotc_(/g" -p "z*1.c"
-recursive-sed.sh -c "s/void zdotu_(doublecomplex \*, /doublecomplex zdotu_(/g" -p "z*1.c"
-recursive-sed.sh -c "s/zdotc_(\&z__1, /z__1 = zdotc_(/g" -p "z*1.c"
-recursive-sed.sh -c "s/zdotu_(\&z__1, /z__1 = zdotu_(/g" -p "z*1.c"
+recursive-sed.sh -c "s/ void zdotc_(doublecomplex \*,/${subst1}doublecomplex zdotc_(${subst2}/g" -p "z*1.c"
+recursive-sed.sh -c "s/ void zdotu_(doublecomplex \*,/${subst1}doublecomplex zdotu_(${subst2}/g" -p "z*1.c"
+recursive-sed.sh -c "s/\(.*\)zdotc_(\&z__1,/${subst1}\1z__1 = zdotc_(${subst2}\1/g" -p "z*1.c"
+recursive-sed.sh -c "s/\(.*\)zdotu_(\&z__1,/${subst1}\1z__1 = zdotu_(${subst2}\1/g" -p "z*1.c"
 

--- a/blastest/src/zblat1.c
+++ b/blastest/src/zblat1.c
@@ -459,12 +459,24 @@ static doublereal c_b52 = 0.;
     integer lenx, leny;
     extern /* Subroutine */ int ctest_(integer *, doublecomplex *, 
 	    doublecomplex *, doublecomplex *, doublereal *);
-    extern /* Double Complex */ doublecomplex zdotc_(integer *, 
+    extern /* Double Complex */
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+ void zdotc_(doublecomplex *,
+#else
+doublecomplex zdotc_(
+#endif
+ integer *, 
 	    doublecomplex *, integer *, doublecomplex *, integer *);
     integer ksize;
     extern /* Subroutine */ int zcopy_(integer *, doublecomplex *, integer *, 
 	    doublecomplex *, integer *);
-    extern /* Double Complex */ doublecomplex zdotu_(integer *, 
+    extern /* Double Complex */
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+ void zdotu_(doublecomplex *,
+#else
+doublecomplex zdotu_(
+#endif
+ integer *, 
 	    doublecomplex *, integer *, doublecomplex *, integer *);
     extern /* Subroutine */ int zswap_(integer *, doublecomplex *, integer *, 
 	    doublecomplex *, integer *), zaxpy_(integer *, doublecomplex *, 
@@ -508,14 +520,26 @@ static doublereal c_b52 = 0.;
 	    }
 	    if (combla_1.icase == 1) {
 /*              .. ZDOTC .. */
-		z__1 = zdotc_(&combla_1.n, cx, &combla_1.incx, cy, &
+
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+		zdotc_(&z__1,
+#else
+		z__1 = zdotc_(
+#endif
+		 &combla_1.n, cx, &combla_1.incx, cy, &
 			combla_1.incy);
 		cdot[0].r = z__1.r, cdot[0].i = z__1.i;
 		ctest_(&c__1, cdot, &ct6[kn + (ki << 2) - 5], &csize1[kn - 1],
 			 sfac);
 	    } else if (combla_1.icase == 2) {
 /*              .. ZDOTU .. */
-		z__1 = zdotu_(&combla_1.n, cx, &combla_1.incx, cy, &
+
+#ifdef BLIS_ENABLE_COMPLEX_RETURN_INTEL
+		zdotu_(&z__1,
+#else
+		z__1 = zdotu_(
+#endif
+		 &combla_1.n, cx, &combla_1.incx, cy, &
 			combla_1.incy);
 		cdot[0].r = z__1.r, cdot[0].i = z__1.i;
 		ctest_(&c__1, cdot, &ct7[kn + (ki << 2) - 5], &csize1[kn - 1],


### PR DESCRIPTION
cblat1 and zblat1 tests crash with --complex-return=intel;
in that case the original f2c'ed code is actually correct.

Adapt run-f2c.sh to enable conditional compilation; as
recursive-sed.sh is not included I approximated it using
```
#!/bin/bash
sed -i "$2" $(echo $4)
```
to test the changed sed commands in run-f2c.sh.