### PR TITLE
Move -fPIC insertion to subconfigs' make_defs.mk.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -731,9 +731,6 @@ $(foreach c, $(CONFIG_LIST_FAM), $(eval $(call append-var-for,CWARNFLAGS,$(c))))
 
 # --- Position-independent code flags (shared libraries only) ---
 
-
-ifeq ($(MK_ENABLE_SHARED),yes)
-
 # Note: Avoid -fPIC flags for Windows builds since all code is position-
 # independent.
 ifeq ($(IS_MSVC),yes)
@@ -742,6 +739,8 @@ endif
 $(foreach c, $(CONFIG_LIST_FAM), $(eval $(call store-var-for,CPICFLAGS,$(c))))
 
 # --- Symbol exporting flags (shared libraries only) ---
+
+ifeq ($(MK_ENABLE_SHARED),yes)
 
 # NOTE: These flags are only applied when building BLIS and not used by
 # applications that import BLIS compilation flags via the

--- a/common.mk
+++ b/common.mk
@@ -734,15 +734,12 @@ $(foreach c, $(CONFIG_LIST_FAM), $(eval $(call append-var-for,CWARNFLAGS,$(c))))
 
 ifeq ($(MK_ENABLE_SHARED),yes)
 
-# Emit position-independent code for dynamic linking.
-ifeq ($(IS_MSVC),yes)
-# Note: Don't use any fPIC flags for Windows builds since all code is position-
+# Note: Avoid -fPIC flags for Windows builds since all code is position-
 # independent.
+ifeq ($(IS_MSVC),yes)
 CPICFLAGS :=
-else
-CPICFLAGS := -fPIC
 endif
-$(foreach c, $(CONFIG_LIST_FAM), $(eval $(call append-var-for,CPICFLAGS,$(c))))
+$(foreach c, $(CONFIG_LIST_FAM), $(eval $(call store-var-for,CPICFLAGS,$(c))))
 
 # --- Symbol exporting flags (shared libraries only) ---
 

--- a/config/a64fx/make_defs.mk
+++ b/config/a64fx/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := a64fx
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE -D_A64FX
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/amd64/make_defs.mk
+++ b/config/amd64/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := amd64
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/amd64_legacy/make_defs.mk
+++ b/config/amd64_legacy/make_defs.mk
@@ -48,7 +48,7 @@ THIS_CONFIG    := amd64_legacy
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/arm32/make_defs.mk
+++ b/config/arm32/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := arm32
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     := -mfloat-abi=hard -mfpu=neon
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/arm64/make_defs.mk
+++ b/config/arm64/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := arm64
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/armsve/make_defs.mk
+++ b/config/armsve/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := armsve
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/bgq/make_defs.mk
+++ b/config/bgq/make_defs.mk
@@ -58,7 +58,7 @@ CMISCFLAGS     := -fopenmp
 else
 $(error xlc or bgclang is required for this configuration.)
 endif
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     := -w
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/bulldozer/make_defs.mk
+++ b/config/bulldozer/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := bulldozer
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/cortexa15/make_defs.mk
+++ b/config/cortexa15/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := cortexa15
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     := -mfloat-abi=hard -mfpu=neon
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/cortexa53/make_defs.mk
+++ b/config/cortexa53/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := cortexa53
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/cortexa57/make_defs.mk
+++ b/config/cortexa57/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := cortexa57
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/cortexa9/make_defs.mk
+++ b/config/cortexa9/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := cortexa9
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     := -mfloat-abi=hard -mfpu=neon
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/excavator/make_defs.mk
+++ b/config/excavator/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := excavator
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/firestorm/make_defs.mk
+++ b/config/firestorm/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := firestorm
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/generic/make_defs.mk
+++ b/config/generic/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := generic
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/haswell/make_defs.mk
+++ b/config/haswell/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := haswell
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/intel64/make_defs.mk
+++ b/config/intel64/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := intel64
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/knc/make_defs.mk
+++ b/config/knc/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := knc
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     := -mmic -fasm-blocks
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/knl/make_defs.mk
+++ b/config/knl/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := knl
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/old/haswellbb/make_defs.mk
+++ b/config/old/haswellbb/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := haswell
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/old/pnacl/make_defs.mk
+++ b/config/old/pnacl/make_defs.mk
@@ -49,7 +49,7 @@ CC_VENDOR      := pnacl-clang
 # NOTE: This is needed to enable posix_memalign().
 CPPROCFLAGS    := -D_POSIX_C_SOURCE=200112L
 CMISCFLAGS     := -std=gnu11 -I$(NACL_SDK_ROOT)/include
-CPICFLAGS      := 
+CPICFLAGS      := -fPIC
 CDBGFLAGS      := -g
 CWARNFLAGS     := -Wall -Wno-unused-function -Wfatal-errors
 COPTFLAGS      := -O3

--- a/config/penryn/make_defs.mk
+++ b/config/penryn/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := penryn
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/piledriver/make_defs.mk
+++ b/config/piledriver/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := piledriver
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/power/make_defs.mk
+++ b/config/power/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := power
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/power10/make_defs.mk
+++ b/config/power10/make_defs.mk
@@ -48,7 +48,7 @@ THIS_CONFIG    := power10
 # may specify additional flags here as needed.
 CPPROCFLAGS    := 
 CMISCFLAGS     :=  
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/power7/make_defs.mk
+++ b/config/power7/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := power7
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     := -mcpu=power7
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/power9/make_defs.mk
+++ b/config/power9/make_defs.mk
@@ -48,7 +48,7 @@ THIS_CONFIG    := power9
 # may specify additional flags here as needed.
 CPPROCFLAGS    := 
 CMISCFLAGS     :=  
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/sandybridge/make_defs.mk
+++ b/config/sandybridge/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := sandybridge
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/skx/make_defs.mk
+++ b/config/skx/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := skx
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/steamroller/make_defs.mk
+++ b/config/steamroller/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := steamroller
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/template/make_defs.mk
+++ b/config/template/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := template
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/thunderx2/make_defs.mk
+++ b/config/thunderx2/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := thunderx2
 # may specify additional flags here as needed.
 CPPROCFLAGS    := -D_GNU_SOURCE
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/x86_64/make_defs.mk
+++ b/config/x86_64/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := x86_64
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/zen/amd_config.mk
+++ b/config/zen/amd_config.mk
@@ -39,7 +39,7 @@
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/zen/make_defs.mk
+++ b/config/zen/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := zen
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/zen2/make_defs.mk
+++ b/config/zen2/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := zen2
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/zen3/make_defs.mk
+++ b/config/zen3/make_defs.mk
@@ -47,7 +47,7 @@ THIS_CONFIG    := zen3
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)

--- a/config/zen3/make_defs.mk.old
+++ b/config/zen3/make_defs.mk.old
@@ -50,7 +50,7 @@ THIS_CONFIG    := zen3
 # may specify additional flags here as needed.
 CPPROCFLAGS    :=
 CMISCFLAGS     :=
-CPICFLAGS      :=
+CPICFLAGS      := -fPIC
 CWARNFLAGS     :=
 
 ifneq ($(DEBUG_TYPE),off)


### PR DESCRIPTION
Details:
- Previously, `common.mk` was appending `-fPIC` to the `CPICFLAGS` variables set within the various subconfigurations' `make_defs.mk` files. This seemed somewhat unintuitive, and so now the `-fPIC` flag is assigned to the various subconfigs' `CPICFLAGS` variables in the respective `make_defs.mk` files.
- This also commit changes the logic in `common.mk` so that instead of appending, the variable is overwritten, but now *only* in the case of Windows (since apparently `-fPIC` needs to be omitted there). Thanks to Nick Knight for catching and reporting this weirdness.

@nick-knight