### PR TITLE
Disable power10 kernels other than sgemm and dgemm

### DIFF
--- a/kernels/power10/3/bli_i16gemm_power10_mma.c
+++ b/kernels/power10/3/bli_i16gemm_power10_mma.c
@@ -32,6 +32,8 @@
 
 */
 
+#ifdef BLIS_SANDBOX_POWER10
+
 #include "vector_int_macros.h"
 
 #define I16_ACCUMULATE \
@@ -140,3 +142,4 @@ void bli_i16gemm_power10_mma_8x16
         SAVE_ACC_bz(iv4sf_t, &acc7, rs_c, 12+4*rs_c);
     }
 }
+#endif // BLIS_SANDBOX_POWER10

--- a/kernels/power10/3/bli_i16sgemm_power10_mma.c
+++ b/kernels/power10/3/bli_i16sgemm_power10_mma.c
@@ -32,6 +32,8 @@
 
 */
 
+#ifdef BLIS_SANDBOX_POWER10
+
 #include "vector_int_macros.h"
 
 #define I16S_ACCUMULATE \
@@ -140,3 +142,4 @@ void bli_i16sgemm_power10_mma_8x16
         SAVE_ACC_bz(iv4sf_t, &acc7, rs_c, 12+4*rs_c);
     }
 }
+#endif // BLIS_SANDBOX_POWER10

--- a/kernels/power10/3/bli_i4gemm_power10_mma.c
+++ b/kernels/power10/3/bli_i4gemm_power10_mma.c
@@ -32,6 +32,8 @@
 
 */
 
+#ifdef BLIS_SANDBOX_POWER10
+
 #include "vector_int_macros.h"
 
 #define I4_ACCUMULATE \
@@ -140,3 +142,4 @@ void bli_i4gemm_power10_mma_8x16
         SAVE_ACC_bz(iv4sf_t, &acc7, rs_c, 12+4*rs_c);
     }
 }
+#endif // BLIS_SANDBOX_POWER10

--- a/kernels/power10/3/bli_i8gemm_power10_mma.c
+++ b/kernels/power10/3/bli_i8gemm_power10_mma.c
@@ -32,6 +32,8 @@
 
 */
 
+#ifdef BLIS_SANDBOX_POWER10
+
 #include "vector_int_macros.h"
 
 #define I8_ACCUMULATE \
@@ -139,3 +141,4 @@ void bli_i8gemm_power10_mma_8x16
         SAVE_ACC_bz(iv4sf_t, &acc7, rs_c, 12+4*rs_c);
     }
 }
+#endif // BLIS_SANDBOX_POWER10

--- a/kernels/power10/3/bli_sbgemm_power10_mma.c
+++ b/kernels/power10/3/bli_sbgemm_power10_mma.c
@@ -32,6 +32,8 @@
 
 */
 
+#ifdef BLIS_SANDBOX_POWER10
+
 #include "vector_int_macros.h"
 
 #define B_ACCUMULATE \
@@ -141,3 +143,4 @@ void bli_sbgemm_power10_mma_8x16
     }
 
 }
+#endif // BLIS_SANDBOX_POWER10

--- a/kernels/power10/3/bli_shgemm_power10_mma.c
+++ b/kernels/power10/3/bli_shgemm_power10_mma.c
@@ -32,6 +32,8 @@
 
 */
 
+#ifdef BLIS_SANDBOX_POWER10
+
 #include "vector_int_macros.h"
 
 #define H_ACCUMULATE \
@@ -141,3 +143,4 @@ void bli_shgemm_power10_mma_8x16
     }
 
 }
+#endif // BLIS_SANDBOX_POWER10

--- a/sandbox/power10/bli_sandbox.h
+++ b/sandbox/power10/bli_sandbox.h
@@ -35,6 +35,10 @@
 #ifndef BLIS_SANDBOX_H
 #define BLIS_SANDBOX_H
 
+#ifndef BLIS_SANDBOX_POWER10
+#define BLIS_SANDBOX_POWER10
+#endif
+
 #include "blis.h"
 #include "gemm_prototypes.h"
 


### PR DESCRIPTION
There is a power10 sandbox which uses micro-kernels for (lower precision) datatypes other than float and double. In the generic power10-configured build (non-sandbox), there were compile errors for some microkernels other than sgemm and dgemm. So enabling those kernels only for power10 sandbox (disabling them in the case of normal power10-configured build).