### PR TITLE
Fixing macro-mismatch error for VEXTRACTF64X2

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -24,6 +24,7 @@ but many others have contributed code and feedback, including
   Dilyn Corner             @dilyn-corner
   Mat Cross                @matcross           (NAG)
                            @decandia50
+  Harsh Dave               @HarshDave12        (AMD)
   Daniël de Kok            @danieldk           (Explosion)
   Kay Dewhurst             @jkd2016            (Max Planck Institute, Halle, Germany)
   Jeff Diamond                                 (Oracle)

--- a/frame/include/bli_x86_asm_macros.h
+++ b/frame/include/bli_x86_asm_macros.h
@@ -1205,7 +1205,7 @@
 #define VEXTRACTF128(_0, _1, _2) INSTR_(vextractf128, _0, _1, _2)
 #define VEXTRACTF32X4(_0, _1, _2) INSTR_(vextractf32x4, _0, _1, _2)
 #define VEXTRACTF32X8(_0, _1, _2) INSTR_(vextractf32x8, _0, _1, _2)
-#define VEXTRACTF64X2(_0, _1, _2) INSTR_(vextractf64x4, _0, _1, _2)
+#define VEXTRACTF64X2(_0, _1, _2) INSTR_(vextractf64x2, _0, _1, _2)
 #define VEXTRACTF64X4(_0, _1, _2) INSTR_(vextractf64x4, _0, _1, _2)
 #define VBLENDPS(_0, _1, _2, _3) INSTR_(vblendps, _0, _1, _2, _3)
 #define VBLENDPD(_0, _1, _2, _3) INSTR_(vblendpd, _0, _1, _2, _3)


### PR DESCRIPTION
    Details:
    - This commit fixes a mismatch between macro mapping.
      Macro VEXTRACTF64X2 was defined as vextractf64x4, instead of
      vextractf64x2.