### PR TITLE
Set thrcomm timpl_t id inside init functions.

### DIFF
--- a/frame/thread/bli_thrcomm.c
+++ b/frame/thread/bli_thrcomm.c
@@ -149,10 +149,9 @@ void bli_thrcomm_init( timpl_t ti, dim_t nt, thrcomm_t* comm )
 	// Call the threading-specific init function.
 	fp( nt, comm );
 
-	// Embed the type of threading implementation within the thrcomm_t struct.
-	// Note that we wait until after the init function has returned in case
-	// that function zeros out the entire struct before setting the fields.
-	comm->ti = ti;
+	// NOTE: The init function that just returned intrinsically knows its
+	// timpl_t value, thus is able to set that value without us explicitly
+	// passing it in.
 }
 
 void bli_thrcomm_cleanup( thrcomm_t* comm )

--- a/frame/thread/bli_thrcomm_hpx.cpp
+++ b/frame/thread/bli_thrcomm_hpx.cpp
@@ -46,12 +46,20 @@ extern "C" {
 void bli_thrcomm_init_hpx( dim_t n_threads, thrcomm_t* comm )
 {
 	if ( comm == nullptr ) return;
+
+	//comm->sent_object             = nullptr;
+	//comm->n_threads               = n_threads;
+	comm->ti                      = BLIS_HPX;
+	//comm->barrier_sense           = 0;
+	//comm->barrier_threads_arrived = 0;
+
 	comm->barrier = new hpx:barrier<>();
 }
 
 void bli_thrcomm_cleanup_hpx( thrcomm_t* comm )
 {
 	if ( comm == nullptr ) return;
+
 	delete comm->barrier;
 }
 
@@ -69,9 +77,11 @@ void bli_thrcomm_barrier( dim_t t_id, thrcomm_t* comm )
 void bli_thrcomm_init_hpx( dim_t n_threads, thrcomm_t* comm )
 {
 	if ( comm == nullptr ) return;
-	comm->sent_object = nullptr;
-	comm->n_threads = n_threads;
-	comm->barrier_sense = 0;
+
+	comm->sent_object             = nullptr;
+	comm->n_threads               = n_threads;
+	comm->ti                      = BLIS_HPX;
+	comm->barrier_sense           = 0;
 	comm->barrier_threads_arrived = 0;
 }
 

--- a/frame/thread/bli_thrcomm_pthreads.c
+++ b/frame/thread/bli_thrcomm_pthreads.c
@@ -45,14 +45,20 @@
 void bli_thrcomm_init_pthreads( dim_t n_threads, thrcomm_t* comm )
 {
 	if ( comm == NULL ) return;
-	comm->sent_object = NULL;
-	comm->n_threads = n_threads;
+
+	comm->sent_object             = NULL;
+	comm->n_threads               = n_threads;
+	comm->ti                      = BLIS_POSIX;
+	//comm->barrier_sense           = 0;
+	//comm->barrier_threads_arrived = 0;
+
 	bli_pthread_barrier_init( &comm->barrier, NULL, n_threads );
 }
 
 void bli_thrcomm_cleanup_pthreads( thrcomm_t* comm )
 {
 	if ( comm == NULL ) return;
+
 	bli_pthread_barrier_destroy( &comm->barrier );
 }
 
@@ -70,36 +76,21 @@ void bli_thrcomm_barrier( dim_t t_id, thrcomm_t* comm )
 void bli_thrcomm_init_pthreads( dim_t n_threads, thrcomm_t* comm )
 {
 	if ( comm == NULL ) return;
-	comm->sent_object = NULL;
-	comm->n_threads = n_threads;
-	comm->barrier_sense = 0;
+
+	comm->sent_object             = NULL;
+	comm->n_threads               = n_threads;
+	comm->ti                      = BLIS_POSIX;
+	comm->barrier_sense           = 0;
 	comm->barrier_threads_arrived = 0;
 }
 
 void bli_thrcomm_cleanup_pthreads( thrcomm_t* comm )
 {
+	return;
 }
 
 void bli_thrcomm_barrier_pthreads( dim_t t_id, thrcomm_t* comm )
 {
-#if 0
-	if ( comm == NULL || comm->n_threads == 1 ) return;
-	bool  my_sense = comm->sense;
-	dim_t my_threads_arrived;
-
-	my_threads_arrived = __sync_add_and_fetch(&(comm->threads_arrived), 1);
-
-	if ( my_threads_arrived == comm->n_threads )
-	{
-		comm->threads_arrived = 0;
-		comm->sense = !comm->sense;
-	}
-	else
-	{
-		volatile bool* listener = &comm->sense;
-		while( *listener == my_sense ) {}
-	}
-#endif
 	bli_thrcomm_barrier_atomic( t_id, comm );
 }
 

--- a/frame/thread/bli_thrcomm_single.c
+++ b/frame/thread/bli_thrcomm_single.c
@@ -41,6 +41,7 @@ void bli_thrcomm_init_single( dim_t n_threads, thrcomm_t* comm )
 
 	comm->sent_object             = NULL;
 	comm->n_threads               = n_threads;
+	comm->ti                      = BLIS_SINGLE;
 	comm->barrier_sense           = 0;
 	comm->barrier_threads_arrived = 0;
 }


### PR DESCRIPTION
Details:
- Previously, the `timpl_t` id being used when a `thrcomm_t` is being initialized was set within the `bli_thrcomm_init()` dispatch function after the `timpl_t`-specific `bli_thrcomm_init_*()` function returned. But it just occurred to me that each `bli_thrcomm_init_*()` function already intrinsically knows its own `timpl_t` value. This commit shifts the setting of the `thrcomm_t.ti` field into the corresponding `bli_thrcomm_init_*()` function for each `timpl_t` type (e.g. single, openmp, pthreads, hpx).
- Removed long-deprecated code dating back nearly 10 years.
- Whitespace changes
- Comment updates.