### PR TITLE
Enhance emacs formatting of C files

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,9 +1,11 @@
-;; First (minimal) attempt at configuring Emacs CC mode for the BLIS
-;; layout requirements.
+;; Emacs C mode formatting for the BLIS layout requirements.
 ((c-mode . ((c-file-style . "stroustrup")
-            (c-basic-offset . 4)
-            (comment-start . "// ")
-            (comment-end . "")
-            (indent-tabs-mode . t)
-            (tab-width . 4)
-            (parens-require-spaces . nil))))
+	    (c-basic-offset . 4)
+	    (comment-start . "// ")
+	    (comment-end . "")
+	    (indent-tabs-mode . t)
+	    (tab-width . 4)
+	    (parens-require-spaces . nil)
+	    (require-final-newline . t)
+	    (eval add-hook `before-save-hook `delete-trailing-whitespace)
+	    )))


### PR DESCRIPTION
Enhance emacs formatting of C files from @loveshack to remove trailing whitespace and ensure a newline at the end of file, bringing it closer to the BLIS Coding Conventions.
