### PR TITLE
Test the 'gemmlike' sandbox via AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,12 @@ environment:
       CC: clang
       THREADING: openmp
 
+    - LIB_TYPE: static
+      CONFIG: auto
+      CC: clang
+      THREADING: openmp
+      SANDBOX: yes
+
 install:
 - set "PATH=C:\msys64\mingw64\bin;C:\msys64\bin;%PATH%"
 - if [%CC%]==[clang] set "PATH=C:\Program Files\LLVM\bin;%PATH%"
@@ -34,6 +40,7 @@ build_script:
 - if [%LIB_TYPE%]==[shared] set "CONFIGURE_OPTS=%CONFIGURE_OPTS% --enable-shared --disable-static"
 - if [%LIB_TYPE%]==[static] set "CONFIGURE_OPTS=%CONFIGURE_OPTS% --disable-shared --enable-static"
 - if not [%CBLAS%]==[no] set "CONFIGURE_OPTS=%CONFIGURE_OPTS% --enable-cblas"
+- if [%SANDBOX%]==[yes] set "CONFIGURE_OPTS=%CONFIGURE_OPTS% -s gemmlike"
 - set RANLIB=echo
 - set LIBPTHREAD=
 - set "PATH=%PATH%;C:\blis\lib"


### PR DESCRIPTION
Details:
- Added a fifth test to our `.appveyor.yml` that enables the `gemmlike` sandbox with OpenMP enabled (via clang, the `auto` configuration target, and building to a static library). Thanks to Jeff Diamond for pointing out that this test would be useful.