### PR TITLE
Change complex_return from 'gnu' to 'intel' for ifx.

### DIFF
--- a/configure
+++ b/configure
@@ -3684,9 +3684,9 @@ main()
 			# Query the compiler "vendor" (ie: the compiler's simple name).
 			# The last part ({ read first rest ; echo $first ; }) is a workaround
 			# to OS X's egrep only returning the first match.
-			fc_vendor=$(echo "${vendor_string}" | egrep -o 'ifort|GNU' | { read first rest ; echo $first ; })
+			fc_vendor=$(echo "${vendor_string}" | egrep -o 'IFORT|GNU' | { read first rest ; echo $first ; })
 
-			if [ "x${fc_vendor}" = "xifort" ]; then
+			if [ "x${fc_vendor}" = "xIFORT" ]; then
 				complex_return='intel'
 			elif [ "x${fc_vendor}" = "xGNU" ]; then
 				complex_return='gnu'


### PR DESCRIPTION
Since both ifx and ifort have IFORT in their version string,
simply test for "IFORT" instead of "ifort" to cover both:

$ ifx --version
ifx (IFORT) 2022.1.0 20220316
Copyright (C) 1985-2022 Intel Corporation. All rights reserved.

$ ifort --version
ifort (IFORT) 2021.6.0 20220226
Copyright (C) 1985-2022 Intel Corporation.  All rights reserved.