### PR TITLE
Fix hobbled multithreaded performance of gemmlike sandbox (and sup when packing)

### DIFF
--- a/frame/3/bli_l3_sup_packm.c
+++ b/frame/3/bli_l3_sup_packm.c
@@ -394,7 +394,7 @@ void bli_packm_sup
 			  ( void* )a,  rs_a,  cs_a,
 			          *p, *rs_p, *cs_p,
 			  ( cntx_t* )cntx,
-			  thread
+			  bli_thrinfo_sub_prenode( thread )
 			);
 		}
 		else // if ( schema == BLIS_PACKED_ROW_PANELS )
@@ -415,7 +415,7 @@ void bli_packm_sup
 			          *p, *rs_p, *cs_p,
 			               pd_p, *ps_p,
 			  ( cntx_t* )cntx,
-			  thread
+			  bli_thrinfo_sub_prenode( thread )
 			);
 		}
 

--- a/frame/3/bli_l3_thrinfo.c
+++ b/frame/3/bli_l3_thrinfo.c
@@ -150,6 +150,15 @@ thrinfo_t* bli_l3_sup_thrinfo_create
 	thrinfo_t* thread_jr = bli_thrinfo_split( n_way_jr, thread_pa );
 	thrinfo_t* thread_ir = bli_thrinfo_split( n_way_ir, thread_jr );
 
+	const dim_t n_way_pb = bli_thrinfo_num_threads( thread_pb );
+	const dim_t n_way_pa = bli_thrinfo_num_threads( thread_pa );
+
+	// Create and set the prenodes for the packb and packa thrinfo_t nodes.
+	thrinfo_t* thread_pb_single = bli_thrinfo_split( n_way_pb, thread_pb );
+	thrinfo_t* thread_pa_single = bli_thrinfo_split( n_way_pa, thread_pa );
+	bli_thrinfo_set_sub_prenode( thread_pb_single, thread_pb );
+	bli_thrinfo_set_sub_prenode( thread_pa_single, thread_pa );
+
 	bli_thrinfo_set_sub_node( thread_jc,      root );
 	bli_thrinfo_set_sub_node( thread_pc, thread_jc );
 	bli_thrinfo_set_sub_node( thread_pb, thread_pc );

--- a/sandbox/gemmlike/bls_l3_packm_a.c
+++ b/sandbox/gemmlike/bls_l3_packm_a.c
@@ -276,7 +276,7 @@ void PASTECH2(bls_,ch,opname) \
 	  *p, *rs_p, *cs_p, \
 	       pd_p, *ps_p, \
 	  cntx, \
-	  thread  \
+	  bli_thrinfo_sub_prenode( thread )  \
 	); \
 \
 	/* Barrier so that packing is done before computation. */ \

--- a/sandbox/gemmlike/bls_l3_packm_b.c
+++ b/sandbox/gemmlike/bls_l3_packm_b.c
@@ -276,7 +276,7 @@ void PASTECH2(bls_,ch,opname) \
 	  *p, *rs_p, *cs_p, \
 	       pd_p, *ps_p, \
 	  cntx, \
-	  thread  \
+	  bli_thrinfo_sub_prenode( thread )  \
 	); \
 \
 	/* Barrier so that packing is done before computation. */ \

--- a/sandbox/gemmlike/bls_l3_packm_var1.c
+++ b/sandbox/gemmlike/bls_l3_packm_var1.c
@@ -121,8 +121,8 @@ void PASTECH2(bls_,ch,varname) \
 \
 	/* Query the number of threads and thread ids from the current thread's
 	   packm thrinfo_t node. */ \
-	const dim_t nt  = bli_thrinfo_num_threads( thread ); \
-	const dim_t tid = bli_thrinfo_thread_id( thread ); \
+	const dim_t nt  = bli_thrinfo_n_way( thread ); \
+	const dim_t tid = bli_thrinfo_work_id( thread ); \
 \
 	/* Suppress warnings in case tid isn't used (ie: as in slab partitioning). */ \
 	( void )nt; \

--- a/sandbox/gemmlike/bls_l3_packm_var2.c
+++ b/sandbox/gemmlike/bls_l3_packm_var2.c
@@ -121,8 +121,8 @@ void PASTECH2(bls_,ch,varname) \
 \
 	/* Query the number of threads and thread ids from the current thread's
 	   packm thrinfo_t node. */ \
-	const dim_t nt  = bli_thrinfo_num_threads( thread ); \
-	const dim_t tid = bli_thrinfo_thread_id( thread ); \
+	const dim_t nt  = bli_thrinfo_n_way( thread ); \
+	const dim_t tid = bli_thrinfo_work_id( thread ); \
 \
 	/* Suppress warnings in case tid isn't used (ie: as in slab partitioning). */ \
 	( void )nt; \

--- a/sandbox/gemmlike/bls_l3_packm_var3.c
+++ b/sandbox/gemmlike/bls_l3_packm_var3.c
@@ -121,8 +121,8 @@ void PASTECH2(bls_,ch,varname) \
 \
 	/* Query the number of threads and thread ids from the current thread's
 	   packm thrinfo_t node. */ \
-	const dim_t nt  = bli_thrinfo_num_threads( thread ); \
-	const dim_t tid = bli_thrinfo_thread_id( thread ); \
+	const dim_t nt  = bli_thrinfo_n_way( thread ); \
+	const dim_t tid = bli_thrinfo_work_id( thread ); \
 \
 	/* Suppress warnings in case tid isn't used (ie: as in slab partitioning). */ \
 	( void )nt; \


### PR DESCRIPTION
This PR is to track the changes needed to fix a couple (probably related) issues in the recent Omnibus PR #678 (aeb5f0c):
- When configuring with `-s gemmlike` and setting `BLIS_JR_NT=4`, performance of `gemm` is depressed by about 25-30% relative to the preceding commit.
- When configuring with sup enabled and setting `BLIS_JR_NT=4`, performance of the `gemm` sup code path is similarly depressed when optional packing is enabled (via `BLIS_PACK_A=1 BLIS_PACK_B=1`). Performance is unaffected when packing is avoided (the default).

My theory is that every thread is packing every micropanel redundantly, which is an issue that @devinamatthews ran into when developing aeb5f0c. This explanation would be consistent with observations and with the state of the code itself, since the sup `thrinfo_t` tree creation in `bli_l3_thrinfo.c` does not utilize the sub-prenodes like the conventional `thrinfo_t` tree does.
