### PR TITLE
Fixed subtle barrier_fpa bug in bli_thrcomm.c.

### DIFF
--- a/frame/thread/bli_thrcomm.c
+++ b/frame/thread/bli_thrcomm.c
@@ -115,17 +115,17 @@ static thrcomm_barrier_ft barrier_fpa[ BLIS_NUM_THREAD_IMPLS ] =
 #if   defined(BLIS_ENABLE_OPENMP)
 	                bli_thrcomm_barrier_openmp,
 #elif defined(BLIS_ENABLE_PTHREADS)
-	                bli_thrcomm_barrier_pthreads,
+	                NULL,
 #else
-	                bli_thrcomm_barrier_single,
+	                NULL,
 #endif
 	[BLIS_POSIX]  =
 #if   defined(BLIS_ENABLE_PTHREADS)
 	                bli_thrcomm_barrier_pthreads,
 #elif defined(BLIS_ENABLE_OPENMP)
-	                bli_thrcomm_barrier_openmp,
+	                NULL,
 #else
-	                bli_thrcomm_barrier_single,
+	                NULL,
 #endif
 };
 


### PR DESCRIPTION
Details:
- In `bli_thrcomm.c`, correctly initialize the `BLIS_OPENMP` element of the barrier function pointer array (`barrier_fpa`) to `NULL` when `BLIS_ENABLE_OPENMP` is *not* defined. Similarly, initialize the `BLIS_POSIX` element of `barrier_fpa` to `NULL` when `BLIS_ENABLE_PTHREADS` is not defined. This bug was introduced in a1a5a9b and was likely the result of an incomplete edit. The effects of the bug would have likely manifested when querying a `thrcomm_t` that was initialized with a `timpl_t` value corresponding to a threading implementation that was omitted from the `-t` option at configure-time.