### PR TITLE
Hpx fixes

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -129,6 +129,7 @@ but many others have contributed code, ideas, and feedback, including
   Benda Xu                 @heroxbd
   Guodong Xu               @docularxu                 (Linaro.org)
   RuQing Xu                @xrq-phys                  (The University of Tokyo)
+  Srinivas Yadav           @srinivasyadav18
   Costas Yamin             @cosstas
   Chenhan Yu               @ChenhanYu                 (The University of Texas at Austin)
   Roman Yurchak            @rth                       (Symerio)

--- a/frame/thread/bli_thread_hpx.cpp
+++ b/frame/thread/bli_thread_hpx.cpp
@@ -36,8 +36,9 @@
 
 #ifdef BLIS_ENABLE_HPX
 
-#include <hpx/parallel/algorithms/for_loop.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/hpx_start.hpp>
+#include <hpx/parallel/algorithms/for_loop.hpp>
 #include <hpx/runtime_local/run_as_hpx_thread.hpp>
 
 extern "C"
@@ -55,11 +56,12 @@ void bli_thread_launch_hpx
 	// Allocate a global communicator for the root thrinfo_t structures.
 	pool_t*    gl_comm_pool = nullptr;
 	thrcomm_t* gl_comm      = bli_thrcomm_create( ti, gl_comm_pool, n_threads );
-
 	hpx::threads::run_as_hpx_thread([&]()
 	{
+    hpx::execution::experimental::num_cores num_cores_(n_threads);
 		hpx::execution::static_chunk_size chunk_size_(1);
-		hpx::experimental::for_loop(hpx::execution::par.with(chunk_size_), 0, n_threads,
+		hpx::experimental::for_loop(
+      hpx::execution::par.with(num_cores_).with(chunk_size_), 0, n_threads,
 		[&gl_comm, &func, &params](const dim_t tid)
 		{
 			func( gl_comm, tid, params );

--- a/frame/thread/bli_thread_hpx.cpp
+++ b/frame/thread/bli_thread_hpx.cpp
@@ -36,10 +36,9 @@
 
 #ifdef BLIS_ENABLE_HPX
 
-#include <hpx/local/execution.hpp>
-#include <hpx/parallel/algorithms/for_each.hpp>
+#include <hpx/parallel/algorithms/for_loop.hpp>
 #include <hpx/hpx_start.hpp>
-
+#include <hpx/runtime_local/run_as_hpx_thread.hpp>
 extern "C"
 {
 
@@ -56,13 +55,15 @@ void bli_thread_launch_hpx
 	pool_t*    gl_comm_pool = nullptr;
 	thrcomm_t* gl_comm      = bli_thrcomm_create( ti, gl_comm_pool, n_threads );
 
-	auto irange = hpx::util::counting_shape(n_threads);
 
-	hpx::for_each(hpx::execution::par, hpx::util::begin(irange), hpx::util::end(irange),
-	[&gl_comm, &func, &params](const dim_t tid)
-	{
-		func( gl_comm, tid, params );
-	});
+  hpx::threads::run_as_hpx_thread([&](){
+    hpx::execution::static_chunk_size chunk_size_(1);
+    hpx::experimental::for_loop(hpx::execution::par.with(chunk_size_), 0, n_threads,
+    [&gl_comm, &func, &params](const dim_t tid)
+    {
+      func( gl_comm, tid, params );
+    });
+  });
 
 	// Free the global communicator, because the root thrinfo_t node
 	// never frees its communicator.
@@ -76,7 +77,7 @@ void bli_thread_initialize_hpx( int argc, char** argv )
 
 int bli_thread_finalize_hpx()
 {
-	hpx::apply([]() { hpx::finalize(); });
+	hpx::post([]() { hpx::finalize(); });
 	return hpx::stop();
 }
 

--- a/frame/thread/bli_thread_hpx.cpp
+++ b/frame/thread/bli_thread_hpx.cpp
@@ -39,6 +39,7 @@
 #include <hpx/parallel/algorithms/for_loop.hpp>
 #include <hpx/hpx_start.hpp>
 #include <hpx/runtime_local/run_as_hpx_thread.hpp>
+
 extern "C"
 {
 
@@ -55,15 +56,15 @@ void bli_thread_launch_hpx
 	pool_t*    gl_comm_pool = nullptr;
 	thrcomm_t* gl_comm      = bli_thrcomm_create( ti, gl_comm_pool, n_threads );
 
-
-  hpx::threads::run_as_hpx_thread([&](){
-    hpx::execution::static_chunk_size chunk_size_(1);
-    hpx::experimental::for_loop(hpx::execution::par.with(chunk_size_), 0, n_threads,
-    [&gl_comm, &func, &params](const dim_t tid)
-    {
-      func( gl_comm, tid, params );
-    });
-  });
+	hpx::threads::run_as_hpx_thread([&]()
+	{
+		hpx::execution::static_chunk_size chunk_size_(1);
+		hpx::experimental::for_loop(hpx::execution::par.with(chunk_size_), 0, n_threads,
+		[&gl_comm, &func, &params](const dim_t tid)
+		{
+			func( gl_comm, tid, params );
+		});
+	});
 
 	// Free the global communicator, because the root thrinfo_t node
 	// never frees its communicator.

--- a/frame/thread/bli_thread_hpx.cpp
+++ b/frame/thread/bli_thread_hpx.cpp
@@ -58,10 +58,10 @@ void bli_thread_launch_hpx
 	thrcomm_t* gl_comm      = bli_thrcomm_create( ti, gl_comm_pool, n_threads );
 	hpx::threads::run_as_hpx_thread([&]()
 	{
-    hpx::execution::experimental::num_cores num_cores_(n_threads);
+		hpx::execution::experimental::num_cores num_cores_(n_threads);
 		hpx::execution::static_chunk_size chunk_size_(1);
 		hpx::experimental::for_loop(
-      hpx::execution::par.with(num_cores_).with(chunk_size_), 0, n_threads,
+		hpx::execution::par.with(num_cores_).with(chunk_size_), 0, n_threads,
 		[&gl_comm, &func, &params](const dim_t tid)
 		{
 			func( gl_comm, tid, params );

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -137,7 +137,7 @@ void libblis_test_thread_decorator( test_params_t* params, test_ops_t* ops )
 #ifdef BLIS_ENABLE_HPX
 	size_t nt = ( size_t )params->n_app_threads;
 
-	size_t tdata_size = nt *
+	size_t tdata_size = ( size_t )nt *
 	                    ( size_t )sizeof( thread_data_t );
 	thread_data_t* tdata = bli_malloc_user( tdata_size, &r_val );
 

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -135,15 +135,16 @@ void libblis_test_thread_decorator( test_params_t* params, test_ops_t* ops )
 	err_t r_val;
 
 #ifdef BLIS_ENABLE_HPX
+	size_t nt = ( size_t )params->n_app_threads;
 
-	size_t tdata_size = ( size_t )params->n_app_threads *
+	size_t tdata_size = nt *
 	                    ( size_t )sizeof( thread_data_t );
 	thread_data_t* tdata = bli_malloc_user( tdata_size, &r_val );
 
 	tdata->params  = params;
 	tdata->ops     = ops;
 	tdata->nt      = nt;
-	tdata->id      = 1;
+	tdata->id      = 0;
 	tdata->xc      = 0;
 
 	// Walk through all test modules.


### PR DESCRIPTION
### Fixes HPX runtime integration

- **Fix hpx::for_each invocation and replace with hpx::for_loop**
      HPX runtime was initialized using `hpx::start`, but the `hpx::for_each` function was being called on a non-hpx runtime (i.e standard BLIS runtime - single main thread). To run `hpx::for_each` on HPX runtime correctly, the code now uses `hpx::run_as_hpx_thread(func, args...)`.
It also replaces `hpx::for_each` with `hpx::for_loop`, which eliminates use of `hpx::util::counting_iterator`. 
Additionally, the new code uses `hpx::execution::chunk_size(1)`, this will make sure that a thread resides on  a particular core. 

    
 -  Replace `hpx::apply()` with updated version `hpx::post()`.
 -  Initialize `tdata->id = 0` in libblis.c to 0, as it is the main thread and is needed for writing results to output file.

