### PR TITLE
Fixed compile errors with `BLIS_DISABLE_BLAS_DEFS`.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,4 +1,3 @@
-
 BLIS framework
 Acknowledgements
 ---

--- a/CREDITS
+++ b/CREDITS
@@ -1,3 +1,4 @@
+
 BLIS framework
 Acknowledgements
 ---

--- a/CREDITS
+++ b/CREDITS
@@ -103,6 +103,7 @@ but many others have contributed code, ideas, and feedback, including
   Nathaniel Smith          @njsmith
   Shaden Smith             @ShadenSmith
   Tyler Smith              @tlrmchlsmth               (The University of Texas at Austin)
+  Edward Smyth             @edwsmyth                  (AMD)
   Snehith                  @ArcadioN09
   Paul Springer            @springer13                (RWTH Aachen University)
   Adam J. Stewart          @adamjstewart              (University of Illinois at Urbana-Champaign)

--- a/frame/compat/bla_amax.h
+++ b/frame/compat/bla_amax.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -47,5 +48,7 @@ BLIS_EXPORT_BLAS f77_int PASTEF772(i,chx,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( amax )
+#endif
+
 #endif
 

--- a/frame/compat/bla_asum.h
+++ b/frame/compat/bla_asum.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -47,5 +48,7 @@ BLIS_EXPORT_BLAS ftype_r PASTEF772(chr,chx,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTR2_BLAS( asum )
+#endif
+
 #endif
 

--- a/frame/compat/bla_axpy.h
+++ b/frame/compat/bla_axpy.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -49,5 +50,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( axpy )
+#endif
+
 #endif
 

--- a/frame/compat/bla_copy.h
+++ b/frame/compat/bla_copy.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -48,5 +49,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( copy )
+#endif
+
 #endif
 

--- a/frame/compat/bla_dot.h
+++ b/frame/compat/bla_dot.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.

--- a/frame/compat/bla_gemm.h
+++ b/frame/compat/bla_gemm.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -55,5 +56,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( gemm )
+#endif
+
 #endif
 

--- a/frame/compat/bla_gemv.h
+++ b/frame/compat/bla_gemv.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -53,5 +54,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( gemv )
+#endif
+
 #endif
 

--- a/frame/compat/bla_ger.h
+++ b/frame/compat/bla_ger.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -51,5 +52,7 @@ BLIS_EXPORT_BLAS void PASTEF772(chxy,blasname,chc) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTDOT_BLAS( ger )
+#endif
+
 #endif
 

--- a/frame/compat/bla_hemm.h
+++ b/frame/compat/bla_hemm.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -54,5 +55,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTCO_BLAS( hemm )
+#endif
+
 #endif
 

--- a/frame/compat/bla_hemv.h
+++ b/frame/compat/bla_hemv.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -52,5 +53,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTCO_BLAS( hemv )
+#endif
+
 #endif
 

--- a/frame/compat/bla_her.h
+++ b/frame/compat/bla_her.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -50,5 +51,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTCO_BLAS( her )
+#endif
+
 #endif
 

--- a/frame/compat/bla_her2.h
+++ b/frame/compat/bla_her2.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -51,5 +52,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTCO_BLAS( her2 )
+#endif
+
 #endif
 

--- a/frame/compat/bla_her2k.h
+++ b/frame/compat/bla_her2k.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -54,5 +55,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTCO_BLAS( her2k )
+#endif
+
 #endif
 

--- a/frame/compat/bla_herk.h
+++ b/frame/compat/bla_herk.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -53,5 +54,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTCO_BLAS( herk )
+#endif
+
 #endif
 

--- a/frame/compat/bla_nrm2.h
+++ b/frame/compat/bla_nrm2.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -47,5 +48,7 @@ BLIS_EXPORT_BLAS ftype_r PASTEF772(chr,chx,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTR2_BLAS( nrm2 )
+#endif
+
 #endif
 

--- a/frame/compat/bla_scal.h
+++ b/frame/compat/bla_scal.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -48,5 +49,7 @@ BLIS_EXPORT_BLAS void PASTEF772(chx,cha,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTSCAL_BLAS( scal )
+#endif
+
 #endif
 

--- a/frame/compat/bla_swap.h
+++ b/frame/compat/bla_swap.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -48,5 +49,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( swap )
+#endif
+
 #endif
 

--- a/frame/compat/bla_symm.h
+++ b/frame/compat/bla_symm.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -54,5 +55,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( symm )
+#endif
+
 #endif
 

--- a/frame/compat/bla_symv.h
+++ b/frame/compat/bla_symv.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -52,5 +53,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTRO_BLAS( symv )
+#endif
+
 #endif
 

--- a/frame/compat/bla_syr.h
+++ b/frame/compat/bla_syr.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -50,5 +51,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTRO_BLAS( syr )
+#endif
+
 #endif
 

--- a/frame/compat/bla_syr2.h
+++ b/frame/compat/bla_syr2.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -51,5 +52,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROTRO_BLAS( syr2 )
+#endif
+
 #endif
 

--- a/frame/compat/bla_syr2k.h
+++ b/frame/compat/bla_syr2k.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -54,5 +55,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( syr2k )
+#endif
+
 #endif
 

--- a/frame/compat/bla_syrk.h
+++ b/frame/compat/bla_syrk.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -53,5 +54,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( syrk )
+#endif
+
 #endif
 

--- a/frame/compat/bla_trmm.h
+++ b/frame/compat/bla_trmm.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -54,5 +55,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( trmm )
+#endif
+
 #endif
 

--- a/frame/compat/bla_trmv.h
+++ b/frame/compat/bla_trmv.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -51,5 +52,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( trmv )
+#endif
+
 #endif
 

--- a/frame/compat/bla_trsm.h
+++ b/frame/compat/bla_trsm.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -54,5 +55,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( trsm )
+#endif
+
 #endif
 

--- a/frame/compat/bla_trsv.h
+++ b/frame/compat/bla_trsv.h
@@ -32,6 +32,7 @@
 
 */
 
+#if 1
 
 //
 // Prototype BLAS-to-BLIS interfaces.
@@ -51,5 +52,7 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( trsv )
+#endif
+
 #endif
 

--- a/frame/compat/bli_blas.h
+++ b/frame/compat/bli_blas.h
@@ -33,13 +33,15 @@
 
 */
 
+#ifndef BLIS_BLAS_H
+#define BLIS_BLAS_H
+
+
 // If the CBLAS compatibility layer was enabled while the BLAS layer
 // was not enabled, we must enable it here.
-#ifdef BLIS_ENABLE_CBLAS
-#ifndef BLIS_ENABLE_BLAS
-#define BLIS_ENABLE_BLAS
+#if defined(BLIS_ENABLE_CBLAS) && !defined(BLIS_ENABLE_BLAS)
+  #define BLIS_ENABLE_BLAS
 #endif
-#endif // BLIS_ENABLE_CBLAS
 
 // By default, if the BLAS compatibility layer is enabled, we define
 // (include) all of the BLAS prototypes. However, if the user is
@@ -47,181 +49,36 @@
 // declares the BLAS functions, then we provide an opportunity to
 // #undefine the BLIS_ENABLE_BLAS_DEFS macro (see below).
 #ifdef BLIS_ENABLE_BLAS
-#define BLIS_ENABLE_BLAS_DEFS
+  #define BLIS_ENABLE_BLAS_DEFS
 #else
-#undef  BLIS_ENABLE_BLAS_DEFS
+  #undef  BLIS_ENABLE_BLAS_DEFS
 #endif
 
 // Skip prototyping all of the BLAS if the BLAS test drivers are being
 // compiled.
 #ifdef BLIS_VIA_BLASTEST
-#undef BLIS_ENABLE_BLAS_DEFS
+  #undef BLIS_ENABLE_BLAS_DEFS
 #endif
 
 // Skip prototyping all of the BLAS if the environment has defined the
 // macro BLIS_DISABLE_BLAS_DEFS.
 #ifdef BLIS_DISABLE_BLAS_DEFS
-#undef BLIS_ENABLE_BLAS_DEFS
+  #undef BLIS_ENABLE_BLAS_DEFS
 #endif
 
-// Begin including all BLAS prototypes.
+// Begin including all BLAS prototypes, if appropriate.
 #ifdef BLIS_ENABLE_BLAS_DEFS
+  // If BLIS_ENABLE_BLAS_DEFS is defined, then we should #include the BLAS
+  // prototypes.
+  #include "bli_blas_defs.h"
+#else
+  // Even if BLAS prototypes are not to be #included into blis.h, we still
+  // need to #include the prototypes when compiling BLIS.
+  #ifdef BLIS_IS_BUILDING_LIBRARY
+    #include "bli_blas_defs.h"
+  #endif
+#endif
 
 
-// -- System headers needed by BLAS compatibility layer --
+#endif // BLIS_BLAS_H
 
-#include <ctype.h>  // for toupper(), used in xerbla()
-
-
-// -- Constants --
-
-#define BLIS_MAX_BLAS_FUNC_STR_LENGTH (7+1)
-
-
-// -- Utility macros --
-
-#include "bla_r_sign.h"
-#include "bla_d_sign.h"
-
-#include "bla_r_cnjg.h"
-#include "bla_d_cnjg.h"
-
-#include "bla_r_imag.h"
-#include "bla_d_imag.h"
-
-#include "bla_c_div.h"
-#include "bla_z_div.h"
-
-#include "bla_f__cabs.h" // needed by c_abs, z_abs
-#include "bla_r_abs.h"
-#include "bla_d_abs.h"
-#include "bla_c_abs.h"
-#include "bla_z_abs.h"
-
-#include "bla_lsame.h"
-#include "bla_xerbla.h"
-#include "bla_xerbla_array.h"
-
-
-// -- Level-0 BLAS prototypes --
-
-#include "bla_cabs1.h"
-
-
-// -- Level-1 BLAS prototypes --
-
-#include "bla_amax.h"
-#include "bla_asum.h"
-#include "bla_axpy.h"
-#include "bla_copy.h"
-#include "bla_dot.h"
-#include "bla_nrm2.h"
-#include "bla_rot.h"
-#include "bla_rotg.h"
-#include "bla_rotm.h"
-#include "bla_rotmg.h"
-#include "bla_scal.h"
-#include "bla_swap.h"
-
-#include "f77_amax_sub.h"
-#include "f77_asum_sub.h"
-#include "f77_dot_sub.h"
-#include "f77_nrm2_sub.h"
-
-
-// -- Level-2 BLAS prototypes --
-
-// dense
-
-#include "bla_gemv.h"
-#include "bla_ger.h"
-#include "bla_hemv.h"
-#include "bla_her.h"
-#include "bla_her2.h"
-#include "bla_symv.h"
-#include "bla_syr.h"
-#include "bla_syr2.h"
-#include "bla_trmv.h"
-#include "bla_trsv.h"
-
-#include "bla_gemv_check.h"
-#include "bla_ger_check.h"
-#include "bla_hemv_check.h"
-#include "bla_her_check.h"
-#include "bla_her2_check.h"
-#include "bla_symv_check.h"
-#include "bla_syr_check.h"
-#include "bla_syr2_check.h"
-#include "bla_trmv_check.h"
-#include "bla_trsv_check.h"
-
-// packed
-
-#include "bla_hpmv.h"
-#include "bla_hpr.h"
-#include "bla_hpr2.h"
-#include "bla_spmv.h"
-#include "bla_spr.h"
-#include "bla_spr2.h"
-#include "bla_tpmv.h"
-#include "bla_tpsv.h"
-
-// banded
-
-#include "bla_gbmv.h"
-#include "bla_hbmv.h"
-#include "bla_sbmv.h"
-#include "bla_tbmv.h"
-#include "bla_tbsv.h"
-
-
-// -- Level-3 BLAS prototypes --
-
-#include "bla_gemm.h"
-#include "bla_hemm.h"
-#include "bla_herk.h"
-#include "bla_her2k.h"
-#include "bla_symm.h"
-#include "bla_syrk.h"
-#include "bla_syr2k.h"
-#include "bla_trmm.h"
-#include "bla_trsm.h"
-
-#include "bla_gemm_check.h"
-#include "bla_hemm_check.h"
-#include "bla_herk_check.h"
-#include "bla_her2k_check.h"
-#include "bla_symm_check.h"
-#include "bla_syrk_check.h"
-#include "bla_syr2k_check.h"
-#include "bla_trmm_check.h"
-#include "bla_trsm_check.h"
-
-
-// -- BLAS extension prototypes --
-
-// unique to BLIS
-
-#include "bla_axpby.h"
-
-// level-3
-
-#include "bla_gemmt.h"
-#include "bla_gemmt_check.h"
-
-// batch
-
-#include "bla_gemm_batch.h"
-
-// 3m
-
-#include "bla_gemm3m.h"
-#include "bla_gemm3m_check.h"
-
-
-// -- Fortran-compatible APIs to BLIS functions --
-
-#include "b77_thread.h"
-
-
-#endif // BLIS_ENABLE_BLAS

--- a/frame/compat/bli_blas_defs.h
+++ b/frame/compat/bli_blas_defs.h
@@ -1,0 +1,197 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2020, Advanced Micro Devices, Inc.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef BLIS_BLAS_DEFS_H
+#define BLIS_BLAS_DEFS_H
+
+
+// -- System headers needed by BLAS compatibility layer --
+
+#include <ctype.h>  // for toupper(), used in xerbla()
+
+
+// -- Constants --
+
+#define BLIS_MAX_BLAS_FUNC_STR_LENGTH (7+1)
+
+
+// -- Utility macros --
+
+#include "bla_r_sign.h"
+#include "bla_d_sign.h"
+
+#include "bla_r_cnjg.h"
+#include "bla_d_cnjg.h"
+
+#include "bla_r_imag.h"
+#include "bla_d_imag.h"
+
+#include "bla_c_div.h"
+#include "bla_z_div.h"
+
+#include "bla_f__cabs.h" // needed by c_abs, z_abs
+#include "bla_r_abs.h"
+#include "bla_d_abs.h"
+#include "bla_c_abs.h"
+#include "bla_z_abs.h"
+
+#include "bla_lsame.h"
+#include "bla_xerbla.h"
+#include "bla_xerbla_array.h"
+
+
+// -- Level-0 BLAS prototypes --
+
+#include "bla_cabs1.h"
+
+
+// -- Level-1 BLAS prototypes --
+
+#include "bla_amax.h"
+#include "bla_asum.h"
+#include "bla_axpy.h"
+#include "bla_copy.h"
+#include "bla_dot.h"
+#include "bla_nrm2.h"
+#include "bla_rot.h"
+#include "bla_rotg.h"
+#include "bla_rotm.h"
+#include "bla_rotmg.h"
+#include "bla_scal.h"
+#include "bla_swap.h"
+
+#include "f77_amax_sub.h"
+#include "f77_asum_sub.h"
+#include "f77_dot_sub.h"
+#include "f77_nrm2_sub.h"
+
+
+// -- Level-2 BLAS prototypes --
+
+// dense
+
+#include "bla_gemv.h"
+#include "bla_ger.h"
+#include "bla_hemv.h"
+#include "bla_her.h"
+#include "bla_her2.h"
+#include "bla_symv.h"
+#include "bla_syr.h"
+#include "bla_syr2.h"
+#include "bla_trmv.h"
+#include "bla_trsv.h"
+
+#include "bla_gemv_check.h"
+#include "bla_ger_check.h"
+#include "bla_hemv_check.h"
+#include "bla_her_check.h"
+#include "bla_her2_check.h"
+#include "bla_symv_check.h"
+#include "bla_syr_check.h"
+#include "bla_syr2_check.h"
+#include "bla_trmv_check.h"
+#include "bla_trsv_check.h"
+
+// packed
+
+#include "bla_hpmv.h"
+#include "bla_hpr.h"
+#include "bla_hpr2.h"
+#include "bla_spmv.h"
+#include "bla_spr.h"
+#include "bla_spr2.h"
+#include "bla_tpmv.h"
+#include "bla_tpsv.h"
+
+// banded
+
+#include "bla_gbmv.h"
+#include "bla_hbmv.h"
+#include "bla_sbmv.h"
+#include "bla_tbmv.h"
+#include "bla_tbsv.h"
+
+
+// -- Level-3 BLAS prototypes --
+
+#include "bla_gemm.h"
+#include "bla_hemm.h"
+#include "bla_herk.h"
+#include "bla_her2k.h"
+#include "bla_symm.h"
+#include "bla_syrk.h"
+#include "bla_syr2k.h"
+#include "bla_trmm.h"
+#include "bla_trsm.h"
+
+#include "bla_gemm_check.h"
+#include "bla_hemm_check.h"
+#include "bla_herk_check.h"
+#include "bla_her2k_check.h"
+#include "bla_symm_check.h"
+#include "bla_syrk_check.h"
+#include "bla_syr2k_check.h"
+#include "bla_trmm_check.h"
+#include "bla_trsm_check.h"
+
+
+// -- BLAS extension prototypes --
+
+// unique to BLIS
+
+#include "bla_axpby.h"
+
+// level-3
+
+#include "bla_gemmt.h"
+#include "bla_gemmt_check.h"
+
+// batch
+
+#include "bla_gemm_batch.h"
+
+// 3m
+
+#include "bla_gemm3m.h"
+#include "bla_gemm3m_check.h"
+
+
+// -- Fortran-compatible APIs to BLIS functions --
+
+#include "b77_thread.h"
+
+
+#endif // BLIS_BLAS_DEFS_H
+

--- a/frame/compat/check/bla_gemm3m_check.h
+++ b/frame/compat/check/bla_gemm3m_check.h
@@ -33,7 +33,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_gemm3m_check( dt_str, op_str, transa, transb, m, n, k, lda, ldb, ldc ) \
 { \

--- a/frame/compat/check/bla_gemm_check.h
+++ b/frame/compat/check/bla_gemm_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_gemm_check( dt_str, op_str, transa, transb, m, n, k, lda, ldb, ldc ) \
 { \

--- a/frame/compat/check/bla_gemmt_check.h
+++ b/frame/compat/check/bla_gemmt_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_gemmt_check( dt_str, op_str, uploc, transa, transb, m, k, lda, ldb, ldc ) \
 { \

--- a/frame/compat/check/bla_gemv_check.h
+++ b/frame/compat/check/bla_gemv_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_gemv_check( dt_str, op_str, transa, m, n, lda, incx, incy ) \
 { \

--- a/frame/compat/check/bla_ger_check.h
+++ b/frame/compat/check/bla_ger_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_ger_check( dt_str, op_str, conj_str, m, n, incx, incy, lda ) \
 { \

--- a/frame/compat/check/bla_hemm_check.h
+++ b/frame/compat/check/bla_hemm_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_hemm_check( dt_str, op_str, sidea, uploa, m, n, lda, ldb, ldc ) \
 { \

--- a/frame/compat/check/bla_hemv_check.h
+++ b/frame/compat/check/bla_hemv_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_hemv_check( dt_str, op_str, uploa, m, lda, incx, incy ) \
 { \

--- a/frame/compat/check/bla_her2_check.h
+++ b/frame/compat/check/bla_her2_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_her2_check( dt_str, op_str, uploa, m, incx, incy, lda ) \
 { \

--- a/frame/compat/check/bla_her2k_check.h
+++ b/frame/compat/check/bla_her2k_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_her2k_check( dt_str, op_str, uploa, trans, m, k, lda, ldb, ldc ) \
 { \

--- a/frame/compat/check/bla_her_check.h
+++ b/frame/compat/check/bla_her_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_her_check( dt_str, op_str, uploa, m, incx, lda ) \
 { \

--- a/frame/compat/check/bla_herk_check.h
+++ b/frame/compat/check/bla_herk_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_herk_check( dt_str, op_str, uploa, transa, m, k, lda, ldc ) \
 { \

--- a/frame/compat/check/bla_symm_check.h
+++ b/frame/compat/check/bla_symm_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_symm_check bla_hemm_check
 

--- a/frame/compat/check/bla_symv_check.h
+++ b/frame/compat/check/bla_symv_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_symv_check bla_hemv_check
 

--- a/frame/compat/check/bla_syr2_check.h
+++ b/frame/compat/check/bla_syr2_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_syr2_check bla_her2_check
 

--- a/frame/compat/check/bla_syr2k_check.h
+++ b/frame/compat/check/bla_syr2k_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_syr2k_check( dt_str, op_str, uploa, trans, m, k, lda, ldb, ldc ) \
 { \

--- a/frame/compat/check/bla_syr_check.h
+++ b/frame/compat/check/bla_syr_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_syr_check bla_her_check
 

--- a/frame/compat/check/bla_syrk_check.h
+++ b/frame/compat/check/bla_syrk_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_syrk_check( dt_str, op_str, uploa, transa, m, k, lda, ldc ) \
 { \

--- a/frame/compat/check/bla_trmm_check.h
+++ b/frame/compat/check/bla_trmm_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_trmm_check( dt_str, op_str, sidea, uploa, transa, diaga, m, n, lda, ldb ) \
 { \

--- a/frame/compat/check/bla_trmv_check.h
+++ b/frame/compat/check/bla_trmv_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_trmv_check( dt_str, op_str, uploa, transa, diaga, m, lda, incx ) \
 { \

--- a/frame/compat/check/bla_trsm_check.h
+++ b/frame/compat/check/bla_trsm_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_trsm_check bla_trmm_check
 

--- a/frame/compat/check/bla_trsv_check.h
+++ b/frame/compat/check/bla_trsv_check.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #define bla_trsv_check bla_trmv_check
 

--- a/frame/compat/f2c/bla_cabs1.h
+++ b/frame/compat/f2c/bla_cabs1.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS bla_real   PASTEF77(s,cabs1)(bla_scomplex *z);
 BLIS_EXPORT_BLAS bla_double PASTEF77(d,cabs1)(bla_dcomplex *z);

--- a/frame/compat/f2c/bla_gbmv.h
+++ b/frame/compat/f2c/bla_gbmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,gbmv)(const bla_character *trans, const bla_integer *m, const bla_integer *n, const bla_integer *kl, const bla_integer *ku, const bla_scomplex *alpha, const bla_scomplex *a, const bla_integer *lda, const bla_scomplex *x, const bla_integer *incx, const bla_scomplex *beta, bla_scomplex *y, const bla_integer *incy);
 BLIS_EXPORT_BLAS int PASTEF77(d,gbmv)(const bla_character *trans, const bla_integer *m, const bla_integer *n, const bla_integer *kl, const bla_integer *ku, const bla_double *alpha, const bla_double *a, const bla_integer *lda, const bla_double *x, const bla_integer *incx, const bla_double *beta, bla_double *y, const bla_integer *incy);

--- a/frame/compat/f2c/bla_hbmv.h
+++ b/frame/compat/f2c/bla_hbmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,hbmv)(const bla_character *uplo, const bla_integer *n, const bla_integer *k, const bla_scomplex *alpha, const bla_scomplex *a, const bla_integer *lda, const bla_scomplex *x, const bla_integer *incx, const bla_scomplex *beta, bla_scomplex *y, const bla_integer *incy);
 BLIS_EXPORT_BLAS int PASTEF77(z,hbmv)(const bla_character *uplo, const bla_integer *n, const bla_integer *k, const bla_dcomplex *alpha, const bla_dcomplex *a, const bla_integer *lda, const bla_dcomplex *x, const bla_integer *incx, const bla_dcomplex *beta, bla_dcomplex *y, const bla_integer *incy);

--- a/frame/compat/f2c/bla_hpmv.h
+++ b/frame/compat/f2c/bla_hpmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,hpmv)(const bla_character *uplo, const bla_integer *n, const bla_scomplex *alpha, const bla_scomplex *ap, const bla_scomplex *x, const bla_integer *incx, const bla_scomplex *beta, bla_scomplex *y, const bla_integer *incy);
 BLIS_EXPORT_BLAS int PASTEF77(z,hpmv)(const bla_character *uplo, const bla_integer *n, const bla_dcomplex *alpha, const bla_dcomplex *ap, const bla_dcomplex *x, const bla_integer *incx, const bla_dcomplex *beta, bla_dcomplex *y, const bla_integer *incy);

--- a/frame/compat/f2c/bla_hpr.h
+++ b/frame/compat/f2c/bla_hpr.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,hpr)(const bla_character *uplo, const bla_integer *n, const bla_real *alpha, const bla_scomplex *x, const bla_integer *incx, bla_scomplex *ap);
 BLIS_EXPORT_BLAS int PASTEF77(z,hpr)(const bla_character *uplo, const bla_integer *n, const bla_double *alpha, const bla_dcomplex *x, const bla_integer *incx, bla_dcomplex *ap);

--- a/frame/compat/f2c/bla_hpr2.h
+++ b/frame/compat/f2c/bla_hpr2.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,hpr2)(const bla_character *uplo, const bla_integer *n, const bla_scomplex *alpha, const bla_scomplex *x, const bla_integer *incx, const bla_scomplex *y, const bla_integer *incy, bla_scomplex *ap);
 BLIS_EXPORT_BLAS int PASTEF77(z,hpr2)(const bla_character *uplo, const bla_integer *n, const bla_dcomplex *alpha, const bla_dcomplex *x, const bla_integer *incx, const bla_dcomplex *y, const bla_integer *incy, bla_dcomplex *ap);

--- a/frame/compat/f2c/bla_lsame.h
+++ b/frame/compat/f2c/bla_lsame.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 #ifdef LAPACK_ILP64
 long PASTEF770(lsame)(const char *ca, const char *cb, long ca_len, long cb_len);

--- a/frame/compat/f2c/bla_rot.h
+++ b/frame/compat/f2c/bla_rot.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(s,rot)(const bla_integer *n, bla_real *sx, const bla_integer *incx, bla_real *sy, const bla_integer *incy, const bla_real *c__, const bla_real *s);
 BLIS_EXPORT_BLAS int PASTEF77(d,rot)(const bla_integer *n, bla_double *dx, const bla_integer *incx, bla_double *dy, const bla_integer *incy, const bla_double *c__, const bla_double *s);

--- a/frame/compat/f2c/bla_rotg.h
+++ b/frame/compat/f2c/bla_rotg.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(s,rotg)(bla_real *sa, bla_real *sb, bla_real *c__, bla_real *s);
 BLIS_EXPORT_BLAS int PASTEF77(d,rotg)(bla_double *da, bla_double *db, bla_double *c__, bla_double *s);

--- a/frame/compat/f2c/bla_rotm.h
+++ b/frame/compat/f2c/bla_rotm.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(s,rotm)(const bla_integer *n, bla_real *sx, const bla_integer *incx, bla_real *sy, const bla_integer *incy, const bla_real *sparam);
 BLIS_EXPORT_BLAS int PASTEF77(d,rotm)(const bla_integer *n, bla_double *dx, const bla_integer *incx, bla_double *dy, const bla_integer *incy, const bla_double *dparam);

--- a/frame/compat/f2c/bla_rotmg.h
+++ b/frame/compat/f2c/bla_rotmg.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(s,rotmg)(bla_real *sd1, bla_real *sd2, bla_real *sx1, const bla_real *sy1, bla_real *sparam);
 BLIS_EXPORT_BLAS int PASTEF77(d,rotmg)(bla_double *dd1, bla_double *dd2, bla_double *dx1, const bla_double *dy1, bla_double *dparam);

--- a/frame/compat/f2c/bla_sbmv.h
+++ b/frame/compat/f2c/bla_sbmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(d,sbmv)(const bla_character *uplo, const bla_integer *n, const bla_integer *k, const bla_double *alpha, const bla_double *a, const bla_integer *lda, const bla_double *x, const bla_integer *incx, const bla_double *beta, bla_double *y, const bla_integer *incy);
 BLIS_EXPORT_BLAS int PASTEF77(s,sbmv)(const bla_character *uplo, const bla_integer *n, const bla_integer *k, const bla_real *alpha, const bla_real *a, const bla_integer *lda, const bla_real *x, const bla_integer *incx, const bla_real *beta, bla_real *y, const bla_integer *incy);

--- a/frame/compat/f2c/bla_spmv.h
+++ b/frame/compat/f2c/bla_spmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(d,spmv)(const bla_character *uplo, const bla_integer *n, const bla_double *alpha, const bla_double *ap, const bla_double *x, const bla_integer *incx, const bla_double *beta, bla_double *y, const bla_integer *incy);
 BLIS_EXPORT_BLAS int PASTEF77(s,spmv)(const bla_character *uplo, const bla_integer *n, const bla_real *alpha, const bla_real *ap, const bla_real *x, const bla_integer *incx, const bla_real *beta, bla_real *y, const bla_integer *incy);

--- a/frame/compat/f2c/bla_spr.h
+++ b/frame/compat/f2c/bla_spr.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(d,spr)(const bla_character *uplo, const bla_integer *n, const bla_double *alpha, const bla_double *x, const bla_integer *incx, bla_double *ap);
 BLIS_EXPORT_BLAS int PASTEF77(s,spr)(const bla_character *uplo, const bla_integer *n, const bla_real *alpha, const bla_real *x, const bla_integer *incx, bla_real *ap);

--- a/frame/compat/f2c/bla_spr2.h
+++ b/frame/compat/f2c/bla_spr2.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(d,spr2)(const bla_character *uplo, const bla_integer *n, const bla_double *alpha, const bla_double *x, const bla_integer *incx, const bla_double *y, const bla_integer *incy, bla_double *ap);
 BLIS_EXPORT_BLAS int PASTEF77(s,spr2)(const bla_character *uplo, const bla_integer *n, const bla_real *alpha, const bla_real *x, const bla_integer *incx, const bla_real *y, const bla_integer *incy, bla_real *ap);

--- a/frame/compat/f2c/bla_tbmv.h
+++ b/frame/compat/f2c/bla_tbmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,tbmv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_integer *k, const bla_scomplex *a, const bla_integer *lda, bla_scomplex *x, const bla_integer *incx);
 BLIS_EXPORT_BLAS int PASTEF77(d,tbmv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_integer *k, const bla_double *a, const bla_integer *lda, bla_double *x, const bla_integer *incx);

--- a/frame/compat/f2c/bla_tbsv.h
+++ b/frame/compat/f2c/bla_tbsv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,tbsv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_integer *k, const bla_scomplex *a, const bla_integer *lda, bla_scomplex *x, const bla_integer *incx);
 BLIS_EXPORT_BLAS int PASTEF77(d,tbsv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_integer *k, const bla_double *a, const bla_integer *lda, bla_double *x, const bla_integer *incx);

--- a/frame/compat/f2c/bla_tpmv.h
+++ b/frame/compat/f2c/bla_tpmv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,tpmv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_scomplex *ap, bla_scomplex *x, const bla_integer *incx);
 BLIS_EXPORT_BLAS int PASTEF77(d,tpmv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_double *ap, bla_double *x, const bla_integer *incx);

--- a/frame/compat/f2c/bla_tpsv.h
+++ b/frame/compat/f2c/bla_tpsv.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF77(c,tpsv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_scomplex *ap, bla_scomplex *x, const bla_integer *incx);
 BLIS_EXPORT_BLAS int PASTEF77(d,tpsv)(const bla_character *uplo, const bla_character *trans, const bla_character *diag, const bla_integer *n, const bla_double *ap, bla_double *x, const bla_integer *incx);

--- a/frame/compat/f2c/bla_xerbla.h
+++ b/frame/compat/f2c/bla_xerbla.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS BLIS_OVERRIDABLE int PASTEF770(xerbla)(const bla_character *srname, const bla_integer *info, ftnlen srname_len);
 

--- a/frame/compat/f2c/bla_xerbla_array.h
+++ b/frame/compat/f2c/bla_xerbla_array.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 BLIS_EXPORT_BLAS int PASTEF770(xerbla_array)(const bla_character *srname, const bla_integer srname_len, const bla_integer *info);
 

--- a/frame/compat/f2c/util/bla_c_abs.h
+++ b/frame/compat/f2c/util/bla_c_abs.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_c_abs(const bla_scomplex *z);
 

--- a/frame/compat/f2c/util/bla_c_div.h
+++ b/frame/compat/f2c/util/bla_c_div.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 void bla_c_div(bla_scomplex *cp, const bla_scomplex *ap, const bla_scomplex *bp);
 

--- a/frame/compat/f2c/util/bla_d_abs.h
+++ b/frame/compat/f2c/util/bla_d_abs.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_d_abs(const bla_double *x);
 

--- a/frame/compat/f2c/util/bla_d_cnjg.h
+++ b/frame/compat/f2c/util/bla_d_cnjg.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 void bla_d_cnjg(bla_dcomplex *dest, const bla_dcomplex *src);
 

--- a/frame/compat/f2c/util/bla_d_imag.h
+++ b/frame/compat/f2c/util/bla_d_imag.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_d_imag(const bla_dcomplex *z);
 

--- a/frame/compat/f2c/util/bla_d_sign.h
+++ b/frame/compat/f2c/util/bla_d_sign.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_d_sign(const bla_double *a, const bla_double *b);
 

--- a/frame/compat/f2c/util/bla_f__cabs.h
+++ b/frame/compat/f2c/util/bla_f__cabs.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_f__cabs(double real, double imag);
 

--- a/frame/compat/f2c/util/bla_r_abs.h
+++ b/frame/compat/f2c/util/bla_r_abs.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_r_abs(const bla_real *x);
 

--- a/frame/compat/f2c/util/bla_r_cnjg.h
+++ b/frame/compat/f2c/util/bla_r_cnjg.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 void bla_r_cnjg(bla_scomplex *dest, const bla_scomplex *src);
 

--- a/frame/compat/f2c/util/bla_r_imag.h
+++ b/frame/compat/f2c/util/bla_r_imag.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 bla_real bla_r_imag(const bla_scomplex *z);
 

--- a/frame/compat/f2c/util/bla_r_sign.h
+++ b/frame/compat/f2c/util/bla_r_sign.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_r_sign(const bla_real *a, const bla_real *b);
 

--- a/frame/compat/f2c/util/bla_z_abs.h
+++ b/frame/compat/f2c/util/bla_z_abs.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 double bla_z_abs(const bla_dcomplex *z);
 

--- a/frame/compat/f2c/util/bla_z_div.h
+++ b/frame/compat/f2c/util/bla_z_div.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_BLAS
+#if 1
 
 void bla_z_div(bla_dcomplex *cp, const bla_dcomplex *ap, const bla_dcomplex *bp);
 


### PR DESCRIPTION
Details:
- This commit fixes a compile-time error related to the type definition (prototype) of `dsdot_()` when `BLIS_DISABLE_BLAS_DEFS` is defined by the application (or the configuration), which is actually a symptom of a larger design issue when disabling BLAS prototypes. The macro was intended to allow applications to bring their own BLAS prototypes and suppress the inclusion of duplicate (or possibly conflicting) prototypes within `blis.h`. However, prototypes are still needed during compilation even if they are ultimately omitted from `blis.h`. The problem is that almost every source file in BLIS--including the BLAS compatibility layer--only includes one header (`blis.h`), and if we were to `#include` a new header in the BLAS source files (to isolate only the BLAS prototypes), we would also have to make the build system aware of the location of those headers. Thanks to Edward Smyth of AMD for reporting this issue.
- The solution I settled upon was to remove all cpp guards from all BLAS headers (by changing them to `#if 1`, for each search-and-replace anchoring in the future if we ever need to re-insert guards) and modifying `bli_blas.h` so that the BLAS prototypes are `#include`d if either (a) `BLIS_ENABLE_BLAS_DEFS` is defined, or (b) `BLIS_ENABLE_BLAS_DEFS` is *not* defined but `BLIS_IS_BUILDING_LIBRARY` *is* defined. (Thanks to Devin Matthews for steering me away from an inferior solution.)
- This commit also spins off the actual BLAS prototypes/definitions to a separate file, `bli_blas_defs.h`.
- `CREDITS` file update.