### PR TITLE
Fix k = 0 edge case in power10 micro kernels

### DIFF
--- a/kernels/power10/3/bli_dgemm_power10_mma.c
+++ b/kernels/power10/3/bli_dgemm_power10_mma.c
@@ -75,6 +75,8 @@ void bli_dgemm_power10_mma_8x8
     )
 {
 
+    if ( k == 0 ) return;
+
     // Typecast local copies of integers in case dim_t and inc_t are a
     // different size than is expected by load instructions.
     // (1 is subtracted from k0 because 1 iteration of the k loop is pulled out)

--- a/kernels/power10/3/bli_sgemm_power10_mma.c
+++ b/kernels/power10/3/bli_sgemm_power10_mma.c
@@ -67,6 +67,8 @@ void bli_sgemm_power10_mma_8x16
         cntx_t*             cntx
     )
 {
+    if ( k == 0 ) return;
+
     // Typecast local copies of integers in case dim_t and inc_t are a
     // different size than is expected by load instructions.
     // (1 is subtracted from k0 because 1 iteration of the k loop is pulled out)


### PR DESCRIPTION
When sgemm and dgemm microkernels of power10 are called with k = 0, they run into infinite loops and segfault. This is fixed now by early exit in the case of k = 0.