### PR TITLE
Fixed bugs in scal2v ref kernel when alpha == 1.

### DIFF
--- a/ref_kernels/1/bli_scal2v_ref.c
+++ b/ref_kernels/1/bli_scal2v_ref.c
@@ -73,7 +73,7 @@ void PASTEMAC3(ch,opname,arch,suf) \
 		); \
 		return; \
 	} \
-	else if ( PASTEMAC(ch,eq0)( *alpha ) ) \
+	else if ( PASTEMAC(ch,eq1)( *alpha ) ) \
 	{ \
 		/* If alpha is one, use copyv. */ \
 \
@@ -83,7 +83,7 @@ void PASTEMAC3(ch,opname,arch,suf) \
 \
 		copyv_p \
 		( \
-		  BLIS_NO_CONJUGATE, \
+		  conjx, \
 		  n, \
 		  x0, incx, \
 		  y0, incy, \


### PR DESCRIPTION
Details:
- Fixed a typo bug in `ref_kernels/1/bli_scal2v_ref.c` where the conditional that was supposed to be checking for cases when `alpha` is equal to 1.0 (so that `copyv` could be used instead of `scal2v`) was instead erroneously comparing `alpha` against 0.0.
- Fixed another bug in the same function whereby `BLIS_NO_CONJUGATE` was erroneously being passed into `copyv` instead of the kernel's `conjx` parameter.