### PR TITLE
Implement `cntx_t` pointer caching in gks.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -104,6 +104,7 @@ but many others have contributed code and feedback, including
   Paul Springer            @springer13         (RWTH Aachen University)
   Adam J. Stewart          @adamjstewart       (University of Illinois at Urbana-Champaign)
   Vladimir Sukarev
+  Harihara Sudhan S        @ihariharasudhan    (AMD)
   Chengguo Sun             @chengguosun
   Santanu Thangaraj                            (AMD)
   Nicholai Tukanov         @nicholaiTukanov    (The University of Texas at Austin)

--- a/frame/base/bli_arch.h
+++ b/frame/base/bli_arch.h
@@ -37,8 +37,9 @@
 
 BLIS_EXPORT_BLIS arch_t bli_arch_query_id( void );
 
-void bli_arch_set_id_once( void );
-void bli_arch_set_id( void );
+void   bli_arch_set_id_once( void );
+void   bli_arch_set_id( void );
+arch_t bli_arch_query_id_impl( void );
 
 BLIS_EXPORT_BLIS const char*  bli_arch_string( arch_t id );
 

--- a/frame/base/bli_gks.h
+++ b/frame/base/bli_gks.h
@@ -46,11 +46,14 @@ const cntx_t* const *          bli_gks_lookup_id( arch_t id );
 void                           bli_gks_register_cntx( arch_t id, void_fp nat_fp, void_fp ref_fp, void_fp ind_fp );
 
 BLIS_EXPORT_BLIS const cntx_t* bli_gks_query_cntx( void );
-BLIS_EXPORT_BLIS const cntx_t* bli_gks_query_nat_cntx( void );
 
-const cntx_t*                  bli_gks_query_cntx_noinit( void );
+BLIS_EXPORT_BLIS const cntx_t* bli_gks_query_nat_cntx( void );
+const cntx_t*                  bli_gks_query_nat_cntx_noinit( void );
+const cntx_t*                  bli_gks_query_nat_cntx_impl( void );
 
 BLIS_EXPORT_BLIS const cntx_t* bli_gks_query_ind_cntx( ind_t ind );
+const cntx_t*                  bli_gks_query_ind_cntx_noinit( ind_t ind );
+const cntx_t*                  bli_gks_query_ind_cntx_impl( ind_t ind );
 
 BLIS_EXPORT_BLIS void          bli_gks_init_ref_cntx( cntx_t* cntx );
 

--- a/frame/base/bli_ind.c
+++ b/frame/base/bli_ind.c
@@ -44,9 +44,9 @@ static const char* bli_ind_impl_str[BLIS_NUM_IND_METHODS] =
 
 void bli_ind_init( void )
 {
-	// NOTE: Instead of calling bli_gks_query_cntx(), we call
-	// bli_gks_query_cntx_noinit() to avoid the call to bli_init_once().
-	const cntx_t* cntx = bli_gks_query_cntx_noinit();
+	// NOTE: We intentionally call bli_gks_query_nat_cntx_noinit() in order
+	// to avoid the internal call to bli_init_once().
+	const cntx_t* cntx = bli_gks_query_nat_cntx_noinit();
 
 	// For each precision, enable the default induced method (1m) if both of
 	// the following conditions are met:

--- a/frame/base/bli_memsys.c
+++ b/frame/base/bli_memsys.c
@@ -39,12 +39,10 @@
 void bli_memsys_init( void )
 {
 	// Query a native context so we have something to pass into
-	// bli_pba_init_pools(). We use BLIS_DOUBLE for the datatype,
-	// but the dt argument is actually only used when initializing
-	// contexts for induced methods.
-	// NOTE: Instead of calling bli_gks_query_cntx(), we call
-	// bli_gks_query_cntx_noinit() to avoid the call to bli_init_once().
-	const cntx_t* cntx_p = bli_gks_query_cntx_noinit();
+	// bli_pba_init_pools().
+	// NOTE: We intentionally call bli_gks_query_nat_cntx_noinit() in order
+	// to avoid the internal call to bli_init_once().
+	const cntx_t* cntx_p = bli_gks_query_nat_cntx_noinit();
 
 	// Initialize the packing block allocator and its data structures.
 	bli_pba_init( cntx_p );

--- a/frame/include/bli_config_macro_defs.h
+++ b/frame/include/bli_config_macro_defs.h
@@ -69,6 +69,17 @@
 
 // -- MULTITHREADING -----------------------------------------------------------
 
+// Enable caching of queried cntx_t pointers in the gks?
+#ifdef BLIS_DISABLE_GKS_CACHING
+  #undef BLIS_ENABLE_GKS_CACHING
+#else
+  // Default behavior is enabled.
+  #define BLIS_ENABLE_GKS_CACHING
+#endif
+
+
+// -- MULTITHREADING -----------------------------------------------------------
+
 // Enable multithreading via POSIX threads.
 #ifdef BLIS_ENABLE_PTHREADS
   // No additional definitions needed.

--- a/frame/thread/bli_pthread.c
+++ b/frame/thread/bli_pthread.c
@@ -701,7 +701,7 @@ int bli_pthread_barrier_wait
 // Note that bli_pthread_switch_t has the following properties:
 //
 // 1. Access to a switch is protected by a mutex specific to that switch, and
-//    therefore state changes and thread-safe.
+//    therefore state changes are thread-safe.
 //
 // 2. An initialized switch always starts in the "off" state.
 //


### PR DESCRIPTION
Details:
- Refactored the gks `cntx_t` query functions so that: (1) there is a clearer pattern of similarity between functions that query a native context and those that query its induced (1m) counterpart; and (2) queried `cntx_t` pointers (for both native and induced `cntx_t` pointers) are cached (by default), or deep-queried upon each invocation, depending on whether cpp macro `BLIS_ENABLE_GKS_CACHING` is defined.
- Refactored query-related functions in `bli_arch.c` to cache the queried `arch_t` value (by default), or deep-query the `arch_t` value upon each invocation, depending on whether cpp macro `BLIS_ENABLE_GKS_CACHING` is defined.
- Tweaked the behavior of `bli_gks_query_ind_cntx_impl()` (formerly named `bli_gks_query_ind_cntx()`) so that the induced method `cntx_t` struct is repopulated each time the function is called. (It is still only allocated once on first call.) This was mostly done in preparation for some future in which the `arch_t` value might change at runtime. In such a scenario, the induced method context would need to be recalculated any time the native context changes.
- Added preprocessor logic to `bli_config_macro_defs.h` to handle enabling or disabling of `cntx_t` pointer caching (via `BLIS_ENABLE_GKS_CACHING`).
- For now, `cntx_t` pointer caching is enabled by default and does not correspond to any official `configure` option. Disabling can be done by inserting a `#define` for `BLIS_DISABLE_GKS_CACHING` into the appropriate `bli_family_*.h` header file within the configuration of interest.
- Thanks to Harihara Sudhan S (AMD) for suggesting that `cntxt_t` pointers (and not just `arch_t` values) be cached.
- Comment updates.

@ihariharasudhan Please review these changes. Thanks.
