### PR TITLE
Omit -fPIC if shared library build is disabled.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -56,6 +56,7 @@ but many others have contributed code, ideas, and feedback, including
   Tony Kelman              @tkelman
   Lee Killough             @leekillough               (Cray)
   Mike Kistler             @mkistler                  (IBM, Austin Research Laboratory)
+  Nick Knight              @nick-knight               (SiFive)
   Ivan Korostelev          @ivan23kor                 (University of Alberta)
   Kyungmin Lee             @kyungminlee               (Ohio State University)
   Michael Lehn             @michael-lehn

--- a/common.mk
+++ b/common.mk
@@ -731,6 +731,9 @@ $(foreach c, $(CONFIG_LIST_FAM), $(eval $(call append-var-for,CWARNFLAGS,$(c))))
 
 # --- Position-independent code flags (shared libraries only) ---
 
+
+ifeq ($(MK_ENABLE_SHARED),yes)
+
 # Emit position-independent code for dynamic linking.
 ifeq ($(IS_MSVC),yes)
 # Note: Don't use any fPIC flags for Windows builds since all code is position-
@@ -812,6 +815,14 @@ else # ifeq ($(EXPORT_SHARED),public)
 BUILD_SYMFLAGS := -fvisibility=hidden
 endif
 endif
+endif
+
+else #ifeq ($(MK_ENABLE_SHARED),no)
+
+# Don't modify CPICFLAGS for the various configuration family members.
+# Don't use any special symbol export flags.
+BUILD_SYMFLAGS :=
+
 endif
 
 # --- Language flags ---


### PR DESCRIPTION
Details:
- Updated `common.mk` so that when `--disable-shared` option is given to `configure`:
  1. The `-fPIC` compiler flag is omitted from the individual configuration family members' `CPICFLAGS` variables (which are initialized in each subconfig's `make_defs.mk` file); and
  2. The `BUILD_SYMFLAGS` variable, which contains flags needed to control the symbol export behavior, is left blank. 
- The net result of these changes is that flags specific to shared library builds are only used when a shared library is actually being built. Thanks to Nick Knight for reporting this issue.
- `CREDITS` file update.

cc: @nick-knight