### PR TITLE
Fixed error when using common.mk from testsuite.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -969,7 +969,8 @@ endif
 ifeq ($(OS_NAME),Linux)
 # Exclude -lrt on Android by detecting Bionic.
 # $(CC) -E bionic.h returns a "bionic" substring iff Bionic is detected.
-BIONIC := $(findstring bionic,$(shell $(CC) -E build/detect/android/bionic.h))
+BIONIC_H_PATH := $(DIST_PATH)/build/detect/android/bionic.h
+BIONIC := $(findstring bionic,$(shell $(CC) -E $(BIONIC_H_PATH)))
 ifeq (,$(BIONIC))
 LDFLAGS += -lrt
 endif


### PR DESCRIPTION
Details:
- Commit 2db31e0 (#755) inserted logic into `common.mk` that attempts to preprocess `build/detect/android/bionic.h` to determine whether the `__BIONIC__` macro is defined (in which case `-lrt` should not be included in `LDFLAGS`). However, the path to `bionic.h` was encoded without regard to `DIST_PATH`, and so utilizing `common.mk` anywhere that isn't the top-level directory (such as in the `testsuite` directory) resulted in a compiler error:
   ```
    gcc: error: build/detect/android/bionic.h: No such file or directory
    gcc: fatal error: no input files
    compilation terminated.
   ```
  This commit adds a `$(DIST_PATH)` prefix to the path to `bionic.h` so that it can be located from other applications' Makefiles that use BLIS without error.