### PR TITLE
Revamped bli_init() to use TLS where feasible.

### DIFF
--- a/docs/Multithreading.md
+++ b/docs/Multithreading.md
@@ -205,6 +205,8 @@ If you still wish to set the parallelization scheme globally, but you want to do
 
 **Note**: Regardless of which way ([automatic](Multithreading.md#globally-at-runtime-the-automatic-way) or [manual](Multithreading.md#globally-at-runtime-the-manual-way)) the global runtime API is used to specify multithreading, that specification will affect operation of BLIS through **both** the BLAS compatibility layer as well as the native ([typed](docs/BLISTypedAPI.md) and [object](docs/BLISObjectAPI.md)) APIs that are unique to BLIS.
 
+If BLIS is being used by two or more application-level threads, each of those application threads will track their own global state for the purpose of specifying parallelism. We felt this makes sense because each application thread may wish to specify a different parallelization scheme without affecting the scheme for he other application thread(s).
+
 ### Globally at runtime: the automatic way
 
 If you simply want to specify an overall number of threads and let BLIS choose a thread factorization automatically, use the following function:
@@ -280,10 +282,6 @@ You **must** initialize the `rntm_t`. This can be done in either of two ways.
 If you want to initialize it as part of the declaration, you may do so via the default `BLIS_RNTM_INITIALIZER` macro:
 ```c
 rntm_t rntm = BLIS_RNTM_INITIALIZER;
-```
-Alternatively, you can perform the same initialization by passing the address of the `rntm_t` to an initialization function:
-```c
-bli_rntm_init( &rntm );
 ```
 As of this writing, BLIS treats a default-initialized `rntm_t` as a request for single-threaded execution.
 

--- a/docs/Multithreading.md
+++ b/docs/Multithreading.md
@@ -205,7 +205,7 @@ If you still wish to set the parallelization scheme globally, but you want to do
 
 **Note**: Regardless of which way ([automatic](Multithreading.md#globally-at-runtime-the-automatic-way) or [manual](Multithreading.md#globally-at-runtime-the-manual-way)) the global runtime API is used to specify multithreading, that specification will affect operation of BLIS through **both** the BLAS compatibility layer as well as the native ([typed](docs/BLISTypedAPI.md) and [object](docs/BLISObjectAPI.md)) APIs that are unique to BLIS.
 
-If BLIS is being used by two or more application-level threads, each of those application threads will track their own global state for the purpose of specifying parallelism. We felt this makes sense because each application thread may wish to specify a different parallelization scheme without affecting the scheme for he other application thread(s).
+If BLIS is being used by two or more application-level threads, each of those application threads will track their own global state for the purpose of specifying parallelism. We felt this makes sense because each application thread may wish to specify a different parallelization scheme without affecting the scheme for the other application thread(s).
 
 ### Globally at runtime: the automatic way
 

--- a/frame/3/bli_l3_ind.c
+++ b/frame/3/bli_l3_ind.c
@@ -36,7 +36,7 @@
 #include "blis.h"
 
 // This array tracks whether a particular operation is implemented for each of
-// the induced methods.
+// the induced methods. This array is meant to be read-only.
 static bool bli_l3_ind_oper_impl[BLIS_NUM_IND_METHODS][BLIS_NUM_LEVEL3_OPS] =
 {
         /*   gemm  gemmt  hemm  herk  her2k  symm  syrk  syr2k  trmm3  trmm  trsm  */
@@ -63,6 +63,11 @@ bool bli_l3_ind_oper_st[BLIS_NUM_IND_METHODS][BLIS_NUM_LEVEL3_OPS][2] =
 /* nat  */ { {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE},
              {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE},   {TRUE,TRUE}    },
 };
+
+// A mutex to allow synchronous access to the bli_l3_ind_oper_st array.
+#ifdef BLIS_DISABLE_TLS
+static bli_pthread_mutex_t oper_st_mutex = BLIS_PTHREAD_MUTEX_INITIALIZER;
+#endif
 
 // -----------------------------------------------------------------------------
 
@@ -191,9 +196,6 @@ void bli_l3_ind_oper_set_enable_all( opid_t oper, num_t dt, bool status )
 
 // -----------------------------------------------------------------------------
 
-// A mutex to allow synchronous access to the bli_l3_ind_oper_st array.
-static bli_pthread_mutex_t oper_st_mutex = BLIS_PTHREAD_MUTEX_INITIALIZER;
-
 void bli_l3_ind_oper_set_enable( opid_t oper, ind_t method, num_t dt, bool status )
 {
 	num_t idt;
@@ -218,8 +220,11 @@ void bli_l3_ind_oper_set_enable( opid_t oper, ind_t method, num_t dt, bool statu
 
 	idt = bli_ind_map_cdt_to_index( dt );
 
-	// Acquire the mutex protecting bli_l3_ind_oper_st.
+	// If TLS is disabled, we need to use a mutex to protect the status array
+	// since it will be shared with all application threads.
+	#ifdef BLIS_DISABLE_TLS
 	bli_pthread_mutex_lock( &oper_st_mutex );
+	#endif
 
 	// BEGIN CRITICAL SECTION
 	{
@@ -227,8 +232,9 @@ void bli_l3_ind_oper_set_enable( opid_t oper, ind_t method, num_t dt, bool statu
 	}
 	// END CRITICAL SECTION
 
-	// Release the mutex protecting bli_l3_ind_oper_st.
+	#ifdef BLIS_DISABLE_TLS
 	bli_pthread_mutex_unlock( &oper_st_mutex );
+	#endif
 }
 
 bool bli_l3_ind_oper_get_enable( opid_t oper, ind_t method, num_t dt )

--- a/frame/3/bli_l3_ind.c
+++ b/frame/3/bli_l3_ind.c
@@ -37,7 +37,7 @@
 
 // This array tracks whether a particular operation is implemented for each of
 // the induced methods. This array is meant to be read-only.
-static bool bli_l3_ind_oper_impl[BLIS_NUM_IND_METHODS][BLIS_NUM_LEVEL3_OPS] =
+static const bool bli_l3_ind_oper_impl[BLIS_NUM_IND_METHODS][BLIS_NUM_LEVEL3_OPS] =
 {
         /*   gemm  gemmt  hemm  herk  her2k  symm  syrk  syr2k  trmm3  trmm  trsm  */
 /* 1m   */ { TRUE, TRUE,  TRUE, TRUE, TRUE,  TRUE, TRUE, TRUE,  TRUE,  TRUE, TRUE  },

--- a/frame/base/bli_gks.h
+++ b/frame/base/bli_gks.h
@@ -35,8 +35,8 @@
 #ifndef BLIS_GKS_H
 #define BLIS_GKS_H
 
-void                           bli_gks_init( void );
-void                           bli_gks_finalize( void );
+int                            bli_gks_init( void );
+int                            bli_gks_finalize( void );
 
 void                           bli_gks_init_index( void );
 

--- a/frame/base/bli_ind.c
+++ b/frame/base/bli_ind.c
@@ -42,8 +42,14 @@ static const char* bli_ind_impl_str[BLIS_NUM_IND_METHODS] =
 
 // -----------------------------------------------------------------------------
 
-void bli_ind_init( void )
+int bli_ind_init( void )
 {
+	// NOTE: If TLS is enabled, this function is called once by EACH application
+	// thread per library init/finalize cycle (see bli_init.c). In this case,
+	// the threads will initialize thread-local data (see bli_l3_ind.c). If TLS
+	// is disabled, this function is called once by ONLY ONE application thread.
+	// In neither case is a mutex needed to protect the data initialization.
+
 	// NOTE: We intentionally call bli_gks_query_nat_cntx_noinit() in order
 	// to avoid the internal call to bli_init_once().
 	const cntx_t* cntx = bli_gks_query_nat_cntx_noinit();
@@ -62,10 +68,13 @@ void bli_ind_init( void )
 
 	if ( c_is_ref && !s_is_ref ) bli_ind_enable_dt( BLIS_1M, BLIS_SCOMPLEX );
 	if ( z_is_ref && !d_is_ref ) bli_ind_enable_dt( BLIS_1M, BLIS_DCOMPLEX );
+
+	return 0;
 }
 
-void bli_ind_finalize( void )
+int bli_ind_finalize( void )
 {
+	return 0;
 }
 
 // -----------------------------------------------------------------------------

--- a/frame/base/bli_ind.h
+++ b/frame/base/bli_ind.h
@@ -38,8 +38,8 @@
 // level-3 induced method management
 #include "bli_l3_ind.h"
 
-void                         bli_ind_init( void );
-void                         bli_ind_finalize( void );
+int                          bli_ind_init( void );
+int                          bli_ind_finalize( void );
 
 BLIS_EXPORT_BLIS void        bli_ind_enable( ind_t method );
 BLIS_EXPORT_BLIS void        bli_ind_disable( ind_t method );

--- a/frame/base/bli_memsys.c
+++ b/frame/base/bli_memsys.c
@@ -36,8 +36,12 @@
 
 #include "blis.h"
 
-void bli_memsys_init( void )
+int bli_memsys_init( void )
 {
+	// NOTE: This function is called once by ONLY ONE application thread per
+	// library init/finalize cycle (see bli_init.c). Thus, a mutex is not
+	// needed to protect the data initialization.
+
 	// Query a native context so we have something to pass into
 	// bli_pba_init_pools().
 	// NOTE: We intentionally call bli_gks_query_nat_cntx_noinit() in order
@@ -49,14 +53,18 @@ void bli_memsys_init( void )
 
 	// Initialize the small block allocator and its data structures.
 	bli_sba_init();
+
+	return 0;
 }
 
-void bli_memsys_finalize( void )
+int bli_memsys_finalize( void )
 {
 	// Finalize the small block allocator and its data structures.
 	bli_sba_finalize();
 
 	// Finalize the packing block allocator and its data structures.
 	bli_pba_finalize();
+
+	return 0;
 }
 

--- a/frame/base/bli_memsys.h
+++ b/frame/base/bli_memsys.h
@@ -37,10 +37,8 @@
 #ifndef BLIS_MEMSYS_H
 #define BLIS_MEMSYS_H
 
-// -----------------------------------------------------------------------------
-
-void bli_memsys_init( void );
-void bli_memsys_finalize( void );
+int bli_memsys_init( void );
+int bli_memsys_finalize( void );
 
 
 #endif

--- a/frame/base/bli_pack.h
+++ b/frame/base/bli_pack.h
@@ -35,15 +35,10 @@
 #ifndef BLIS_PACK_H
 #define BLIS_PACK_H
 
-void  bli_pack_init( void );
-void  bli_pack_finalize( void );
-
 BLIS_EXPORT_BLIS void bli_pack_get_pack_a( bool* pack_a );
 BLIS_EXPORT_BLIS void bli_pack_get_pack_b( bool* pack_b );
 BLIS_EXPORT_BLIS void bli_pack_set_pack_a( bool pack_a );
 BLIS_EXPORT_BLIS void bli_pack_set_pack_b( bool pack_b );
-
-void  bli_pack_init_rntm_from_env( rntm_t* rntm );
 
 #endif
 

--- a/frame/base/bli_rntm.h
+++ b/frame/base/bli_rntm.h
@@ -267,7 +267,8 @@ BLIS_INLINE void bli_rntm_clear_l3_sup( rntm_t* rntm )
           .l3_sup      = TRUE, \
         }  \
 
-BLIS_INLINE void bli_rntm_init( rntm_t* rntm )
+#if 0
+//BLIS_INLINE void bli_rntm_clear( rntm_t* rntm )
 {
 	bli_rntm_clear_thread_impl( rntm );
 
@@ -279,6 +280,7 @@ BLIS_INLINE void bli_rntm_init( rntm_t* rntm )
 	bli_rntm_clear_pack_b( rntm );
 	bli_rntm_clear_l3_sup( rntm );
 }
+#endif
 
 //
 // -- rntm_t total thread calculation ------------------------------------------
@@ -303,6 +305,15 @@ BLIS_INLINE dim_t bli_rntm_calc_num_threads
 //
 // -- Function prototypes ------------------------------------------------------
 //
+
+rntm_t*              bli_global_rntm( void );
+rntm_t*              bli_global_rntm_at_init( void );
+bli_pthread_mutex_t* bli_global_rntm_mutex( void );
+
+int bli_rntm_init( void );
+int bli_rntm_finalize( void );
+
+void bli_rntm_init_from_env( rntm_t* rntm );
 
 BLIS_EXPORT_BLIS void bli_rntm_init_from_global( rntm_t* rntm );
 

--- a/frame/thread/bli_thread.h
+++ b/frame/thread/bli_thread.h
@@ -53,8 +53,8 @@ typedef void (*thread_func_t)( thrcomm_t* gl_comm, dim_t tid, const void* params
 #include "bli_thread_single.h"
 
 // Initialization-related prototypes.
-void bli_thread_init( void );
-void bli_thread_finalize( void );
+int bli_thread_init( void );
+int bli_thread_finalize( void );
 
 // -----------------------------------------------------------------------------
 
@@ -126,8 +126,7 @@ BLIS_EXPORT_BLIS const char* bli_thread_get_thread_impl_str( timpl_t ti );
 BLIS_EXPORT_BLIS void    bli_thread_set_ways( dim_t jc, dim_t pc, dim_t ic, dim_t jr, dim_t ir );
 BLIS_EXPORT_BLIS void    bli_thread_set_num_threads( dim_t value );
 BLIS_EXPORT_BLIS void    bli_thread_set_thread_impl( timpl_t ti );
-
-void                     bli_thread_init_rntm_from_env( rntm_t* rntm );
+BLIS_EXPORT_BLIS void    bli_thread_reset( void );
 
 
 #endif

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -2716,8 +2716,7 @@ thrinfo_t* libblis_test_pobj_create( bszid_t bmult_id_m, bszid_t bmult_id_n, inv
 	if ( inv_diag == BLIS_NO_INVERT_DIAG ) does_inv_diag = FALSE;
 	else                                   does_inv_diag = TRUE;
 
-	rntm_t rntm;
-	bli_rntm_init( &rntm );
+	rntm_t rntm = BLIS_RNTM_INITIALIZER;
 
 	// Create a control tree node for the packing operation.
 	cntl_t* cntl = bli_packm_cntl_create_node


### PR DESCRIPTION
Details:
- Revamped `bli_init_apis()` and `bli_finalize_apis()` to use separate `bli_pthread_switch_t` objects for each of the five sub-API init functions, with the objects for the 'ind' and 'rntm' sub-APIs being declared with `BLIS_THREAD_LOCAL`. This allows some APIs to be treated as thread-local and the rest as thread-shared. Thanks to Edward Smyth for requesting application thread-specific `rntm_t` structs, which inspired these change.
- Combined `bli_thread_init_from_env()` and `bli_pack_init_from_env()` into a new function, `bli_rntm_init_rntm_from_env()`, and placed the combined code in `bli_rntm.c` inside of a new `bli_rntm_init()` function. Then removed the (now empty) `bli_pack_init()` and `_finalize()` function defs.
- Deprecated `bli_rntm_init()` for the purposes of initializing a `rntm_t` (temporarily preserving it as cpp-undefined code as `bli_rntm_clear()`) so that the function name could be used for the aforementioned `bli_rntm_init()` function.
- Updated `libblis_test_pobj_create()` in `test_libblis.c` to use a static `rntm_t` initializer instead of the deprecated `bli_rntm_init()` function-based option.
- Minor updates to `docs/Multithreading.md`, including removal of `bli_rntm_init()` in the example of how to initialize `rntm_t` structs.
- Changed the return value of `bli_gks_init()`, `bli_ind_init()`, `bli_memsys_init()`, `bli_thread_init()`, and `bli_rntm_init()` (and their `_finalize()` counterparts) from `void` to `int` so that those functions match the function type expected by `bli_pthread_switch_on()`/`_off()`. Those init/finalize functions now return 0 to indicate success, which is needed so that the switch actually changes state from off to on and vice versa.
- Defined `bli_thread_reset()`, which copies the contents of the `global_rntm_at_init` struct into the `global_rntm` struct (for the current application thread).
- Guard calls to `bli_pthread_mutex_lock()`/`_unlock()` in
  - `bli_pack_set_pack_a() and _pack_b()`
  - `bli_rntm_init_from_global()`
  - `bli_thread_set_ways()`
  - `bli_thread_set_num_threads()`
  - `bli_thread_set_thread_impl()`
  - `bli_thread_reset()`
  - `bli_l3_ind_oper_set_enable()` with `#ifdef BLIS_DISABLE_TLS` (since TLS precludes the possibility of race conditions).
- In `frame/base/bli_rntm.c`, declare `global_rntm`, `global_rntm_at_init`, and `global_rntm_mutex` as `BLIS_THREAD_LOCAL` so that separate application threads can change the number of ways of BLIS parallelism independently from one another.
- Access `global_rntm` only via a new private (not exported) function, `bli_global_rntm()`. Defined a similar function for a `rntm_t` new to this commit, `global_rntm_at_init`, which preserves the state of the global rntm at initialization-time.
- In `frame/3/bli_l3_ind.c`, added a guard to the declaration of the static variable `oper_st_mutex` with `#ifdef BLIS_DISABLE_TLS` so that the mutex is omitted altogether when TLS is enabled (which prevents the compiler from warning about an unused variable).
- Removed redundant code from `bli_thread.c`:
   ```c
    #ifdef BLIS_ENABLE_HPX
    #include "bli_thread_hpx.h"
    #endif
   ```
  since this code is already present in `bli_thread.h`.
- Comment updates.

cc: @edwsmyth