### PR TITLE
Optionally disable thread-local storage.

### DIFF
--- a/build/bli_config.h.in
+++ b/build/bli_config.h.in
@@ -53,6 +53,12 @@
 #define BLIS_DISABLE_SYSTEM
 #endif
 
+#if @enable_tls@
+#define BLIS_ENABLE_TLS
+#else
+#define BLIS_DISABLE_TLS
+#endif
+
 #if @enable_openmp@
 #define BLIS_ENABLE_OPENMP
 #if @enable_openmp_as_def@

--- a/configure
+++ b/configure
@@ -3576,11 +3576,7 @@ main()
 		enable_tls_01=1
 	else
 		echo "${script_name}: disabling thread-local storage (TLS) support."
-		echo "${script_name}: WARNING: disabling thread-local storage forcibly disables all threading!"
 		enable_tls_01=0
-
-		# Force threading to be disabled.
-		threading_model='off'
 	fi
 
 	# Check the threading model flag and standardize its value, if needed.

--- a/configure
+++ b/configure
@@ -199,6 +199,16 @@ print_usage()
                  library. When disabled, this option also forces the use
                  of --disable-threading.
 
+   --enable-tls, --disable-tls
+
+                 Enable thread-local storage (TLS) for static variables
+                 in BLIS. The default state is enabled. However, like with
+                 --disable-system, there may be rare situations, such as
+                 when --disable-system is appropriate, where thread-local
+                 storage is unsupported by the compiler. In those cases,
+                 disabling TLS may be a suitable workaround. When disabled,
+                 this option also forces the use of --disable-threading.
+
    --disable-pba-pools, --enable-pba-pools
    --disable-sba-pools, --enable-sba-pools
 
@@ -2512,6 +2522,9 @@ main()
 	# The system flag.
 	enable_system='yes'
 
+	# The thread-local storage flag.
+	enable_tls='yes'
+
 	# The threading flag.
 	threading_model='off'
 
@@ -2690,6 +2703,13 @@ main()
 							;;
 						disable-system)
 							enable_system='no'
+							;;
+
+						enable-tls)
+							enable_tls='yes'
+							;;
+						disable-tls)
+							enable_tls='no'
 							;;
 
 						enable-threading=*)
@@ -3543,8 +3563,21 @@ main()
 		enable_system_01=1
 	else
 		echo "${script_name}: disabling operating system support."
-		echo "${script_name}: WARNING: all threading will be disabled!"
+		echo "${script_name}: WARNING: disabling OS support forcibly disables all threading!"
 		enable_system_01=0
+
+		# Force threading to be disabled.
+		threading_model='off'
+	fi
+
+	# Check if we are building with or without thread-local storage support.
+	if [[ ${enable_tls} = yes ]]; then
+		echo "${script_name}: enabling thread-local storage (TLS) support."
+		enable_tls_01=1
+	else
+		echo "${script_name}: disabling thread-local storage (TLS) support."
+		echo "${script_name}: WARNING: disabling thread-local storage forcibly disables all threading!"
+		enable_tls_01=0
 
 		# Force threading to be disabled.
 		threading_model='off'
@@ -4202,6 +4235,7 @@ main()
 	| sed >"${bli_config_h_out_path}"                                    \
 	-e "s/@version@/${version_esc}/g"                                    \
 	-e "s/@enable_system@/${enable_system_01}/g"                         \
+	-e "s/@enable_tls@/${enable_tls_01}/g"                               \
 	-e "s/@enable_openmp@/${enable_openmp_01}/g"                         \
 	-e "s/@enable_openmp_as_def@/${enable_openmp_as_def_01}/g"           \
 	-e "s/@enable_pthreads@/${enable_pthreads_01}/g"                     \

--- a/configure
+++ b/configure
@@ -206,8 +206,11 @@ print_usage()
                  --disable-system, there may be rare situations, such as
                  when --disable-system is appropriate, where thread-local
                  storage is unsupported by the compiler. In those cases,
-                 disabling TLS may be a suitable workaround. When disabled,
-                 this option also forces the use of --disable-threading.
+                 disabling TLS may be a suitable workaround.
+		         WARNING: DISABLING TLS IS DANGEROUS AND MAY CAUSE RACE
+                 CONDITIONS! Please try combining --disable-tls with
+                 --disable-threading if you suspect any correctness or
+                 deadlock issues.
 
    --disable-pba-pools, --enable-pba-pools
    --disable-sba-pools, --enable-sba-pools
@@ -3576,6 +3579,9 @@ main()
 		enable_tls_01=1
 	else
 		echo "${script_name}: disabling thread-local storage (TLS) support."
+		echo "${script_name}: WARNING: THIS IS DANGEROUS! Disabling TLS may cause race conditions!"
+		echo "${script_name}: WARNING: Please try --disable-threading if you suspect any correctness"
+		echo "${script_name}: WARNING: or deadlock issues."
 		enable_tls_01=0
 	fi
 

--- a/frame/base/bli_info.c
+++ b/frame/base/bli_info.c
@@ -103,10 +103,10 @@ gint_t bli_info_get_enable_sba_pools( void )
 }
 gint_t bli_info_get_enable_threading( void )
 {
-	if ( bli_info_get_enable_openmp() ||
+	if ( bli_info_get_enable_openmp()   ||
 	     bli_info_get_enable_pthreads() ||
 	     bli_info_get_enable_hpx() ) return 1;
-	else                                  return 0;
+	else                             return 0;
 }
 gint_t bli_info_get_enable_openmp( void )
 {
@@ -175,6 +175,14 @@ gint_t bli_info_get_thread_jrir_rr( void )
 gint_t bli_info_get_thread_jrir_tlb( void )
 {
 #ifdef BLIS_ENABLE_JRIR_TLB
+	return 1;
+#else
+	return 0;
+#endif
+}
+gint_t bli_info_get_enable_tls( void )
+{
+#ifdef BLIS_ENABLE_TLS
 	return 1;
 #else
 	return 0;

--- a/frame/base/bli_info.h
+++ b/frame/base/bli_info.h
@@ -77,6 +77,7 @@ BLIS_EXPORT_BLIS gint_t bli_info_get_enable_hpx_as_default( void );
 BLIS_EXPORT_BLIS gint_t bli_info_get_thread_jrir_slab( void );
 BLIS_EXPORT_BLIS gint_t bli_info_get_thread_jrir_rr( void );
 BLIS_EXPORT_BLIS gint_t bli_info_get_thread_jrir_tlb( void );
+BLIS_EXPORT_BLIS gint_t bli_info_get_enable_tls( void );
 BLIS_EXPORT_BLIS gint_t bli_info_get_enable_memkind( void );
 BLIS_EXPORT_BLIS gint_t bli_info_get_enable_sandbox( void );
 

--- a/frame/include/bli_lang_defs.h
+++ b/frame/include/bli_lang_defs.h
@@ -73,7 +73,10 @@
 // doesn't support __thread, as __GNUC__ is not quite unique to GCC.
 // But the possibility of someone using such non-main-stream compiler
 // for building BLIS is low.
-#if defined(__GNUC__) || defined(__clang__) || defined(__ICC) || defined(__IBMC__)
+#if defined(BLIS_ENABLE_TLS) && ( defined(__GNUC__)  || \
+                                  defined(__clang__) || \
+                                  defined(__ICC)     || \
+                                  defined(__IBMC__) )
   #define BLIS_THREAD_LOCAL __thread
 #else
   #define BLIS_THREAD_LOCAL

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -867,6 +867,9 @@ void libblis_test_output_params_struct( FILE* os, test_params_t* params )
 	bli_rntm_set_ways_for_op( BLIS_TRSM, BLIS_LEFT,  m, n, k, &trsm_l );
 	bli_rntm_set_ways_for_op( BLIS_TRSM, BLIS_RIGHT, m, n, k, &trsm_r );
 
+	const bool tls_enabled = bli_info_get_enable_tls();
+	const bool thr_enabled = bli_info_get_enable_threading();
+
 	// Output some system parameters.
 	libblis_test_fprintf_c( os, "\n" );
 	libblis_test_fprintf_c( os, "--- BLIS library info -------------------------------------\n" );
@@ -915,6 +918,17 @@ void libblis_test_output_params_struct( FILE* os, test_params_t* params )
 	libblis_test_fprintf_c( os, "\n" );
 	libblis_test_fprintf_c( os, "\n" );
 	libblis_test_fprintf_c( os, "--- BLIS parallelization info ---\n" );
+	libblis_test_fprintf_c( os, "\n" );
+	libblis_test_fprintf_c( os, "thread-local storage (TLS)     %d\n", ( int )tls_enabled );
+	if ( !tls_enabled && thr_enabled )
+	{
+	libblis_test_fprintf_c( os, "\n" );
+	libblis_test_fprintf_c( os, "[WARNING] BLIS was compiled with TLS disabled. We assume you know what\n" );
+	libblis_test_fprintf_c( os, "[WARNING] you're doing! Multithreaded race conditions, correctness\n" );
+	libblis_test_fprintf_c( os, "[WARNING] issues, and deadlocks may occur. If any of these happen,\n" );
+	libblis_test_fprintf_c( os, "[WARNING] please consider reconfiguring with --disable-threading.\n" );
+
+	}
 	libblis_test_fprintf_c( os, "\n" );
 	libblis_test_fprintf_c( os, "multithreading modes           %s\n", impl_str );
 	libblis_test_fprintf_c( os, "  default mode                 %s\n", def_impl_unset_str );


### PR DESCRIPTION
Details:
- Implemented a new configure option, `--disable-tls`, which allows the user to optionally disable the use of thread-local storage qualifiers on `static` variables in BLIS. This option will rarely be needed, but in some situations may allow BLIS to compile when TLS is unavailable. Like the `--disable-system` option, `--disable-tls` forcibly disables threading (e.g. forcibly uses `--disable-threading`). Thanks to Nick Knight for suggesting this option.
- Modified `frame/include/bli_lang_defs.h` so that `BLIS_THREAD_LOCAL` is defined to nothing when `BLIS_ENABLE_TLS` is not defined.
- Edited `--disable-system` configure status output for clarity.

@nick-knight @hominhquan You may wish to discuss this feature since you both make use of a similar option, `--disable-system`. 🙂 