### PR TITLE
Fix one error in doc and some minor typos in comments

### DIFF
--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -433,7 +433,7 @@ Return the storage datatype property of `obj`.
 ---
 
 ```c
-dom_t bli_obj_dom( obj_t* obj );
+dom_t bli_obj_domain( obj_t* obj );
 ```
 Return the domain component of the storage datatype property of `obj`.
 

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -764,7 +764,7 @@ void bli_axpbyv
        obj_t*  x,
        obj_t*  beta,
        obj_t*  y
-     )
+     );
 ```
 Perform
 ```
@@ -991,7 +991,7 @@ void bli_xpbyv
        obj_t*  x,
        obj_t*  beta,
        obj_t*  y
-     )
+     );
 ```
 Perform
 ```
@@ -2187,7 +2187,7 @@ void bli_getsc
        obj_t*  chi,
        double* zeta_r,
        double* zeta_i
-     )
+     );
 ```
 Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and `zeta_i`. If `chi` is stored as a real type, then `zeta_i` is set to zero. (If `chi` is stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -85,57 +85,57 @@ The following tables list various types used throughout the BLIS object API.
 
 ### Floating-point types
 
-| BLIS fp type      | Type definition                        | Used to represent...                 |
-|:------------------|:---------------------------------------|:-------------------------------------|
-| `float`           | _N/A_                                  | single-precision real numbers        |
-| `double`          | _N/A_                                  | double-precision real numbers        |
-| `scomplex`        | `struct { float real; float imag; }`   | single-precision complex numbers     |
-| `dcomplex`        | `struct { double real; double imag; }` | double-precision complex numbers     |
+| BLIS fp type      | Type definition                        | Used to represent...              |
+|:------------------|:---------------------------------------|:----------------------------------|
+| `float`           | _N/A_                                  | single-precision real numbers.    |
+| `double`          | _N/A_                                  | double-precision real numbers.    |
+| `scomplex`        | `struct { float real; float imag; }`   | single-precision complex numbers. |
+| `dcomplex`        | `struct { double real; double imag; }` | double-precision complex numbers. |
 
 ### Enumerated parameter types
 
-| `num_t`         | Semantic meaning: Matrix/vector operand...              |
-|:----------------|:--------------------------------------------------------|
-| `BLIS_FLOAT`    | contains single-precision real elements.                |
-| `BLIS_DOUBLE`   | contains double-precision real elements.                |
-| `BLIS_SCOMPLEX` | contains single-precision complex elements.             |
-| `BLIS_DCOMPLEX` | contains double-precision complex elements.             |
-| `BLIS_INT`      | contains integer elements of type `gint_t`.             |
-| `BLIS_CONSTANT` | contains polymorphic representation of a constant value |
+| `num_t`         | Semantic meaning: Matrix/vector operand...               |
+|:----------------|:---------------------------------------------------------|
+| `BLIS_FLOAT`    | contains single-precision real elements.                 |
+| `BLIS_DOUBLE`   | contains double-precision real elements.                 |
+| `BLIS_SCOMPLEX` | contains single-precision complex elements.              |
+| `BLIS_DCOMPLEX` | contains double-precision complex elements.              |
+| `BLIS_INT`      | contains integer elements of type `gint_t`.              |
+| `BLIS_CONSTANT` | contains polymorphic representation of a constant value. |
 
-| `dom_t`         | Semantic meaning: Matrix/vector operand...  |
-|:----------------|:--------------------------------------------|
-| `BLIS_REAL`     | contains real domain elements.              |
-| `BLIS_COMPLEX`  | contains complex domain elements.           |
+| `dom_t`         | Semantic meaning: Matrix/vector operand... |
+|:----------------|:-------------------------------------------|
+| `BLIS_REAL`     | contains real domain elements.             |
+| `BLIS_COMPLEX`  | contains complex domain elements.          |
 
-| `prec_t`           | Semantic meaning: Matrix/vector operand...  |
-|:-------------------|:--------------------------------------------|
-| `BLIS_SINGLE_PREC` | contains single-precision elements.         |
-| `BLIS_DOUBLE_PREC` | contains double-precision elements.         |
+| `prec_t`           | Semantic meaning: Matrix/vector operand... |
+|:-------------------|:-------------------------------------------|
+| `BLIS_SINGLE_PREC` | contains single-precision elements.        |
+| `BLIS_DOUBLE_PREC` | contains double-precision elements.        |
 
-| `trans_t`                | Semantic meaning: Matrix operand ...              |
-|:-------------------------|:--------------------------------------------------|
-| `BLIS_NO_TRANSPOSE`      | will be used as given.                            |
-| `BLIS_TRANSPOSE`         | will be implicitly transposed.                    |
-| `BLIS_CONJ_NO_TRANSPOSE` | will be implicitly conjugated.                    |
-| `BLIS_CONJ_TRANSPOSE`    | will be implicitly transposed _and_ conjugated.   |
+| `trans_t`                | Semantic meaning: Matrix operand ...            |
+|:-------------------------|:------------------------------------------------|
+| `BLIS_NO_TRANSPOSE`      | will be used as given.                          |
+| `BLIS_TRANSPOSE`         | will be implicitly transposed.                  |
+| `BLIS_CONJ_NO_TRANSPOSE` | will be implicitly conjugated.                  |
+| `BLIS_CONJ_TRANSPOSE`    | will be implicitly transposed _and_ conjugated. |
 
-| `conj_t`             | Semantic meaning: Matrix/vector operand...               |
-|:---------------------|:---------------------------------------------------------|
-| `BLIS_NO_CONJUGATE`  | will be used as given.                                   |
-| `BLIS_CONJUGATE`     | will be implicitly conjugated.                           |
+| `conj_t`             | Semantic meaning: Matrix/vector operand... |
+|:---------------------|:-------------------------------------------|
+| `BLIS_NO_CONJUGATE`  | will be used as given.                     |
+| `BLIS_CONJUGATE`     | will be implicitly conjugated.             |
 
-| `side_t`     | Semantic meaning: Matrix operand...                |
-|:-------------|:---------------------------------------------------|
-| `BLIS_LEFT`  | appears on the left.                               |
-| `BLIS_RIGHT` | appears on the right.                              |
+| `side_t`     | Semantic meaning: Matrix operand... |
+|:-------------|:------------------------------------|
+| `BLIS_LEFT`  | appears on the left.                |
+| `BLIS_RIGHT` | appears on the right.               |
 
-| `struc_t`         | Semantic meaning: Matrix operand...                               |
-|:------------------|:------------------------------------------------------------------|
-| `BLIS_GENERAL`    | has no structure.                                                 |
-| `BLIS_HERMITIAN`  | has Hermitian structure.                                          |
-| `BLIS_SYMMETRIC`  | has symmetric structure.                                          |
-| `BLIS_TRIANGULAR` | has triangular structure.                                         |
+| `struc_t`         | Semantic meaning: Matrix operand... |
+|:------------------|:------------------------------------|
+| `BLIS_GENERAL`    | has no structure.                   |
+| `BLIS_HERMITIAN`  | has Hermitian structure.            |
+| `BLIS_SYMMETRIC`  | has symmetric structure.            |
+| `BLIS_TRIANGULAR` | has triangular structure.           |
 
 | `uplo_t`     | Semantic meaning: Matrix operand...                               |
 |:-------------|:------------------------------------------------------------------|

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -287,7 +287,7 @@ void bli_?axpbyv
        ctype*  x, inc_t incx,
        ctype*  beta,
        ctype*  y, inc_t incy
-     )
+     );
 ```
 Perform
 ```
@@ -482,7 +482,7 @@ void bli_?xpbyv
        ctype*  x, inc_t incx,
        ctype*  beta,
        ctype*  y, inc_t incy
-     )
+     );
 ```
 Perform
 ```
@@ -1756,7 +1756,7 @@ void bli_getsc
        ctype*  chi,
        double* zeta_r,
        double* zeta_i
-     )
+     );
 ```
 Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and `zeta_i`. If `chi` is stored as a real type, then `zeta_i` is set to zero. (If `chi` is stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 
@@ -1770,7 +1770,7 @@ err_t bli_?getijv
        ctype*  x, incx,
        double* ar,
        double* ai
-     )
+     );
 ```
 Copy the real and imaginary values at the `i`th element of vector `x` to `ar` and `ai`. For real domain invocations, only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 Note that the object-based analogue of [getijv](BLISObjectAPI.md#getijv) does bounds checking of the vector element offset `i` against the vector length while the typed functions specified above do not (since the vector length is not given).
@@ -1786,7 +1786,7 @@ err_t bli_?getijm
        ctype*  b, inc_t rs_b, inc_t cs_b,
        double* ar,
        double* ai
-     )
+     );
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. For real domain invocations, only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 Note that the object-based analogue of [getijm](BLISObjectAPI.md#getijm) does bounds checking of the matrix element offsets (`i`,`j`) against the matrix dimensions while the typed functions specified above do not (since the matrix dimensions are not given).
@@ -1881,7 +1881,7 @@ void bli_?eqm
        ctype*  a, inc_t rs_a, inc_t cs_a,
        ctype*  b, inc_t rs_b, inc_t cs_b,
        bool*   is_eq
-     )
+     );
 ```
 Perform an element-wise comparison between matrices `A` and `B` and store the boolean result in the `bool` pointed to by `is_eq`.
 Here, `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or upper-triangular/trapezoidal matrix with arbitrary diagonal offset and unit or non-unit diagonal.

--- a/examples/oapi/06level1m.c
+++ b/examples/oapi/06level1m.c
@@ -169,7 +169,7 @@ int main( int argc, char** argv )
 	//bli_obj_apply_trans( trans, &e );
 
 	// Copy 'e' to 'f', transposing 'e' in the process. Notice that we haven't
-	// modified any properties of 'd'. It's the source operand that matters
+	// modified any properties of 'f'. It's the source operand that matters
 	// when marking an operand for transposition, not the destination.
 	bli_copym( &e, &f );
 

--- a/examples/oapi/10util.c
+++ b/examples/oapi/10util.c
@@ -115,7 +115,7 @@ int main( int argc, char** argv )
 
 	bli_printm( "a:", &a, "%4.1f", "" );
 
-	// Compute the one-norm of 'a'.
+	// Compute the one, infinity, and frobenius norms of 'a'.
 	bli_norm1m( &a, &norm1 );
 	bli_normim( &a, &normi );
 	bli_normfm( &a, &normf );

--- a/examples/tapi/01level1m.c
+++ b/examples/tapi/01level1m.c
@@ -171,7 +171,7 @@ int main( int argc, char** argv )
 
 
 	// Copy 'e' to 'f', transposing 'e' in the process. Notice that we haven't
-	// modified any properties of 'd'. It's the source operand that matters
+	// modified any properties of 'f'. It's the source operand that matters
 	// when marking an operand for transposition, not the destination.
 	bli_dcopym( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_TRANSPOSE,
 	            n, m, e, rs, cs, f, rsf, csf );


### PR DESCRIPTION
1. docs/BLISObjectAPI.md : a function bli_obj_dom() doesn't exist, replaced by bli_obj_domain() .
2. docs/BLIS*API.md : minor formatting unification.
3. examples/?api/*.c : it seems like there are a few typos there, but I could be wrong.