### PR TITLE
fix compilation issue for haswell + gcc 7.3.0 (impossible constraints)

### DIFF
--- a/kernels/haswell/3/bli_gemm_haswell_asm_d8x6.c
+++ b/kernels/haswell/3/bli_gemm_haswell_asm_d8x6.c
@@ -412,15 +412,15 @@ void bli_sgemm_haswell_asm_16x6
 	end_asm(
 	: // output operands (none)
 	: // input operands
-	  [k_iter] "m" (k_iter), // 0
-	  [k_left] "m" (k_left), // 1
-	  [a]      "m" (a),      // 2
-	  [b]      "m" (b),      // 3
-	  [alpha]  "m" (alpha),  // 4
-	  [beta]   "m" (beta),   // 5
-	  [c]      "m" (c),      // 6
-	  [rs_c]   "m" (rs_c),   // 7
-	  [cs_c]   "m" (cs_c)/*,   // 8
+	  [k_iter] "g" (k_iter), // 0
+	  [k_left] "g" (k_left), // 1
+	  [a]      "g" (a),      // 2
+	  [b]      "g" (b),      // 3
+	  [alpha]  "g" (alpha),  // 4
+	  [beta]   "g" (beta),   // 5
+	  [c]      "g" (c),      // 6
+	  [rs_c]   "g" (rs_c),   // 7
+	  [cs_c]   "g" (cs_c)/*,   // 8
 	  [b_next] "m" (b_next), // 9
 	  [a_next] "m" (a_next)*/  // 10
 	: // register clobber list
@@ -796,15 +796,15 @@ void bli_dgemm_haswell_asm_8x6
 	end_asm(
 	: // output operands (none)
 	: // input operands
-	  [k_iter] "m" (k_iter), // 0
-	  [k_left] "m" (k_left), // 1
-	  [a]      "m" (a),      // 2
-	  [b]      "m" (b),      // 3
-	  [alpha]  "m" (alpha),  // 4
-	  [beta]   "m" (beta),   // 5
-	  [c]      "m" (c),      // 6
-	  [rs_c]   "m" (rs_c),   // 7
-	  [cs_c]   "m" (cs_c)/*,   // 8
+	  [k_iter] "g" (k_iter), // 0
+	  [k_left] "g" (k_left), // 1
+	  [a]      "g" (a),      // 2
+	  [b]      "g" (b),      // 3
+	  [alpha]  "g" (alpha),  // 4
+	  [beta]   "g" (beta),   // 5
+	  [c]      "g" (c),      // 6
+	  [rs_c]   "g" (rs_c),   // 7
+	  [cs_c]   "g" (cs_c)/*,   // 8
 	  [b_next] "m" (b_next), // 9
 	  [a_next] "m" (a_next)*/  // 10
 	: // register clobber list
@@ -1187,15 +1187,15 @@ void bli_cgemm_haswell_asm_8x3
 	end_asm(
 	: // output operands (none)
 	: // input operands
-	  [k_iter] "m" (k_iter), // 0
-	  [k_left] "m" (k_left), // 1
-	  [a]      "m" (a),      // 2
-	  [b]      "m" (b),      // 3
-	  [alpha]  "m" (alpha),  // 4
-	  [beta]   "m" (beta),   // 5
-	  [c]      "m" (c),      // 6
-	  [rs_c]   "m" (rs_c),   // 7
-	  [cs_c]   "m" (cs_c)/*,   // 8
+	  [k_iter] "g" (k_iter), // 0
+	  [k_left] "g" (k_left), // 1
+	  [a]      "g" (a),      // 2
+	  [b]      "g" (b),      // 3
+	  [alpha]  "g" (alpha),  // 4
+	  [beta]   "g" (beta),   // 5
+	  [c]      "g" (c),      // 6
+	  [rs_c]   "g" (rs_c),   // 7
+	  [cs_c]   "g" (cs_c)/*,   // 8
 	  [b_next] "m" (b_next), // 9
 	  [a_next] "m" (a_next)*/  // 10
 	: // register clobber list
@@ -1579,15 +1579,15 @@ void bli_zgemm_haswell_asm_4x3
 	end_asm(
 	: // output operands (none)
 	: // input operands
-	  [k_iter] "m" (k_iter), // 0
-	  [k_left] "m" (k_left), // 1
-	  [a]      "m" (a),      // 2
-	  [b]      "m" (b),      // 3
-	  [alpha]  "m" (alpha),  // 4
-	  [beta]   "m" (beta),   // 5
-	  [c]      "m" (c),      // 6
-	  [rs_c]   "m" (rs_c),   // 7
-	  [cs_c]   "m" (cs_c)/*,   // 8
+	  [k_iter] "g" (k_iter), // 0
+	  [k_left] "g" (k_left), // 1
+	  [a]      "g" (a),      // 2
+	  [b]      "g" (b),      // 3
+	  [alpha]  "g" (alpha),  // 4
+	  [beta]   "g" (beta),   // 5
+	  [c]      "g" (c),      // 6
+	  [rs_c]   "g" (rs_c),   // 7
+	  [cs_c]   "g" (cs_c)/*,   // 8
 	  [b_next] "m" (b_next), // 9
 	  [a_next] "m" (a_next)*/  // 10
 	: // register clobber list


### PR DESCRIPTION
I'm not sure why I'm running into this issue, but gcc 7.3.0 is failing with

```
gcc -O2 -O3 -fomit-frame-pointer -mavx2 -mfma -mfpmath=sse -march=haswell -Wall -Wno-unused-function -Wfatal-errors -fPIC -std=c99 -D_POSIX_C_SOURCE=200112L -Iinclude/haswell -I./frame/3/ -I./frame/1m/ -I./frame/1f/ -I./frame/1/ -I./frame/include -DBLIS_VERSION_STRING=\"0.9.0\" -DBLIS_IS_BUILDING_LIBRARY -fvisibility=hidden -c kernels/haswell/3/bli_gemm_haswell_asm_d8x6.c -o bli_gemm_haswell_asm_d8x6.o 
In file included from kernels/haswell/3/bli_gemm_haswell_asm_d8x6.c:38:0: kernels/haswell/3/bli_gemm_haswell_asm_d8x6.c: In function 'bli_sgemm_haswell_asm_16x6': ./frame/include/bli_x86_asm_macros.h:102:21: error: 'asm' operand has impossible constraints
 #define BEGIN_ASM() __asm__ volatile (
                     ^
./frame/include/bli_x86_asm_macros.h:153:21: note: in expansion of macro 'BEGIN_ASM'
 #define begin_asm() BEGIN_ASM()
                     ^~~~~~~~~
kernels/haswell/3/bli_gemm_haswell_asm_d8x6.c:105:2: note: in expansion of macro 'begin_asm'
```

Will tests be run automatically or should I run some?