### PR TITLE
Updated ARMv8a kernels to fix 2 prefetching issues.

### DIFF
--- a/kernels/armv8a/3/bli_gemm_armv8a_asm_d6x8.c
+++ b/kernels/armv8a/3/bli_gemm_armv8a_asm_d6x8.c
@@ -1,4 +1,4 @@
-    /*
+/*
 
    BLIS
    An object-based framework for developing high-performance BLAS-like
@@ -30,7 +30,6 @@
    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 */
 
 #include "blis.h"
@@ -59,7 +58,7 @@
  * Tested on Juno Board. Around 15.9 GFLOPS, 2 x A57 cores @ 1.1 GHz.
  * Tested on Juno board. Around  3.1 GFLOPS, 1 x A53 core  @ 850 MHz.
  * Tested on Juno board. Around 12   GFLOPS, 4 x A53 cores @ 850 MHz.
- 
+
  * UPDATE JULY 2021 - Leick Robinson
  * Both Microkernels changed to fix two prefetching performance bugs
  * Tested on 2s Altra.   Around 6,900 GFLOPS, 160 x N2 cores @ 3.0 GHz
@@ -76,8 +75,8 @@ void bli_sgemm_armv8a_asm_8x12
        float*     restrict b,
        float*     restrict beta,
        float*     restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 	void* a_next = bli_auxinfo_next_a( data );
@@ -106,7 +105,7 @@ void bli_sgemm_armv8a_asm_8x12
 	"                                            \n\t"
 	" ldr x5,%[k_iter]                           \n\t" // Number of unrolled iterations (k_iter).
 	" ldr x6,%[k_left]                           \n\t" // Number of remaining iterations (k_left).
-	" add x16,x2,x10                             \n\t" //Load address Column 1 of C
+	" add x16,x2,x10                             \n\t" // Load address Column 1 of C
 	"                                            \n\t"
 	// " ldr x14,%[rs_c]                            \n\t" // Load rs_c.
 	// " lsl x14,x14,#2                             \n\t" // rs_c * sizeof(float).
@@ -115,97 +114,97 @@ void bli_sgemm_armv8a_asm_8x12
 	" dup  v8.4s, wzr                            \n\t" // Vector for accummulating column 0
 	" prfm    PLDL1KEEP, [x1, #192]              \n\t"
 	" prfm pldl1keep,[x2]                        \n\t" // Prefetch c.
-	" add x17,x16,x10                            \n\t" //Load address Column 2 of C
-    
+	" add x17,x16,x10                            \n\t" // Load address Column 2 of C
+
 	" dup  v9.4s, wzr                            \n\t" // Vector for accummulating column 0
 	" prfm    PLDL1KEEP, [x1, #256]              \n\t"
-    "                                            \n\t" // Since the columns can cross a cache line boundary,
-                                                       // we also need to prefetch the "ends"
+	"                                            \n\t" // Since columns of C can cross a cache
+	                                                   // line boundary, we also need to prefetch
+	                                                   // the "ends."
 	" prfm pldl1keep,[x2, #16]                   \n\t" // Prefetch c.
-	" add x19,x17,x10                            \n\t" //Load address Column 3 of C
-    
+	" add x19,x17,x10                            \n\t" // Load address Column 3 of C
+
 	" dup  v10.4s, wzr                           \n\t" // Vector for accummulating column 1
 	" prfm    PLDL1KEEP, [x1, #320]              \n\t"
 	" prfm pldl1keep,[x16]                       \n\t" // Prefetch c.
-	" add x20,x19,x10                            \n\t" //Load address Column 4 of C
-    
+	" add x20,x19,x10                            \n\t" // Load address Column 4 of C
+
 	" dup  v11.4s, wzr                           \n\t" // Vector for accummulating column 1
 	" prfm pldl1keep,[x16]                       \n\t" // Prefetch c.
 	" prfm pldl1keep,[x16, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v12.4s, wzr                           \n\t" // Vector for accummulating column 2
 	" prfm pldl1keep,[x17]                       \n\t" // Prefetch c.
-	" add x21,x20,x10                            \n\t" //Load address Column 5 of C
-    
+	" add x21,x20,x10                            \n\t" // Load address Column 5 of C
+
 	" dup  v13.4s, wzr                           \n\t" // Vector for accummulating column 2
 	" prfm pldl1keep,[x17, #16]                  \n\t" // Prefetch c.
 	"                                            \n\t"
 	" dup  v14.4s, wzr                           \n\t" // Vector for accummulating column 3
 	" prfm    PLDL1KEEP, [x0, #128]              \n\t"
 	" prfm pldl1keep,[x19]                       \n\t" // Prefetch c.
-	" add x22,x21,x10                            \n\t" //Load address Column 6 of C
-    
+	" add x22,x21,x10                            \n\t" // Load address Column 6 of C
+
 	" dup  v15.4s, wzr                           \n\t" // Vector for accummulating column 3
 	" prfm    PLDL1KEEP, [x0, #192]              \n\t"
 	" prfm pldl1keep,[x19, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v16.4s, wzr                           \n\t" // Vector for accummulating column 4
 	" prfm pldl1keep,[x20]                       \n\t" // Prefetch c.
-	" add x23,x22,x10                            \n\t" //Load address Column 7 of C
-    
+	" add x23,x22,x10                            \n\t" // Load address Column 7 of C
+
 	" dup  v17.4s, wzr                           \n\t" // Vector for accummulating column 4
 	" prfm pldl1keep,[x20, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v18.4s, wzr                           \n\t" // Vector for accummulating column 5
 	" prfm pldl1keep,[x21]                       \n\t" // Prefetch c.
-	" add x24,x23,x10                            \n\t" //Load address Column 8 of C
-    
+	" add x24,x23,x10                            \n\t" // Load address Column 8 of C
+
 	" dup  v19.4s, wzr                           \n\t" // Vector for accummulating column 5
 	" prfm pldl1keep,[x21, #16]                  \n\t" // Prefetch c.
-    
+
 	"                                            \n\t"
 	" dup  v20.4s, wzr                           \n\t" // Vector for accummulating column 6
 	" prfm pldl1keep,[x22]                       \n\t" // Prefetch c.
-	" add x25,x24,x10                            \n\t" //Load address Column 9 of C
-    
+	" add x25,x24,x10                            \n\t" // Load address Column 9 of C
+
 	" dup  v21.4s, wzr                           \n\t" // Vector for accummulating column 6
 	" prfm pldl1keep,[x22, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v22.4s, wzr                           \n\t" // Vector for accummulating column 7
 	" prfm pldl1keep,[x23]                       \n\t" // Prefetch c.
-	" add x26,x25,x10                            \n\t" //Load address Column 10 of C
-    
+	" add x26,x25,x10                            \n\t" // Load address Column 10 of C
+
 	" dup  v23.4s, wzr                           \n\t" // Vector for accummulating column 7
 	" prfm pldl1keep,[x23, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v24.4s, wzr                           \n\t" // Vector for accummulating column 8
 	" prfm pldl1keep,[x24]                       \n\t" // Prefetch c.
-	" add x27,x26,x10                            \n\t" //Load address Column 11 of C
-    
+	" add x27,x26,x10                            \n\t" // Load address Column 11 of C
+
 	" dup  v25.4s, wzr                           \n\t" // Vector for accummulating column 8
 	" prfm pldl1keep,[x24, #16]                  \n\t" // Prefetch c.
 	"                                            \n\t"
 	" dup  v26.4s, wzr                           \n\t" // Vector for accummulating column 9
 	" prfm pldl1keep,[x25]                       \n\t" // Prefetch c.
-    
+
 	" dup  v27.4s, wzr                           \n\t" // Vector for accummulating column 9
 	" prfm pldl1keep,[x25, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v28.4s, wzr                           \n\t" // Vector for accummulating column 10
 	" prfm pldl1keep,[x26]                       \n\t" // Prefetch c.
-    
+
 	" dup  v29.4s, wzr                           \n\t" // Vector for accummulating column 10
 	" prfm pldl1keep,[x26, #16]                  \n\t" // Prefetch c.
-    
+
 	" dup  v30.4s, wzr                           \n\t" // Vector for accummulating column 11
 	" prfm pldl1keep,[x27]                       \n\t" // Prefetch c.
-    
+
 	" dup  v31.4s, wzr                           \n\t" // Vector for accummulating column 11
 	" prfm pldl1keep,[x27, #16]                  \n\t" // Prefetch c.
 	"                                            \n\t"
 	"                                            \n\t"
-    
-    
+
 	" cmp x5,#0                                  \n\t" // If k_iter == 0, jump to k_left.
 	BEQ(SCONSIDERKLEFT)
 	"                                            \n\t"
@@ -216,10 +215,10 @@ void bli_sgemm_armv8a_asm_8x12
 	" ldr q3, [x1, #16]                          \n\t"
 	" ldr q4, [x1, #32]                          \n\t"
 	"                                            \n\t"
-	" add x0, x0, #32                            \n\t" //update address of A
-	" add x1, x1, #48                            \n\t" //update address of B
+	" add x0, x0, #32                            \n\t" // Update address of A
+	" add x1, x1, #48                            \n\t" // Update address of B
 	"                                            \n\t"
-	" cmp x5,1                                   \n\t" // If there is just one k_iter, jump to that one.
+	" cmp x5,1                                   \n\t" // If there's only one k_iter, jump to it
 	BEQ(SLASTITER)                                     // (as loop is do-while-like).
 	"                                            \n\t"
 	LABEL(SLOOPKITER)                                  // Body of the k_iter loop.
@@ -259,7 +258,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
 	" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
 	" ldr q4, [x1, #32]                          \n\t"
-	"                                            \n\t" //End It 1
+	"                                            \n\t"                  // End It 1
 	"                                            \n\t"
 	" ldr q0, [x0, #32]                          \n\t"
 	" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
@@ -295,7 +294,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v29.4s,v6.4s,v4.s[2]                  \n\t" // Accummulate.
 	" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
 	" ldr q4, [x1, #80]                          \n\t"
-	"                                            \n\t" //End It 2
+	"                                            \n\t"                  // End It 2
 	"                                            \n\t"
 	" ldr q5, [x0, #64]                          \n\t"
 	" fmla v8.4s,v0.4s,v2.s[0]                   \n\t" // Accummulate.
@@ -329,7 +328,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
 	" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
 	" ldr q4, [x1, #128]                         \n\t"
-	"                                            \n\t" //End It 3
+	"                                            \n\t"                  // End It 3
 	"                                            \n\t"
 	" ldr q0, [x0, #96]                          \n\t"
 	" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
@@ -365,7 +364,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" ldr q4, [x1, #176]                         \n\t"
 	" add x1, x1, #192                           \n\t"
 	" add x0, x0, #128                           \n\t"
-	"                                            \n\t" //End It 4
+	"                                            \n\t"                  // End It 4
 	" sub x5,x5,1                                \n\t" // i-=1.
 	" cmp x5,1                                   \n\t" // Iterate again if we are not in k_iter == 1.
 	BNE(SLOOPKITER)
@@ -405,7 +404,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
 	" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
 	" ldr q4, [x1, #32]                          \n\t"
-	"                                            \n\t" //End It 1
+	"                                            \n\t"                  // End It 1
 	"                                            \n\t"
 	" ldr q0, [x0, #32]                          \n\t"
 	" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
@@ -439,7 +438,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v29.4s,v6.4s,v4.s[2]                  \n\t" // Accummulate.
 	" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
 	" ldr q4, [x1, #80]                          \n\t"
-	"                                            \n\t" //End It 2
+	"                                            \n\t"                  // End It 2
 	"                                            \n\t"
 	" ldr q5, [x0, #64]                          \n\t"
 	" fmla v8.4s,v0.4s,v2.s[0]                   \n\t" // Accummulate.
@@ -473,7 +472,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v29.4s,v1.4s,v4.s[2]                  \n\t" // Accummulate.
 	" fmla v31.4s,v1.4s,v4.s[3]                  \n\t" // Accummulate.
 	" ldr q4, [x1, #128]                         \n\t"
-	"                                            \n\t" //End It 3
+	"                                            \n\t"                  // End It 3
 	"                                            \n\t"
 	" fmla v8.4s,v5.4s,v2.s[0]                   \n\t" // Accummulate.
 	" fmla v9.4s,v6.4s,v2.s[0]                   \n\t" // Accummulate.
@@ -504,7 +503,7 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v31.4s,v6.4s,v4.s[3]                  \n\t" // Accummulate.
 	" add x1, x1, #144                           \n\t"
 	" add x0, x0, #96                            \n\t"
-	"                                            \n\t" //End It 4
+	"                                            \n\t"                  // End It 4
 	"                                            \n\t"
 	LABEL(SCONSIDERKLEFT)
 	" cmp x6,0                                   \n\t" // If k_left == 0, we are done.
@@ -574,11 +573,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fcmp s7,#0.0                               \n\t"
 	BEQ(SBETAZEROCOLSTOREDS1)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q0, [x2]                               \n\t" //Load column 0 of C
+	" ldr q0, [x2]                               \n\t" // Load column 0 of C
 	" ldr q1, [x2, #16]                          \n\t"
-	" ldr q2, [x16]                              \n\t" //Load column 1 of C
+	" ldr q2, [x16]                              \n\t" // Load column 1 of C
 	" ldr q3, [x16, #16]                         \n\t"
-	" ldr q4, [x17]                              \n\t" //Load column 2 of C
+	" ldr q4, [x17]                              \n\t" // Load column 2 of C
 	" ldr q5, [x17, #16]                         \n\t"
 	"                                            \n\t"
 	" fmul v0.4s,v0.4s,v7.s[0]                   \n\t" // Scale by beta
@@ -597,11 +596,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v4.4s,v12.4s,v6.s[0]                  \n\t" // Scale by alpha
 	" fmla v5.4s,v13.4s,v6.s[0]                  \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q0, [x2]                               \n\t" //Store column 0 of C
+	" str q0, [x2]                               \n\t" // Store column 0 of C
 	" str q1, [x2, #16]                          \n\t"
-	" str q2, [x16]                              \n\t" //Store column 1 of C
+	" str q2, [x16]                              \n\t" // Store column 1 of C
 	" str q3, [x16, #16]                         \n\t"
-	" str q4, [x17]                              \n\t" //Store column 2 of C
+	" str q4, [x17]                              \n\t" // Store column 2 of C
 	" str q5, [x17, #16]                         \n\t"
 	"                                            \n\t"
 	" dup  v8.4s, wzr                            \n\t"
@@ -614,11 +613,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fcmp s7,#0.0                               \n\t"
 	BEQ(SBETAZEROCOLSTOREDS2)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q8, [x19]                              \n\t" //Load column 3 of C
+	" ldr q8, [x19]                              \n\t" // Load column 3 of C
 	" ldr q9, [x19, #16]                         \n\t"
-	" ldr q10, [x20]                             \n\t" //Load column 4 of C
+	" ldr q10, [x20]                             \n\t" // Load column 4 of C
 	" ldr q11, [x20, #16]                        \n\t"
-	" ldr q12, [x21]                             \n\t" //Load column 5 of C
+	" ldr q12, [x21]                             \n\t" // Load column 5 of C
 	" ldr q13, [x21, #16]                        \n\t"
 	"                                            \n\t"
 	" fmul v8.4s, v8.4s, v7.s[0]                 \n\t" // Scale by beta
@@ -637,11 +636,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v12.4s,v18.4s,v6.s[0]                 \n\t" // Scale by alpha
 	" fmla v13.4s,v19.4s,v6.s[0]                 \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q8, [x19]                              \n\t" //Store column 3 of C
+	" str q8, [x19]                              \n\t" // Store column 3 of C
 	" str q9, [x19, #16]                         \n\t"
-	" str q10, [x20]                             \n\t" //Store column 4 of C
+	" str q10, [x20]                             \n\t" // Store column 4 of C
 	" str q11, [x20, #16]                        \n\t"
-	" str q12, [x21]                             \n\t" //Store column 5 of C
+	" str q12, [x21]                             \n\t" // Store column 5 of C
 	" str q13, [x21, #16]                        \n\t"
 	"                                            \n\t"
 	" dup  v0.4s, wzr                            \n\t"
@@ -654,11 +653,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fcmp s7,#0.0                               \n\t"
 	BEQ(SBETAZEROCOLSTOREDS3)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q0, [x22]                              \n\t" //Load column 6 of C
+	" ldr q0, [x22]                              \n\t" // Load column 6 of C
 	" ldr q1, [x22, #16]                         \n\t"
-	" ldr q2, [x23]                              \n\t" //Load column 7 of C
+	" ldr q2, [x23]                              \n\t" // Load column 7 of C
 	" ldr q3, [x23, #16]                         \n\t"
-	" ldr q4, [x24]                              \n\t" //Load column 8 of C
+	" ldr q4, [x24]                              \n\t" // Load column 8 of C
 	" ldr q5, [x24, #16]                         \n\t"
 	"                                            \n\t"
 	" fmul v0.4s,v0.4s,v7.s[0]                   \n\t" // Scale by beta
@@ -677,11 +676,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v4.4s,v24.4s,v6.s[0]                  \n\t" // Scale by alpha
 	" fmla v5.4s,v25.4s,v6.s[0]                  \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q0, [x22]                              \n\t" //Store column 6 of C
+	" str q0, [x22]                              \n\t" // Store column 6 of C
 	" str q1, [x22, #16]                         \n\t"
-	" str q2, [x23]                              \n\t" //Store column 7 of C
+	" str q2, [x23]                              \n\t" // Store column 7 of C
 	" str q3, [x23, #16]                         \n\t"
-	" str q4, [x24]                              \n\t" //Store column 8 of C
+	" str q4, [x24]                              \n\t" // Store column 8 of C
 	" str q5, [x24, #16]                         \n\t"
 	"                                            \n\t"
 	" dup  v8.4s, wzr                            \n\t"
@@ -694,11 +693,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fcmp s7,#0.0                               \n\t"
 	BEQ(SBETAZEROCOLSTOREDS4)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q8, [x25]                              \n\t" //Load column 9 of C
+	" ldr q8, [x25]                              \n\t" // Load column 9 of C
 	" ldr q9, [x25, #16]                         \n\t"
-	" ldr q10, [x26]                             \n\t" //Load column 10 of C
+	" ldr q10, [x26]                             \n\t" // Load column 10 of C
 	" ldr q11, [x26, #16]                        \n\t"
-	" ldr q12, [x27]                             \n\t" //Load column 11 of C
+	" ldr q12, [x27]                             \n\t" // Load column 11 of C
 	" ldr q13, [x27, #16]                        \n\t"
 	"                                            \n\t"
 	" fmul v8.4s, v8.4s, v7.s[0]                 \n\t" // Scale by beta
@@ -720,11 +719,11 @@ void bli_sgemm_armv8a_asm_8x12
 	" fmla v12.4s,v30.4s,v6.s[0]                 \n\t" // Scale by alpha
 	" fmla v13.4s,v31.4s,v6.s[0]                 \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q8, [x25]                              \n\t" //Store column 9 of C
+	" str q8, [x25]                              \n\t" // Store column 9 of C
 	" str q9, [x25, #16]                         \n\t"
-	" str q10, [x26]                             \n\t" //Store column 10 of C
+	" str q10, [x26]                             \n\t" // Store column 10 of C
 	" str q11, [x26, #16]                        \n\t"
-	" str q12, [x27]                             \n\t" //Store column 11 of C
+	" str q12, [x27]                             \n\t" // Store column 11 of C
 	" str q13, [x27, #16]                        \n\t"
 	"                                            \n\t"
 	"                                            \n\t"
@@ -782,7 +781,7 @@ void bli_sgemm_armv8a_asm_8x12
  * Tested on Juno Board. Around 7.6 GFLOPS, 2 x A57 cores @ 1.1 GHz.
  * Tested on Juno board. Around 1.5 GFLOPS, 1 x A53 core  @ 850 MHz.
  * Tested on Juno board. Around 5.5 GFLOPS, 4 x A53 cores @ 850 MHz.
- 
+
  * UPDATE JULY 2021 - Leick Robinson
  * Both Microkernels changed to fix two prefetching performance bugs
  * Tested on 2s Altra. Around 3,200 GFLOPS, 160 x N2 cores @ 3.0 GHz
@@ -799,21 +798,21 @@ void bli_dgemm_armv8a_asm_6x8
        double*    restrict b,
        double*    restrict beta,
        double*    restrict c, inc_t rs_c0, inc_t cs_c0,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       auxinfo_t*          data,
+       cntx_t*             cntx
      )
 {
 #ifdef DISPLAY_DEBUG_INFO
 
 	static bool bFirstTime = true;
- 
-	if (bFirstTime)
-		{
-  	printf("In bli_dgemm_armv8a_asm_6x8: rs_c0=%d, cs_c0=%d \n",
-   		(int) rs_c0, (int) cs_c0);
-    fflush(stdout);
+
+	if ( bFirstTime )
+	{
+		printf( "In bli_dgemm_armv8a_asm_6x8: rs_c0=%d, cs_c0=%d \n",
+		        (int) rs_c0, (int) cs_c0 );
+		fflush( stdout );
 		bFirstTime = false;
-  	}
+	}
 
 #endif
 
@@ -842,7 +841,7 @@ void bli_dgemm_armv8a_asm_6x8
 	"                                            \n\t"
 	" ldr x5,%[k_iter]                           \n\t" // Init guard (k_iter)
 	" ldr x6,%[k_left]                           \n\t" // Init guard (k_iter)
-	" add x20,x2,x10                             \n\t" //Load address Column 1 of C
+	" add x20,x2,x10                             \n\t" // Load address Column 1 of C
 	"                                            \n\t"
 	// " ldr x14,%[rs_c]                            \n\t" // Load rs_c.
 	// " lsl x14,x14,#3                             \n\t" // rs_c * sizeof(double).
@@ -859,73 +858,74 @@ void bli_dgemm_armv8a_asm_6x8
 	" prfm    PLDL1KEEP, [x1, #448]              \n\t"
 	" dup  v12.2d, xzr                           \n\t" // Vector for accummulating column 1
 	" prfm    PLDL1KEEP, [x0, #192]              \n\t"
-	" add x21,x20,x10                            \n\t" //Load address Column 2 of C
-    
+	" add x21,x20,x10                            \n\t" // Load address Column 2 of C
+
 	" dup  v13.2d, xzr                           \n\t" // Vector for accummulating column 1
 	" prfm    PLDL1KEEP, [x0, #256]              \n\t"
 	"                                            \n\t"
 	" dup  v14.2d, xzr                           \n\t" // Vector for accummulating column 2
 	" prfm    PLDL1KEEP, [x0, #320]              \n\t"
-	" add x22,x21,x10                            \n\t" //Load address Column 3 of C
-    
+	" add x22,x21,x10                            \n\t" // Load address Column 3 of C
+
 	" dup  v15.2d, xzr                           \n\t" // Vector for accummulating column 2
 	" prfm pldl1keep,[x2]                        \n\t" // Prefetch c.
 	" dup  v16.2d, xzr                           \n\t" // Vector for accummulating column 2
-    "                                            \n\t" // Since the columns can cross a cache line boundary,
-                                                       // we also need to prefetch the "ends"
+	"                                            \n\t" // Since columns of C can cross a cache
+	                                                   // line boundary, we also need to prefetch
+	                                                   // the "ends."
 	" prfm pldl1keep,[x2, #32]                   \n\t" // Prefetch c.
-	" add x23,x22,x10                            \n\t" //Load address Column 4 of C
-    
+	" add x23,x22,x10                            \n\t" // Load address Column 4 of C
+
 	" dup  v17.2d, xzr                           \n\t" // Vector for accummulating column 3
 	" prfm pldl1keep,[x20]                       \n\t" // Prefetch c.
-    
+
 	" dup  v18.2d, xzr                           \n\t" // Vector for accummulating column 3
 	" prfm pldl1keep,[x20, #32]                  \n\t" // Prefetch c.
-	" add x24,x23,x10                            \n\t" //Load address Column 5 of C
-    
+	" add x24,x23,x10                            \n\t" // Load address Column 5 of C
+
 	" dup  v19.2d, xzr                           \n\t" // Vector for accummulating column 3
 	" prfm pldl1keep,[x21]                       \n\t" // Prefetch c.
 	"                                            \n\t"
-    
+
 	" dup  v20.2d, xzr                           \n\t" // Vector for accummulating column 4
 	" prfm pldl1keep,[x21, #32]                  \n\t" // Prefetch c.
-	" add x25,x24,x10                            \n\t" //Load address Column 6 of C
-    
+	" add x25,x24,x10                            \n\t" // Load address Column 6 of C
+
 	" dup  v21.2d, xzr                           \n\t" // Vector for accummulating column 4
 	" prfm pldl1keep,[x22]                       \n\t" // Prefetch c.
-    
+
 	" dup  v22.2d, xzr                           \n\t" // Vector for accummulating column 4
 	" prfm pldl1keep,[x22, #32]                  \n\t" // Prefetch c.
-	" add x26,x25,x10                            \n\t" //Load address Column 7 of C
-    
+	" add x26,x25,x10                            \n\t" // Load address Column 7 of C
+
 	" dup  v23.2d, xzr                           \n\t" // Vector for accummulating column 5
 	" prfm pldl1keep,[x23]                       \n\t" // Prefetch c.
-    
+
 	" dup  v24.2d, xzr                           \n\t" // Vector for accummulating column 5
 	" prfm pldl1keep,[x23, #32]                  \n\t" // Prefetch c.
-    
+
 	" dup  v25.2d, xzr                           \n\t" // Vector for accummulating column 5
 	" prfm pldl1keep,[x24]                       \n\t" // Prefetch c.
 	"                                            \n\t"
 	" dup  v26.2d, xzr                           \n\t" // Vector for accummulating column 6
 	" prfm pldl1keep,[x24, #32]                  \n\t" // Prefetch c.
-    
+
 	" dup  v27.2d, xzr                           \n\t" // Vector for accummulating column 6
 	" prfm pldl1keep,[x25]                       \n\t" // Prefetch c.
-    
+
 	" dup  v28.2d, xzr                           \n\t" // Vector for accummulating column 6
 	" prfm pldl1keep,[x25, #32]                  \n\t" // Prefetch c.
-    
+
 	" dup  v29.2d, xzr                           \n\t" // Vector for accummulating column 7
 	" prfm pldl1keep,[x26]                       \n\t" // Prefetch c.
-    
+
 	" dup  v30.2d, xzr                           \n\t" // Vector for accummulating column 7
 	" prfm pldl1keep,[x26, #32]                  \n\t" // Prefetch c.
-    
+
 	" dup  v31.2d, xzr                           \n\t" // Vector for accummulating column 7
 	"                                            \n\t"
 	"                                            \n\t"
-    
+
 	" cmp x5,#0                                  \n\t" // If k_iter == 0, jump to k_left.
 	BEQ(DCONSIDERKLEFT)
 	"                                            \n\t"
@@ -938,10 +938,10 @@ void bli_dgemm_armv8a_asm_6x8
 	" ldr q5, [x1, #32]                          \n\t"
 	" ldr q6, [x1, #48]                          \n\t"
 	"                                            \n\t"
-	" add x0, x0, #48                            \n\t" //update address of A
-	" add x1, x1, #64                            \n\t" //update address of B
+	" add x0, x0, #48                            \n\t" // Update address of A
+	" add x1, x1, #64                            \n\t" // Update address of B
 	"                                            \n\t"
-	" cmp x5,1                                   \n\t" // If there is just one k_iter, jump to that one.
+	" cmp x5,1                                   \n\t" // If there's only one k_iter, jump to it
 	BEQ(DLASTITER)                                     // (as loop is do-while-like).
 	"                                            \n\t"
 	LABEL(DLOOP)                                       // Body
@@ -1031,7 +1031,7 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
 	" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
 	" ldr q6, [x1, #112]                         \n\t"
-	"                                            \n\t"                  //End it 2
+	"                                            \n\t"                  // End it 2
 	" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
 	" prfm    PLDL1KEEP, [x0, #464]              \n\t"
 	" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
@@ -1112,7 +1112,7 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
 	" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
 	" ldr q6, [x1, #240]                         \n\t"
-	"                                            \n\t"                  //End it 4
+	"                                            \n\t"                  // End it 4
 	" add x0, x0, #192                           \n\t"
 	" add x1, x1, #256                           \n\t"
 	"                                            \n\t"
@@ -1201,7 +1201,7 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
 	" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
 	" ldr q6, [x1, #112]                         \n\t"
-	"                                            \n\t"                  //End it 2
+	"                                            \n\t"                  // End it 2
 	" fmla v8.2d ,v0.2d,v3.d[0]                  \n\t" // Accummulate
 	" fmla v9.2d ,v1.2d,v3.d[0]                  \n\t" // Accummulate
 	" fmla v10.2d,v2.2d,v3.d[0]                  \n\t" // Accummulate
@@ -1275,7 +1275,7 @@ void bli_dgemm_armv8a_asm_6x8
 	"                                            \n\t"
 	" fmla v28.2d,v7.2d,v6.d[0]                  \n\t" // Accummulate
 	" fmla v31.2d,v7.2d,v6.d[1]                  \n\t" // Accummulate
-	"                                            \n\t"                  //End it 4
+	"                                            \n\t"                  // End it 4
 	" add x0, x0, #144                           \n\t"
 	"                                            \n\t"
 	LABEL(DCONSIDERKLEFT)
@@ -1354,11 +1354,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fcmp d7,#0.0                               \n\t"
 	BEQ(DBETAZEROCOLSTOREDS1)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q0, [x2]                               \n\t" //Load column 0 of C
+	" ldr q0, [x2]                               \n\t" // Load column 0 of C
 	" ldr q1, [x2, #16]                          \n\t"
 	" ldr q2, [x2, #32]                          \n\t"
 	"                                            \n\t"
-	" ldr q3, [x20]                              \n\t" //Load column 1 of C
+	" ldr q3, [x20]                              \n\t" // Load column 1 of C
 	" ldr q4, [x20, #16]                         \n\t"
 	" ldr q5, [x20, #32]                         \n\t"
 	"                                            \n\t"
@@ -1378,11 +1378,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v4.2d,v12.2d,v6.d[0]                  \n\t" // Scale by alpha
 	" fmla v5.2d,v13.2d,v6.d[0]                  \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q0, [x2]                               \n\t" //Store column 0 of C
+	" str q0, [x2]                               \n\t" // Store column 0 of C
 	" str q1, [x2, #16]                          \n\t"
 	" str q2, [x2, #32]                          \n\t"
 	"                                            \n\t"
-	" str q3, [x20]                              \n\t" //Store column 1 of C
+	" str q3, [x20]                              \n\t" // Store column 1 of C
 	" str q4, [x20, #16]                         \n\t"
 	" str q5, [x20, #32]                         \n\t"
 	"                                            \n\t"
@@ -1396,11 +1396,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fcmp d7,#0.0                               \n\t"
 	BEQ(DBETAZEROCOLSTOREDS2)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q8, [x21]                              \n\t" //Load column 2 of C
+	" ldr q8, [x21]                              \n\t" // Load column 2 of C
 	" ldr q9, [x21, #16]                         \n\t"
 	" ldr q10, [x21, #32]                        \n\t"
 	"                                            \n\t"
-	" ldr q11, [x22]                             \n\t" //Load column 3 of C
+	" ldr q11, [x22]                             \n\t" // Load column 3 of C
 	" ldr q12, [x22, #16]                        \n\t"
 	" ldr q13, [x22, #32]                        \n\t"
 	"                                            \n\t"
@@ -1420,11 +1420,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v12.2d,v18.2d,v6.d[0]                 \n\t" // Scale by alpha
 	" fmla v13.2d,v19.2d,v6.d[0]                 \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q8, [x21]                              \n\t" //Store column 2 of C
+	" str q8, [x21]                              \n\t" // Store column 2 of C
 	" str q9, [x21, #16]                         \n\t"
 	" str q10, [x21, #32]                        \n\t"
 	"                                            \n\t"
-	" str q11, [x22]                             \n\t" //Store column 3 of C
+	" str q11, [x22]                             \n\t" // Store column 3 of C
 	" str q12, [x22, #16]                        \n\t"
 	" str q13, [x22, #32]                        \n\t"
 	"                                            \n\t"
@@ -1438,11 +1438,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fcmp d7,#0.0                               \n\t"
 	BEQ(DBETAZEROCOLSTOREDS3)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q0, [x23]                              \n\t" //Load column 4 of C
+	" ldr q0, [x23]                              \n\t" // Load column 4 of C
 	" ldr q1, [x23, #16]                         \n\t"
 	" ldr q2, [x23, #32]                         \n\t"
 	"                                            \n\t"
-	" ldr q3, [x24]                              \n\t" //Load column 5 of C
+	" ldr q3, [x24]                              \n\t" // Load column 5 of C
 	" ldr q4, [x24, #16]                         \n\t"
 	" ldr q5, [x24, #32]                         \n\t"
 	"                                            \n\t"
@@ -1462,11 +1462,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v4.2d,v24.2d,v6.d[0]                  \n\t" // Scale by alpha
 	" fmla v5.2d,v25.2d,v6.d[0]                  \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q0, [x23]                              \n\t" //Store column 4 of C
+	" str q0, [x23]                              \n\t" // Store column 4 of C
 	" str q1, [x23, #16]                         \n\t"
 	" str q2, [x23, #32]                         \n\t"
 	"                                            \n\t"
-	" str q3, [x24]                              \n\t" //Store column 5 of C
+	" str q3, [x24]                              \n\t" // Store column 5 of C
 	" str q4, [x24, #16]                         \n\t"
 	" str q5, [x24, #32]                         \n\t"
 	"                                            \n\t"
@@ -1480,11 +1480,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fcmp d7,#0.0                               \n\t"
 	BEQ(DBETAZEROCOLSTOREDS4)                          // Taking care of the beta==0 case.
 	"                                            \n\t"
-	" ldr q8, [x25]                              \n\t" //Load column 6 of C
+	" ldr q8, [x25]                              \n\t" // Load column 6 of C
 	" ldr q9, [x25, #16]                         \n\t"
 	" ldr q10, [x25, #32]                        \n\t"
 	"                                            \n\t"
-	" ldr q11, [x26]                             \n\t" //Load column 7 of C
+	" ldr q11, [x26]                             \n\t" // Load column 7 of C
 	" ldr q12, [x26, #16]                        \n\t"
 	" ldr q13, [x26, #32]                        \n\t"
 	"                                            \n\t"
@@ -1507,11 +1507,11 @@ void bli_dgemm_armv8a_asm_6x8
 	" fmla v12.2d,v30.2d,v6.d[0]                 \n\t" // Scale by alpha
 	" fmla v13.2d,v31.2d,v6.d[0]                 \n\t" // Scale by alpha
 	"                                            \n\t"
-	" str q8, [x25]                              \n\t" //Store column 6 of C
+	" str q8, [x25]                              \n\t" // Store column 6 of C
 	" str q9, [x25, #16]                         \n\t"
 	" str q10, [x25, #32]                        \n\t"
 	"                                            \n\t"
-	" str q11, [x26]                             \n\t" //Store column 7 of C
+	" str q11, [x26]                             \n\t" // Store column 7 of C
 	" str q12, [x26, #16]                        \n\t"
 	" str q13, [x26, #32]                        \n\t"
 	"                                            \n\t"


### PR DESCRIPTION
Details:
- The ARMv8a dgemm/sgemm microkernels had 2 prefetching issues that
  impacted performance on modern ARM platforms. The most significant
  issue was that only a single prefetch per C tile column was issued.
  When a column of C was not cache aligned, the second cache line would
  not be prefetched at all, forcing the kernel to wait for an entire
  load to update elements of C. This happened with roughly 50% of the
  C prefetches. The fix was to have two prefetches per column, spaced
  64 bytes (1 cache line) apart.
- A secondary performance issue was that all the C prefetch instructions
  were issued sequentially at the beginning of the kernel call. This
  caused a noticeable performance slowdown. Interleaving the prefetch
  calls every 2-3 instructions in the prologue code solved the issue.