### PR TITLE
Added an 'arm64' entry to `.travis.yml`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,15 @@ matrix:
       CC=aarch64-linux-gnu-gcc-10 CXX=aarch64-linux-gnu-g++-10 \
       PACKAGES="gcc-10-aarch64-linux-gnu g++-10-aarch64-linux-gnu libc6-dev-arm64-cross qemu-system-arm qemu-user" \
       TESTSUITE_WRAPPER="qemu-aarch64 -cpu max,sve=true,sve512=true -L /usr/aarch64-linux-gnu/"
+  # arm64 build and fast testsuite (qemu)
+  # NOTE: This entry omits the -cpu flag so that while both NEON and SVE kernels
+  # are compiled, only NEON kernels will be tested. (h/t to RuQing Xu)
+  - os: linux
+    compiler: aarch64-linux-gnu-gcc-10
+    env: OOT=0 TEST=FAST SDE=0 THR="none" CONF="arm64" \
+      CC=aarch64-linux-gnu-gcc-10 CXX=aarch64-linux-gnu-g++-10 \
+      PACKAGES="gcc-10-aarch64-linux-gnu g++-10-aarch64-linux-gnu libc6-dev-arm64-cross qemu-system-arm qemu-user" \
+      TESTSUITE_WRAPPER="qemu-aarch64 -L /usr/aarch64-linux-gnu/"
 install:
 - if [ "$CC" = "gcc"  ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-9"; fi
 - if [ -n "$PACKAGES" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y $PACKAGES; fi

--- a/config/arm64/bli_family_arm64.h
+++ b/config/arm64/bli_family_arm64.h
@@ -40,7 +40,7 @@
 
 #define BLIS_SIMD_ALIGN_SIZE 16
 
-//#define BLIS_SIMD_MAX_SIZE 512
+#define BLIS_SIMD_MAX_SIZE 128 // Note: The default is 64.
 #define BLIS_SIMD_MAX_NUM_REGISTERS 32
 
 // SVE-specific configs.

--- a/config/arm64/bli_family_arm64.h
+++ b/config/arm64/bli_family_arm64.h
@@ -39,6 +39,8 @@
 // -- MEMORY ALLOCATION --------------------------------------------------------
 
 #define BLIS_SIMD_ALIGN_SIZE 16
+
+#define BLIS_SIMD_MAX_SIZE 512
 #define BLIS_SIMD_MAX_NUM_REGISTERS 32
 
 // SVE-specific configs.

--- a/config/arm64/bli_family_arm64.h
+++ b/config/arm64/bli_family_arm64.h
@@ -40,7 +40,7 @@
 
 #define BLIS_SIMD_ALIGN_SIZE 16
 
-#define BLIS_SIMD_MAX_SIZE 512
+//#define BLIS_SIMD_MAX_SIZE 512
 #define BLIS_SIMD_MAX_NUM_REGISTERS 32
 
 // SVE-specific configs.

--- a/frame/base/bli_check.c
+++ b/frame/base/bli_check.c
@@ -837,7 +837,12 @@ err_t bli_check_sufficient_stack_buf_size( const cntx_t* cntx )
 		// of it (real or imaginary part) at a time.
 
 		if ( mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE )
+		{
 			e_val = BLIS_INSUFFICIENT_STACK_BUF_SIZE;
+			printf( "DEBUG: Ruh roh... mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE :(\n" );
+			printf( "DEBUG: mr x nr = %d x %d    dt_size = %d\n", (int)mr, (int)nr, (int)dt_size );
+			printf( "DEBUG: BLIS_STACK_BUF_MAX_SIZE = %d\n" , (int)BLIS_STACK_BUF_MAX_SIZE );
+		}
 	}
 
 	return e_val;

--- a/frame/base/bli_check.c
+++ b/frame/base/bli_check.c
@@ -837,12 +837,7 @@ err_t bli_check_sufficient_stack_buf_size( const cntx_t* cntx )
 		// of it (real or imaginary part) at a time.
 
 		if ( mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE )
-		{
 			e_val = BLIS_INSUFFICIENT_STACK_BUF_SIZE;
-			fprintf( stderr, "DEBUG: Ruh roh... mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE :(\n" );
-			fprintf( stderr, "DEBUG: mr x nr = %d x %d    dt_size = %d\n", (int)mr, (int)nr, (int)dt_size );
-			fprintf( stderr, "DEBUG: BLIS_STACK_BUF_MAX_SIZE = %d\n" , (int)BLIS_STACK_BUF_MAX_SIZE );
-		}
 	}
 
 	return e_val;

--- a/frame/base/bli_check.c
+++ b/frame/base/bli_check.c
@@ -839,9 +839,9 @@ err_t bli_check_sufficient_stack_buf_size( const cntx_t* cntx )
 		if ( mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE )
 		{
 			e_val = BLIS_INSUFFICIENT_STACK_BUF_SIZE;
-			printf( "DEBUG: Ruh roh... mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE :(\n" );
-			printf( "DEBUG: mr x nr = %d x %d    dt_size = %d\n", (int)mr, (int)nr, (int)dt_size );
-			printf( "DEBUG: BLIS_STACK_BUF_MAX_SIZE = %d\n" , (int)BLIS_STACK_BUF_MAX_SIZE );
+			fprintf( stderr, "DEBUG: Ruh roh... mr * nr * dt_size > BLIS_STACK_BUF_MAX_SIZE :(\n" );
+			fprintf( stderr, "DEBUG: mr x nr = %d x %d    dt_size = %d\n", (int)mr, (int)nr, (int)dt_size );
+			fprintf( stderr, "DEBUG: BLIS_STACK_BUF_MAX_SIZE = %d\n" , (int)BLIS_STACK_BUF_MAX_SIZE );
 		}
 	}
 

--- a/travis/do_testsuite.sh
+++ b/travis/do_testsuite.sh
@@ -9,25 +9,25 @@ export BLIS_JR_NT=1
 export BLIS_IR_NT=1
 
 if [ "$TEST" = "FAST" -o "$TEST" = "ALL" ]; then
-    make testblis-fast || cat ./output.testsuite
-    $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	make testblis-fast || cat ./output.testsuite
+	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 if [ "$TEST" = "MD" -o "$TEST" = "ALL" ]; then
 	make testblis-md || cat ./output.testsuite
-    $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 if [ "$TEST" = "SALT" -o "$TEST" = "ALL" ]; then
 	# Disable multithreading within BLIS.
 	export BLIS_JC_NT=1 BLIS_IC_NT=1 BLIS_JR_NT=1 BLIS_IR_NT=1
 	make testblis-salt || cat ./output.testsuite
-    $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 if [ "$TEST" = "1" -o "$TEST" = "ALL" ]; then
-    make testblis || cat ./output.testsuite
-    $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	make testblis || cat ./output.testsuite
+	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 make testblas || cat ./output.testsuite

--- a/travis/do_testsuite.sh
+++ b/travis/do_testsuite.sh
@@ -9,27 +9,27 @@ export BLIS_JR_NT=1
 export BLIS_IR_NT=1
 
 if [ "$TEST" = "FAST" -o "$TEST" = "ALL" ]; then
-    make testblis-fast
+    make testblis-fast || cat ./output.testsuite
     $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 if [ "$TEST" = "MD" -o "$TEST" = "ALL" ]; then
-	make testblis-md
+	make testblis-md || cat ./output.testsuite
     $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 if [ "$TEST" = "SALT" -o "$TEST" = "ALL" ]; then
 	# Disable multithreading within BLIS.
 	export BLIS_JC_NT=1 BLIS_IC_NT=1 BLIS_JR_NT=1 BLIS_IR_NT=1
-	make testblis-salt
+	make testblis-salt || cat ./output.testsuite
     $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 if [ "$TEST" = "1" -o "$TEST" = "ALL" ]; then
-    make testblis
+    make testblis || cat ./output.testsuite
     $DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
-make testblas
+make testblas || cat ./output.testsuite
 $DIST_PATH/blastest/check-blastest.sh
 


### PR DESCRIPTION
Details:
- Added a new `arm64` entry to the `.travis.yml` file in an attempt to get Travis CI to compile both NEON and SVE kernels, even if only NEON kernels are exercised in the testing. With this new `arm64` entry, the `cortexa57` entry becomes redundant and may be removed. Thanks to RuQing Xu for this suggestion.

cc: @xrq-phys