### PR TITLE
Refine emacs handling of indentation; remove shebang from .mk file which confuses emacs mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,11 +1,32 @@
-;; Emacs C mode formatting for the BLIS layout requirements.
-((c-mode . ((c-file-style . "stroustrup")
-	    (c-basic-offset . 4)
-	    (comment-start . "// ")
-	    (comment-end . "")
-	    (indent-tabs-mode . t)
-	    (tab-width . 4)
-	    (parens-require-spaces . nil)
-	    (require-final-newline . t)
-	    (eval add-hook `before-save-hook `delete-trailing-whitespace)
-	    )))
+;; Emacs formatting for the BLIS layout requirements.
+
+(
+ ;; Recognize *.mk files as Makefile fragments
+ (auto-mode-alist . (("\\.mk\\'" . makefile-mode)) )
+
+ ;; Makefiles require tabs and are almost always width 8
+ (makefile-mode . (
+                   (indent-tabs-mode . t)
+                   (tab-width . 8)
+                   )
+                )
+
+ ;; C code formatting roughly according to docs/CodingConventions.md
+ (c-mode . (
+            (c-file-style . "bsd")
+            (c-basic-offset . 4)
+            (comment-start . "// ")
+            (comment-end . "")
+            (parens-require-spaces . nil)
+            )
+         )
+
+ ;; Default formatting for all source files not overriden above
+ (prog-mode . (
+               (indent-tabs-mode . nil)
+               (tab-width . 4)
+               (require-final-newline . t)
+               (eval add-hook `before-save-hook `delete-trailing-whitespace)
+               )
+            )
+)

--- a/config/old/newarch/make_defs.mk
+++ b/config/old/newarch/make_defs.mk
@@ -1,6 +1,6 @@
-#!/bin/bash
 #
-#  BLIS    
+#
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -47,7 +47,7 @@ CC             := gcc
 CC_VENDOR      := gcc
 endif
 
-# Enable IEEE Standard 1003.1-2004 (POSIX.1d). 
+# Enable IEEE Standard 1003.1-2004 (POSIX.1d).
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=c99
@@ -67,13 +67,13 @@ endif
 CKOPTFLAGS     := $(COPTFLAGS)
 
 ifeq ($(CC_VENDOR),gcc)
-CKVECFLAGS     := 
+CKVECFLAGS     :=
 else
 ifeq ($(CC_VENDOR),icc)
-CKVECFLAGS     := 
+CKVECFLAGS     :=
 else
 ifeq ($(CC_VENDOR),clang)
-CKVECFLAGS     := 
+CKVECFLAGS     :=
 else
 $(error gcc, icc, or clang is required for this configuration.)
 endif
@@ -83,4 +83,3 @@ endif
 # Store all of the variables here to new variables containing the
 # configuration name.
 $(eval $(call store-make-defs,$(THIS_CONFIG)))
-


### PR DESCRIPTION
This refines the `emacs` autoformatting to be better in line with contribution guidelines.

Remove a stray shebang in a `.mk` file which confuses `emacs` about the file mode, which should be `makefile-mode`. (`emacs` also removes stray whitespace at the ends of lines.)

 