### PR TITLE
Shuffled checked properties in `bli_l3_check.c`

### DIFF
--- a/frame/3/bli_l3_check.c
+++ b/frame/3/bli_l3_check.c
@@ -44,7 +44,7 @@ void bli_gemm_check
        const cntx_t* cntx
      )
 {
-	//err_t e_val;
+	err_t e_val;
 
 	// Check basic properties of the operation.
 
@@ -52,15 +52,14 @@ void bli_gemm_check
 
 	// Check object structure.
 
-	// NOTE: Can't perform these checks as long as bli_gemm_check() is called
-	// from bli_l3_int(), which is in the execution path for structured
-	// level-3 operations such as hemm.
+	e_val = bli_check_general_object( a );
+	bli_check_error_code( e_val );
 
-	//e_val = bli_check_general_object( a );
-	//bli_check_error_code( e_val );
+	e_val = bli_check_general_object( b );
+	bli_check_error_code( e_val );
 
-	//e_val = bli_check_general_object( b );
-	//bli_check_error_code( e_val );
+	e_val = bli_check_general_object( c );
+	bli_check_error_code( e_val );
 }
 
 void bli_gemmt_check
@@ -83,6 +82,14 @@ void bli_gemmt_check
 
 	e_val = bli_check_square_object( c );
 	bli_check_error_code( e_val );
+
+	// Check object structure.
+
+	e_val = bli_check_general_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
+	bli_check_error_code( e_val );
 }
 
 void bli_hemm_check
@@ -102,9 +109,20 @@ void bli_hemm_check
 
 	bli_hemm_basic_check( side, alpha, a, b, beta, c, cntx );
 
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( a );
+	bli_check_error_code( e_val );
+
 	// Check object structure.
 
 	e_val = bli_check_hermitian_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( c );
 	bli_check_error_code( e_val );
 }
 
@@ -127,17 +145,25 @@ void bli_herk_check
 
 	bli_herk_basic_check( alpha, a, &ah, beta, c, cntx );
 
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( c );
+	bli_check_error_code( e_val );
+
+	// Check matrix structure.
+
+	e_val = bli_check_hermitian_object( c );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( a );
+	bli_check_error_code( e_val );
+
 	// Check for real-valued alpha and beta.
 
 	e_val = bli_check_real_valued_object( alpha );
 	bli_check_error_code( e_val );
 
 	e_val = bli_check_real_valued_object( beta );
-	bli_check_error_code( e_val );
-
-	// Check matrix structure.
-
-	e_val = bli_check_hermitian_object( c );
 	bli_check_error_code( e_val );
 }
 
@@ -162,14 +188,25 @@ void bli_her2k_check
 
 	bli_her2k_basic_check( alpha, a, &bh, b, &ah, beta, c, cntx );
 
-	// Check for real-valued beta.
+	// Check matrix squareness.
 
-	e_val = bli_check_real_valued_object( beta );
+	e_val = bli_check_square_object( c );
 	bli_check_error_code( e_val );
 
 	// Check matrix structure.
 
 	e_val = bli_check_hermitian_object( c );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
+	bli_check_error_code( e_val );
+
+	// Check for real-valued beta.
+
+	e_val = bli_check_real_valued_object( beta );
 	bli_check_error_code( e_val );
 }
 
@@ -190,9 +227,20 @@ void bli_symm_check
 
 	bli_hemm_basic_check( side, alpha, a, b, beta, c, cntx );
 
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( a );
+	bli_check_error_code( e_val );
+
 	// Check object structure.
 
 	e_val = bli_check_symmetric_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( c );
 	bli_check_error_code( e_val );
 }
 
@@ -215,9 +263,17 @@ void bli_syrk_check
 
 	bli_herk_basic_check( alpha, a, &at, beta, c, cntx );
 
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( c );
+	bli_check_error_code( e_val );
+
 	// Check matrix structure.
 
 	e_val = bli_check_symmetric_object( c );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( a );
 	bli_check_error_code( e_val );
 }
 
@@ -242,9 +298,20 @@ void bli_syr2k_check
 
 	bli_her2k_basic_check( alpha, a, &bt, b, &at, beta, c, cntx );
 
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( c );
+	bli_check_error_code( e_val );
+
 	// Check matrix structure.
 
 	e_val = bli_check_symmetric_object( c );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
 	bli_check_error_code( e_val );
 }
 
@@ -261,13 +328,24 @@ void bli_trmm3_check
 {
 	err_t e_val;
 
-	// Perform checks common to hemm/symm/trmm/trsm.
+	// Check basic properties of the operation.
 
 	bli_hemm_basic_check( side, alpha, a, b, beta, c, cntx );
+
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( a );
+	bli_check_error_code( e_val );
 
 	// Check object structure.
 
 	e_val = bli_check_triangular_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( c );
 	bli_check_error_code( e_val );
 }
 
@@ -282,13 +360,21 @@ void bli_trmm_check
 {
 	err_t e_val;
 
-	// Perform checks common to hemm/symm/trmm/trsm.
+	// Check basic properties of the operation.
 
 	bli_hemm_basic_check( side, alpha, a, b, &BLIS_ZERO, b, cntx );
+
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( a );
+	bli_check_error_code( e_val );
 
 	// Check object structure.
 
 	e_val = bli_check_triangular_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
 	bli_check_error_code( e_val );
 }
 
@@ -307,9 +393,17 @@ void bli_trsm_check
 
 	bli_hemm_basic_check( side, alpha, a, b, &BLIS_ZERO, b, cntx );
 
+	// Check matrix squareness.
+
+	e_val = bli_check_square_object( a );
+	bli_check_error_code( e_val );
+
 	// Check object structure.
 
 	e_val = bli_check_triangular_object( a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_general_object( b );
 	bli_check_error_code( e_val );
 }
 
@@ -385,6 +479,14 @@ void bli_gemmt_basic_check
 
 	e_val = bli_check_level3_dims( a, b, c );
 	bli_check_error_code( e_val );
+
+	// Check for consistent datatypes.
+
+	e_val = bli_check_consistent_object_datatypes( c, a );
+	bli_check_error_code( e_val );
+
+	e_val = bli_check_consistent_object_datatypes( c, b );
+	bli_check_error_code( e_val );
 }
 
 void bli_hemm_basic_check
@@ -417,11 +519,6 @@ void bli_hemm_basic_check
 		bli_check_error_code( e_val );
 	}
 
-	// Check matrix squareness.
-
-	e_val = bli_check_square_object( a );
-	bli_check_error_code( e_val );
-
 	// Check for consistent datatypes.
 
 	e_val = bli_check_consistent_object_datatypes( c, a );
@@ -450,19 +547,6 @@ void bli_herk_basic_check
 	// Check object dimensions.
 
 	e_val = bli_check_level3_dims( a, ah, c );
-	bli_check_error_code( e_val );
-
-	// Check matrix squareness.
-
-	e_val = bli_check_square_object( c );
-	bli_check_error_code( e_val );
-
-	// Check matrix structure.
-
-	e_val = bli_check_general_object( a );
-	bli_check_error_code( e_val );
-
-	e_val = bli_check_general_object( ah );
 	bli_check_error_code( e_val );
 
 	// Check for consistent datatypes.
@@ -499,25 +583,6 @@ void bli_her2k_basic_check
 	bli_check_error_code( e_val );
 
 	e_val = bli_check_level3_dims( b, ah, c );
-	bli_check_error_code( e_val );
-
-	// Check matrix squareness.
-
-	e_val = bli_check_square_object( c );
-	bli_check_error_code( e_val );
-
-	// Check matrix structure.
-
-	e_val = bli_check_general_object( a );
-	bli_check_error_code( e_val );
-
-	e_val = bli_check_general_object( bh );
-	bli_check_error_code( e_val );
-
-	e_val = bli_check_general_object( b );
-	bli_check_error_code( e_val );
-
-	e_val = bli_check_general_object( ah );
 	bli_check_error_code( e_val );
 
 	// Check for consistent datatypes.
@@ -586,13 +651,13 @@ void bli_l3_basic_check
 	e_val = bli_check_object_buffer( alpha );
 	bli_check_error_code( e_val );
 
+	e_val = bli_check_object_buffer( beta );
+	bli_check_error_code( e_val );
+
 	e_val = bli_check_object_buffer( a );
 	bli_check_error_code( e_val );
 
 	e_val = bli_check_object_buffer( b );
-	bli_check_error_code( e_val );
-
-	e_val = bli_check_object_buffer( beta );
 	bli_check_error_code( e_val );
 
 	e_val = bli_check_object_buffer( c );


### PR DESCRIPTION
Details:
- Added certain checks for matrix structure to the level-3 operations' _check() functions, and slightly reorganized existing checks.