### PR TITLE
Fix a race condition which manifested as incorrect results (rarely).

### DIFF
--- a/frame/3/bli_l3_decor.c
+++ b/frame/3/bli_l3_decor.c
@@ -114,6 +114,9 @@ static void bli_l3_thread_decorator_entry( thrcomm_t* gl_comm, dim_t tid, const 
 	bli_l3_cntl_free( sba_pool, cntl_use );
 
 	// Free the current thread's thrinfo_t structure.
+    // The barrier is very important as it prevents memory being released by the
+    // chief of some thread sub-group before its peers are done using it.
+    bli_thrinfo_barrier( thread );
 	bli_thrinfo_free( thread );
 }
 

--- a/frame/3/bli_l3_decor.c
+++ b/frame/3/bli_l3_decor.c
@@ -114,9 +114,11 @@ static void bli_l3_thread_decorator_entry( thrcomm_t* gl_comm, dim_t tid, const 
 	bli_l3_cntl_free( sba_pool, cntl_use );
 
 	// Free the current thread's thrinfo_t structure.
-    // The barrier is very important as it prevents memory being released by the
-    // chief of some thread sub-group before its peers are done using it.
-    bli_thrinfo_barrier( thread );
+	// NOTE: The barrier here is very important as it prevents memory being
+	// released by the chief of some thread sub-group before its peers are done
+	// using it. See PR #702 for more info [1].
+	// [1] https://github.com/flame/blis/pull/702
+	bli_thrinfo_barrier( thread );
 	bli_thrinfo_free( thread );
 }
 


### PR DESCRIPTION
The problem occurs when there are at least two teams of threads packing different parts of a matrix, and where each team has at least two threads; call them team A and team B. The problematic sequence is:

1. The chief of team A checks out a block B and broadcasts the pointer to its teammates.
2. Team A completely packs their data and perform a barrier amongst themselves.
3. Team A commences computing with the packed data.
4. The chief of team A finishes computing before its teammates, then calls `bli_thrinfo_free` on its `thrinfo_t` struct (which contains the `mem_t` object referencing the buffer B). This causes buffer B to be checked back in to the `pba_t`.
5. The chief of team B checks out the *same* block B that was just checked back in and broadcasts the pointer to its teammates.
6. DATA RACE: now the remaining threads of team A are reading *while* team B are writing to the same buffer B. If team A write new data before team B are done computing then an incorrect result is generated.

The solution is to place a global barrier before the call to `bli_thrinfo_free` at the end of the computation.