### PR TITLE
Add new constants.

### DIFF
--- a/frame/base/bli_const.c
+++ b/frame/base/bli_const.c
@@ -36,19 +36,25 @@
 
 // Statically initialize structs containing representations of various
 // constants for each datatype supported in BLIS.
-static constdata_t bli_two_buffer  = bli_obj_init_constdata(  2.0 );
-static constdata_t bli_one_buffer  = bli_obj_init_constdata(  1.0 );
-static constdata_t bli_zero_buffer = bli_obj_init_constdata(  0.0 );
-static constdata_t bli_mone_buffer = bli_obj_init_constdata( -1.0 );
-static constdata_t bli_mtwo_buffer = bli_obj_init_constdata( -2.0 );
+static constdata_t bli_two_buffer   = bli_obj_init_constdata(  2.0 );
+static constdata_t bli_one_buffer   = bli_obj_init_constdata(  1.0 );
+static constdata_t bli_zero_buffer  = bli_obj_init_constdata(  0.0 );
+static constdata_t bli_mone_buffer  = bli_obj_init_constdata( -1.0 );
+static constdata_t bli_mtwo_buffer  = bli_obj_init_constdata( -2.0 );
+static constdata_t bli_onei_buffer  = bli_obj_init_constdata_ri( 0.0,  1.0 );
+static constdata_t bli_monei_buffer = bli_obj_init_constdata_ri( 0.0, -1.0 );
+static constdata_t bli_nan_buffer   = bli_obj_init_constdata_ri( NAN,  NAN );
 
 // Statically initialize global scalar constants, attaching the addresses
 // of the corresponding structs above.
-const obj_t BLIS_TWO       = bli_obj_init_const( &bli_two_buffer );
-const obj_t BLIS_ONE       = bli_obj_init_const( &bli_one_buffer );
-const obj_t BLIS_ZERO      = bli_obj_init_const( &bli_zero_buffer );
-const obj_t BLIS_MINUS_ONE = bli_obj_init_const( &bli_mone_buffer );
-const obj_t BLIS_MINUS_TWO = bli_obj_init_const( &bli_mtwo_buffer );
+const obj_t BLIS_TWO         = bli_obj_init_const( &bli_two_buffer );
+const obj_t BLIS_ONE         = bli_obj_init_const( &bli_one_buffer );
+const obj_t BLIS_ZERO        = bli_obj_init_const( &bli_zero_buffer );
+const obj_t BLIS_MINUS_ONE   = bli_obj_init_const( &bli_mone_buffer );
+const obj_t BLIS_MINUS_TWO   = bli_obj_init_const( &bli_mtwo_buffer );
+const obj_t BLIS_ONE_I       = bli_obj_init_const( &bli_onei_buffer );
+const obj_t BLIS_MINUS_ONE_I = bli_obj_init_const( &bli_monei_buffer );
+const obj_t BLIS_NAN         = bli_obj_init_const( &bli_nan_buffer );
 
 #if 0
 obj_t BLIS_TWO = {};

--- a/frame/include/bli_extern_defs.h
+++ b/frame/include/bli_extern_defs.h
@@ -42,6 +42,9 @@ BLIS_EXPORT_BLIS extern const obj_t BLIS_ZERO;
 //BLIS_EXPORT_BLIS extern obj_t BLIS_MINUS_ONE_HALF;
 BLIS_EXPORT_BLIS extern const obj_t BLIS_MINUS_ONE;
 BLIS_EXPORT_BLIS extern const obj_t BLIS_MINUS_TWO;
+BLIS_EXPORT_BLIS extern const obj_t BLIS_ONE_I;
+BLIS_EXPORT_BLIS extern const obj_t BLIS_MINUS_ONE_I;
+BLIS_EXPORT_BLIS extern const obj_t BLIS_NAN;
 
 BLIS_EXPORT_BLIS extern thrcomm_t BLIS_SINGLE_COMM;
 

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -1415,6 +1415,15 @@ BLIS_INLINE void bli_obj_init_subpart_from( const obj_t* a, obj_t* b )
 	.i =           ( gint_t )val, \
 }
 
+#define bli_obj_init_constdata_ri( valr, vali ) \
+{ \
+	.s =           ( float  )valr, \
+	.d =           ( double )valr, \
+	.c = { .real = ( float  )valr, .imag = ( float  )vali }, \
+	.z = { .real = ( double )valr, .imag = ( double )vali }, \
+	.i =           ( gint_t )valr, \
+}
+
 
 // -- Context type --
 


### PR DESCRIPTION
- `BLIS_ONE_I`: the imaginary unit
- `BLIS_MINUS_ONE_I`: the negative imaginary unit
- `BLIS_NAN`: a not-a-number value. Both real and imaginary parts are set to NaN for complex datatypes.