### PR TITLE
Add autodetection for POWER7, POWER9 & POWER10

### DIFF
--- a/frame/base/bli_cpuid.c
+++ b/frame/base/bli_cpuid.c
@@ -485,7 +485,7 @@ bool bli_cpuid_is_bulldozer
 	return TRUE;
 }
 
-#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_ARCH_PPC)
 
 arch_t bli_cpuid_query_id( void )
 {
@@ -530,9 +530,14 @@ arch_t bli_cpuid_query_id( void )
 			return BLIS_ARCH_GENERIC;
 		}
 	}
-	else if ( vendor == VENDOR_UNKNOWN )
+	else if ( vendor == VENDOR_IBM )
 	{
-		return BLIS_ARCH_GENERIC;
+		if ( model == MODEL_POWER7)
+			return BLIS_ARCH_POWER7;
+		else if ( model == MODEL_POWER9)
+			return BLIS_ARCH_POWER9;
+		else if ( model == MODEL_POWER10)
+			return BLIS_ARCH_POWER10;
 	}
 
 	return BLIS_ARCH_GENERIC;
@@ -1203,7 +1208,7 @@ uint32_t bli_cpuid_query
 	return VENDOR_ARM;
 }
 
-#elif defined(__arm__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM) || defined(_ARCH_PPC)
 
 /* 
    I can't easily find documentation to do this as for aarch64, though
@@ -1239,6 +1244,20 @@ uint32_t bli_cpuid_query
 	char  ptno_str[ TEMP_BUFFER_SIZE ];
 	char  feat_str[ TEMP_BUFFER_SIZE ];
 	char* r_val;
+
+#ifdef _ARCH_PPC
+	r_val = find_string_in( "cpu", proc_str, TEMP_BUFFER_SIZE, pci_str );
+	if ( r_val == NULL ) return VENDOR_IBM;
+
+	if ( strstr( proc_str, "POWER7" ) != NULL )
+		*model = MODEL_POWER7;
+	else if ( strstr( proc_str, "POWER9" ) != NULL )
+		*model = MODEL_POWER9;
+	else if ( strstr( proc_str, "POWER10" ) != NULL )
+		*model = MODEL_POWER10;
+
+	return VENDOR_IBM;
+#endif
 
 	//printf( "bli_cpuid_query(): beginning search\n" );
 

--- a/frame/base/bli_cpuid.h
+++ b/frame/base/bli_cpuid.h
@@ -161,19 +161,23 @@ enum
 	FEATURE_AVX512VL = 0x4000
 };
 
-#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM)
+#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_ARCH_PPC)
 
 char* find_string_in( char* target, char* buffer, size_t buf_len, char* filepath );
 
 enum
 {
 	VENDOR_ARM = 0,
+	VENDOR_IBM,
 	VENDOR_UNKNOWN
 };
 enum
 {
 	MODEL_ARMV7 = 0,
 	MODEL_ARMV8,
+	MODEL_POWER7,
+	MODEL_POWER9,
+	MODEL_POWER10,
 	MODEL_UNKNOWN
 };
 enum


### PR DESCRIPTION
Read from `/proc/cpuinfo` as done for ARM.
Fixes #501