### PR TITLE
Add output.testsuite to .gitignore since it isn't matched by output.testsuite.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ include/*/*.h
 # -- misc. --
 
 # BLIS testsuite output file
+output.testsuite
 output.testsuite.*
 
 # BLAS test output files


### PR DESCRIPTION
Add `output.testsuite` to `.gitignore` since it isn't matched by `output.testsuite.*`. I accidentally added `output.testsuite` in a commit with `git add .` after a test run.