### PR TITLE
Fixing type-mismatch errors in power10 sandbox

### DIFF
--- a/sandbox/power10/bli_gemm_ex.c
+++ b/sandbox/power10/bli_gemm_ex.c
@@ -46,13 +46,13 @@
 
 void bli_gemm_ex
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c,
-       cntx_t* cntx,
-       rntm_t* rntm
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c,
+       const cntx_t* cntx,
+       const rntm_t* rntm
      )
 {
 	bli_init_once();
@@ -73,7 +73,7 @@ void bli_gemm_ex
 	// Invoke the operation's front end.
 	bli_gemm_front
 	(
-	  alpha, a, b, beta, c, cntx, rntm
+	  alpha, a, b, beta, c, cntx, (rntm_t* )rntm
 	);
 }
 


### PR DESCRIPTION
There was a mismatch between the definition and declaration of bli_gemm_ex() function in the power10 sandbox, which was throwing compilation errors. Now, the definition matches the declaration in blis.h.

There was also a mismatch between the function definition and the function call for bli_gemm_front() in power10 sandbox. This is also fixed by typecasting the corresponding argument passed in the function.