### PR TITLE
Fix bug where multiple threads pack the same parts of each panel.

### DIFF
--- a/frame/1m/packm/bli_packm_blk_var1.c
+++ b/frame/1m/packm/bli_packm_blk_var1.c
@@ -54,10 +54,10 @@ static void_fp GENARRAY2_ALL(packm_struc_cxk_md,packm_struc_cxk_md);
 
 void bli_packm_blk_var1
      (
-       const obj_t*   c,
-             obj_t*   p,
-       const cntx_t*  cntx,
-       const cntl_t*  cntl,
+       const obj_t*     c,
+             obj_t*     p,
+       const cntx_t*    cntx,
+       const cntl_t*    cntl,
              thrinfo_t* thread_par
      )
 {
@@ -67,17 +67,16 @@ void bli_packm_blk_var1
 	bool   revifup = bli_cntl_packm_params_rev_iter_if_upper( cntl );
 	bool   reviflo = bli_cntl_packm_params_rev_iter_if_lower( cntl );
 
-	// Every thread initializes p and determines the size of memory
-	// block needed (which gets embedded into the otherwise "blank" mem_t
-	// entry in the control tree node). Return early if no packing is required.
+	// Every thread initializes p and determines the size of memory block
+	// needed (which gets embedded into the otherwise "blank" mem_t entry
+	// in the control tree node). Return early if no packing is required.
 	if ( !bli_packm_init( c, p, cntx, cntl, bli_thrinfo_sub_node( thread_par ) ) )
 		return;
 
-    // Use the sub-prenode. In bli_l3_thrinfo_grow, this node
-    // was created to represent the team of threads as a group
-    // of single-threaded teams. This is necessary since the
-    // work distribution functions all work off of the work_id and
-    // n_way fields.
+	// Use the sub-prenode. In bli_l3_thrinfo_grow(), this node was created to
+	// represent the team of threads as a group of single-member thread teams.
+	// This is necessary since the all of the work distribution function depend
+	// on the work_id and n_way fields.
 	thrinfo_t* thread = bli_thrinfo_sub_prenode( thread_par );
 
 	// Check parameters.
@@ -141,11 +140,11 @@ void bli_packm_blk_var1
 		packm_ker_cast = params->ukr_fn[ dt_c ][ dt_p ];
 	}
 
-	/* Compute the total number of iterations we'll need. */
+	// Compute the total number of iterations we'll need.
 	dim_t n_iter = iter_dim / panel_dim_max + ( iter_dim % panel_dim_max ? 1 : 0 );
 
-	/* Set the initial values and increments for indices related to C and P
-	   based on whether reverse iteration was requested. */
+	// Set the initial values and increments for indices related to C and P
+	// based on whether reverse iteration was requested.
 	dim_t  ic0, ip0;
 	doff_t ic_inc, ip_inc;
 
@@ -165,8 +164,8 @@ void bli_packm_blk_var1
 		ip_inc = 1;
 	}
 
-	// Query the number of threads and thread ids from the current thread's
-	// packm thrinfo_t node.
+	// Query the number of threads (single-member thread teams) and the thread
+	// team ids from the current thread's packm thrinfo_t node.
 	const dim_t nt  = bli_thrinfo_n_way( thread );
 	const dim_t tid = bli_thrinfo_work_id( thread );
 

--- a/frame/1m/packm/bli_packm_int.c
+++ b/frame/1m/packm/bli_packm_int.c
@@ -60,7 +60,7 @@ void bli_packm_int
 	  p,
 	  cntx,
 	  cntl,
-	  thread
+	  thread_par
 	);
 
 	// Barrier so that packing is done before computation.

--- a/frame/1m/packm/bli_packm_int.c
+++ b/frame/1m/packm/bli_packm_int.c
@@ -36,10 +36,10 @@
 
 void bli_packm_int
      (
-       const obj_t*  a,
-             obj_t*  p,
-       const cntx_t* cntx,
-       const cntl_t* cntl,
+       const obj_t*     a,
+             obj_t*     p,
+       const cntx_t*    cntx,
+       const cntl_t*    cntl,
              thrinfo_t* thread_par
      )
 {
@@ -53,7 +53,16 @@ void bli_packm_int
 	thrinfo_t* thread = bli_thrinfo_sub_node( thread_par );
 	bli_thrinfo_barrier( thread );
 
-	// Invoke the variant with kappa_use.
+	// Invoke the packm variant.
+	// NOTE: The packing kernel uses two communicators: one which represents a
+	// single workgroup of many threads, and one which represents a group of
+	// many single-member workgroups. The former communicator is used for
+	// barriers and thread communication (i.e. broadcasting the pack buffer
+	// pointer), while the latter communicator is used for partitioning work.
+	// This is because all of the thread range functions rely on the work_id
+	// and number of workgroups (n_way). Thus, we pass along the parent
+	// thrinfo_t node which has these two communicators as the sub-node and
+	// sub-prenode, respectively.
 	f
 	(
 	  a,

--- a/frame/3/bli_l3_thrinfo.c
+++ b/frame/3/bli_l3_thrinfo.c
@@ -77,17 +77,18 @@ void bli_l3_thrinfo_grow
 	thrinfo_t* thread_cur = bli_thrinfo_split( n_way, thread_par );
 	bli_thrinfo_set_sub_node( thread_cur, thread_par );
 
-    if ( bszid == BLIS_NO_PART )
-    {
-        // A hack: the packing code needs a thread communicator which represents
-        // a group of single-threaded teams working together. However, the
-        // "normal" packm thrinfo_t node has a single team with multiple threads.
-        // So, we create a sub-prenode on the thrinfo_t tree which splits this
-        // single team into multiple single-threaded teams.
-        const dim_t n_threads = bli_thrinfo_num_threads( thread_par );
+	if ( bszid == BLIS_NO_PART )
+	{
+		// A hack: the packing code needs a thread communicator which represents
+		// a group of single-member thread teams working cooperatively However,
+		// the "normal" packm thrinfo_t node has a single team of multiple
+		// threads. Our solution (for now) is to create a sub-prenode on the
+		// thrinfo_t tree which splits this single team into multiple
+		// single-member thread teams.
+		const dim_t n_threads = bli_thrinfo_num_threads( thread_par );
 		thrinfo_t* thread_pre = bli_thrinfo_split( n_threads, thread_par );
 		bli_thrinfo_set_sub_prenode( thread_pre, thread_par );
-    }
+	}
 	else if ( sub_prenode != NULL )
 	{
 		// A pre-node is only used in the IC loop of trsm. In this case,
@@ -99,13 +100,12 @@ void bli_l3_thrinfo_grow
 		bli_rntm_set_ic_ways_only(               1, &rntm_l );
 		bli_rntm_set_jr_ways_only( ic_nway*jr_nway, &rntm_l );
 
-		// Use thread_pre instead of thread_cur since we *don't* want to
-		// do any parallelism at this level. The thread_pre node is
-        // attached to thread_par and not thread_cur! This results in a
-        // split "one level higher" than in the corresponding cntl_t tree.
-        // This is intentional since two different thrinfo_t nodes will
-        // be used at the cntl_t node for trsm variant 1 (one for trsm,
-        // one for gemm).
+		// Use thread_pre instead of thread_cur since we *don't* want to do any
+		// parallelism at this level. So the thread_pre node gets attached to
+		// thread_par and not thread_cur! This results in a split "one level
+		// higher" than in the corresponding cntl_t tree. This is intentional
+		// since two different thrinfo_t nodes will be used at the cntl_t node
+		// for trsm blocked variant 1 (one for trsm, one for gemm).
 		thrinfo_t* thread_pre = bli_thrinfo_split( 1, thread_par );
 		bli_thrinfo_set_sub_prenode( thread_pre, thread_par );
 		bli_l3_thrinfo_grow( thread_pre, &rntm_l, sub_prenode );

--- a/frame/3/bli_l3_thrinfo.c
+++ b/frame/3/bli_l3_thrinfo.c
@@ -77,7 +77,18 @@ void bli_l3_thrinfo_grow
 	thrinfo_t* thread_cur = bli_thrinfo_split( n_way, thread_par );
 	bli_thrinfo_set_sub_node( thread_cur, thread_par );
 
-	if ( sub_prenode != NULL )
+    if ( bszid == BLIS_NO_PART )
+    {
+        // A hack: the packing code needs a thread communicator which represents
+        // a group of single-threaded teams working together. However, the
+        // "normal" packm thrinfo_t node has a single team with multiple threads.
+        // So, we create a sub-prenode on the thrinfo_t tree which splits this
+        // single team into multiple single-threaded teams.
+        const dim_t n_threads = bli_thrinfo_num_threads( thread_par );
+		thrinfo_t* thread_pre = bli_thrinfo_split( n_threads, thread_par );
+		bli_thrinfo_set_sub_prenode( thread_pre, thread_par );
+    }
+	else if ( sub_prenode != NULL )
 	{
 		// A pre-node is only used in the IC loop of trsm. In this case,
 		// we cannot actually thread in the m dimension due to data dependencies
@@ -89,7 +100,12 @@ void bli_l3_thrinfo_grow
 		bli_rntm_set_jr_ways_only( ic_nway*jr_nway, &rntm_l );
 
 		// Use thread_pre instead of thread_cur since we *don't* want to
-		// do any parallelism at this level.
+		// do any parallelism at this level. The thread_pre node is
+        // attached to thread_par and not thread_cur! This results in a
+        // split "one level higher" than in the corresponding cntl_t tree.
+        // This is intentional since two different thrinfo_t nodes will
+        // be used at the cntl_t node for trsm variant 1 (one for trsm,
+        // one for gemm).
 		thrinfo_t* thread_pre = bli_thrinfo_split( 1, thread_par );
 		bli_thrinfo_set_sub_prenode( thread_pre, thread_par );
 		bli_l3_thrinfo_grow( thread_pre, &rntm_l, sub_prenode );


### PR DESCRIPTION
This was caused by different parts of the code using num_threads/thread_id vs. n_way/work_id. The fix was to standardize on the latter and provide a "fake" thrinfo_t sub-prenode in the thread control tree which consists of single-threaded teams. The single-team with multiple threads node is also required since it and only it can be used to do barriers and broadcasting (e.g. of the packed buffer pointer).