### PR TITLE
Fix enablement of 1m for syrk and friends in the testsuite

### DIFF
--- a/frame/3/bli_l3_ind.c
+++ b/frame/3/bli_l3_ind.c
@@ -201,6 +201,18 @@ void bli_l3_ind_oper_set_enable( opid_t oper, ind_t method, num_t dt, bool statu
 	if ( !bli_is_complex( dt ) ) return;
 	if ( !bli_opid_is_level3( oper ) ) return;
 
+	// BLIS currently implements herk/her2k/syrk/syr2k in terms of the user-
+	// level gemmt (expert) API, and so those operations choose to execute
+	// 1m (or not) based on the induced method enablement status of gemmt.
+	// In other words, changing the enablement status of those operations
+	// would have no effect. Therefore, we redirect queries/accesses to those
+	// operations' induced method enablement statuses to that of gemmt.
+	if ( method != BLIS_NAT && ( oper == BLIS_HERK  ||
+	                             oper == BLIS_HER2K ||
+	                             oper == BLIS_SYRK  ||
+	                             oper == BLIS_SYR2K ) )
+		oper = BLIS_GEMMT;
+
 	// Disallow changing status of native execution.
 	if ( method == BLIS_NAT ) return;
 
@@ -223,6 +235,18 @@ bool bli_l3_ind_oper_get_enable( opid_t oper, ind_t method, num_t dt )
 {
 	num_t idt = bli_ind_map_cdt_to_index( dt );
 	bool  r_val;
+
+	// BLIS currently implements herk/her2k/syrk/syr2k in terms of the user-
+	// level gemmt (expert) API, and so those operations choose to execute
+	// 1m (or not) based on the induced method enablement status of gemmt.
+	// In other words, changing the enablement status of those operations
+	// would have no effect. Therefore, we redirect queries/accesses to those
+	// operations' induced method enablement statuses to that of gemmt.
+	if ( method != BLIS_NAT && ( oper == BLIS_HERK  ||
+	                             oper == BLIS_HER2K ||
+	                             oper == BLIS_SYRK  ||
+	                             oper == BLIS_SYR2K ) )
+		oper = BLIS_GEMMT;
 
 	{
 		r_val = bli_l3_ind_oper_st[ method ][ oper ][ idt ];

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -2267,12 +2267,6 @@ void libblis_test_op_driver
 
 				bli_ind_oper_enable_only( op->opid, indi, datatype );
 
-				if ( op->opid == BLIS_SYRK || op->opid == BLIS_SYR2K ||
-				     op->opid == BLIS_HERK || op->opid == BLIS_HER2K )
-				{
-					bli_ind_oper_enable_only( BLIS_GEMMT, indi, datatype );
-				}
-
 				// Query the implementation string associated with the
 				// current operation and datatype. If the operation is
 				// not level-3, we will always get back the native string.
@@ -2399,12 +2393,6 @@ void libblis_test_op_driver
 						// the thread executed or skipped the current experiment).
 						tdata->xc += 1;
 					}
-				}
-
-				if ( op->opid == BLIS_SYRK || op->opid == BLIS_SYR2K ||
-				     op->opid == BLIS_HERK || op->opid == BLIS_HER2K )
-				{
-					bli_l3_ind_oper_set_enable( BLIS_GEMMT, indi, datatype, false );
 				}
 			}
 

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -2267,6 +2267,12 @@ void libblis_test_op_driver
 
 				bli_ind_oper_enable_only( op->opid, indi, datatype );
 
+				if ( op->opid == BLIS_SYRK || op->opid == BLIS_SYR2K ||
+				     op->opid == BLIS_HERK || op->opid == BLIS_HER2K )
+				{
+					bli_ind_oper_enable_only( BLIS_GEMMT, indi, datatype );
+				}
+
 				// Query the implementation string associated with the
 				// current operation and datatype. If the operation is
 				// not level-3, we will always get back the native string.
@@ -2393,6 +2399,12 @@ void libblis_test_op_driver
 						// the thread executed or skipped the current experiment).
 						tdata->xc += 1;
 					}
+				}
+
+				if ( op->opid == BLIS_SYRK || op->opid == BLIS_SYR2K ||
+				     op->opid == BLIS_HERK || op->opid == BLIS_HER2K )
+				{
+					bli_l3_ind_oper_set_enable( BLIS_GEMMT, indi, datatype, false );
 				}
 			}
 


### PR DESCRIPTION
Because (sy|he)r2?k are implemented in terms of gemmt, the testsuite doesn't actually turn on 1m for these operations by enabling induced methods for the corresponding operation ID. This commit provides a somewhat hackish workaround.

Alternatively, it seems like it wouldn't be harmful to just enable the induced method for all operations while testing.