### PR TITLE
Fixed brokenness when sba is disabled.

### DIFF
--- a/frame/1m/packm/bli_packm_cntl.c
+++ b/frame/1m/packm/bli_packm_cntl.c
@@ -37,7 +37,7 @@
 
 BLIS_EXPORT_BLIS cntl_t* bli_packm_cntl_create_node
      (
-       pool_t*   pool,
+       pool_t*   sba_pool,
        void_fp   var_func,
        bszid_t   bmid_m,
        bszid_t   bmid_n,
@@ -57,7 +57,7 @@ BLIS_EXPORT_BLIS cntl_t* bli_packm_cntl_create_node
 	#endif
 
 	// Allocate a packm_params_t struct.
-	params = bli_sba_acquire( pool, sizeof( packm_params_t ) );
+	params = bli_sba_acquire( sba_pool, sizeof( packm_params_t ) );
 
 	// Initialize the packm_params_t struct.
 	params->size              = sizeof( packm_params_t );
@@ -79,7 +79,7 @@ BLIS_EXPORT_BLIS cntl_t* bli_packm_cntl_create_node
 	// sync with the cntl_t tree.
 	cntl = bli_cntl_create_node
 	(
-	  pool,
+	  sba_pool,
 	  BLIS_NOID,
 	  BLIS_NO_PART,
 	  var_func,

--- a/frame/1m/packm/bli_packm_cntl.h
+++ b/frame/1m/packm/bli_packm_cntl.h
@@ -85,7 +85,7 @@ BLIS_INLINE packbuf_t bli_cntl_packm_params_pack_buf_type( const cntl_t* cntl )
 
 cntl_t* bli_packm_cntl_create_node
      (
-       pool_t*   pool,
+       pool_t*   sba_pool,
        void_fp   var_func,
        bszid_t   bmid_m,
        bszid_t   bmid_n,

--- a/frame/3/bli_l3_decor.c
+++ b/frame/3/bli_l3_decor.c
@@ -89,7 +89,7 @@ static void bli_l3_thread_decorator_entry( thrcomm_t* gl_comm, dim_t tid, const 
 
 	// Create a default control tree for the operation, if needed.
 	cntl_t* cntl_use;
-	pool_t* sba_pool = bli_apool_array_elem( tid, array );
+	pool_t* sba_pool = bli_sba_array_elem( tid, array );
 	bli_l3_cntl_create_if( family, schema_a, schema_b,
 	                       &a_t, &b_t, &c_t, sba_pool, NULL, &cntl_use );
 

--- a/frame/3/bli_l3_sup_decor.c
+++ b/frame/3/bli_l3_sup_decor.c
@@ -69,7 +69,7 @@ static void bli_l3_sup_thread_decorator_entry( thrcomm_t* gl_comm, dim_t tid, co
 	bli_l3_thread_decorator_thread_check( gl_comm, rntm );
 
 	// Create the root node of the thread's thrinfo_t structure.
-	pool_t*    pool   = bli_apool_array_elem( tid, array );
+	pool_t*    pool   = bli_sba_array_elem( tid, array );
 	thrinfo_t* thread = bli_l3_sup_thrinfo_create( tid, gl_comm, pool, rntm );
 
 	func

--- a/frame/3/bli_l3_thrinfo.c
+++ b/frame/3/bli_l3_thrinfo.c
@@ -44,16 +44,14 @@ thrinfo_t* bli_l3_thrinfo_create
        const cntl_t*     cntl
      )
 {
-	pool_t* pool = NULL;
-	if ( array != NULL )
-		pool = bli_apool_array_elem( id, array );
+	pool_t* sba_pool = bli_sba_array_elem( id, array );
 
 	// Create the root thrinfo_t node.
 	thrinfo_t* root = bli_thrinfo_create_root
 	(
 	  gl_comm,
 	  id,
-	  pool,
+	  sba_pool,
 	  bli_pba_query()
 	);
 
@@ -123,7 +121,7 @@ thrinfo_t* bli_l3_sup_thrinfo_create
      (
              dim_t      id,
              thrcomm_t* gl_comm,
-             pool_t*    pool,
+             pool_t*    sba_pool,
        const rntm_t*    rntm
      )
 {
@@ -132,7 +130,7 @@ thrinfo_t* bli_l3_sup_thrinfo_create
 	(
 	  gl_comm,
 	  id,
-	  pool,
+	  sba_pool,
 	  bli_pba_query()
 	);
 
@@ -176,10 +174,10 @@ void bli_l3_sup_thrinfo_update
              thrinfo_t** root
      )
 {
-	thrcomm_t* gl_comm = bli_thrinfo_comm( *root );
-	dim_t      tid     = bli_thrinfo_thread_id( *root );
-	pool_t*    pool    = bli_thrinfo_sba_pool( *root );
-	dim_t      nt      = bli_thrinfo_num_threads( *root );
+	thrcomm_t* gl_comm  = bli_thrinfo_comm( *root );
+	dim_t      tid      = bli_thrinfo_thread_id( *root );
+	pool_t*    sba_pool = bli_thrinfo_sba_pool( *root );
+	dim_t      nt       = bli_thrinfo_num_threads( *root );
 
 	// Return early in single-threaded execution
 	// since the thread control tree may not have been
@@ -187,7 +185,7 @@ void bli_l3_sup_thrinfo_update
 	if ( nt == 1 ) return;
 
 	bli_thrinfo_free( *root );
-	*root = bli_l3_sup_thrinfo_create( tid, gl_comm, pool, rntm );
+	*root = bli_l3_sup_thrinfo_create( tid, gl_comm, sba_pool, rntm );
 }
 
 // -----------------------------------------------------------------------------

--- a/frame/base/bli_apool.h
+++ b/frame/base/bli_apool.h
@@ -56,7 +56,7 @@ BLIS_INLINE pool_t* bli_apool_pool( apool_t* apool )
 	return &(apool->pool);
 }
 
-BLIS_INLINE  bli_pthread_mutex_t* bli_apool_mutex( apool_t* apool )
+BLIS_INLINE bli_pthread_mutex_t* bli_apool_mutex( apool_t* apool )
 {
 	return &(apool->mutex);
 }

--- a/frame/base/bli_cntl.c
+++ b/frame/base/bli_cntl.c
@@ -37,7 +37,7 @@
 
 cntl_t* bli_cntl_create_node
      (
-       pool_t* pool,
+       pool_t* sba_pool,
        opid_t  family,
        bszid_t bszid,
        void_fp var_func,
@@ -52,7 +52,7 @@ cntl_t* bli_cntl_create_node
 	#endif
 
 	// Allocate the cntl_t struct.
-	cntl = bli_sba_acquire( pool, sizeof( cntl_t ) );
+	cntl = bli_sba_acquire( sba_pool, sizeof( cntl_t ) );
 
 	bli_cntl_set_family( family, cntl );
 	bli_cntl_set_bszid( bszid, cntl );
@@ -66,7 +66,7 @@ cntl_t* bli_cntl_create_node
 
 void bli_cntl_free_node
      (
-       pool_t* pool,
+       pool_t* sba_pool,
        cntl_t* cntl
      )
 {
@@ -74,7 +74,7 @@ void bli_cntl_free_node
 	printf( "bli_cntl_free_node(): " );
 	#endif
 
-	bli_sba_release( pool, cntl );
+	bli_sba_release( sba_pool, cntl );
 }
 
 void bli_cntl_clear_node
@@ -94,7 +94,7 @@ void bli_cntl_clear_node
 
 void bli_cntl_free
      (
-       pool_t* pool,
+       pool_t* sba_pool,
        cntl_t* cntl
      )
 {
@@ -110,7 +110,7 @@ void bli_cntl_free
 	{
 		// Recursively free all memory associated with the sub-prenode and its
 		// children.
-		bli_cntl_free( pool, cntl_sub_prenode );
+		bli_cntl_free( sba_pool, cntl_sub_prenode );
 	}
 
 	// Only recurse into the child node if it exists.
@@ -118,7 +118,7 @@ void bli_cntl_free
 	{
 		// Recursively free all memory associated with the sub-node and its
 		// children.
-		bli_cntl_free( pool, cntl_sub_node );
+		bli_cntl_free( sba_pool, cntl_sub_node );
 	}
 
 	// Free the current node's params field, if it is non-NULL.
@@ -128,18 +128,18 @@ void bli_cntl_free
 		printf( "bli_cntl_free_w_thrinfo(): " );
 		#endif
 
-		bli_sba_release( pool, cntl_params );
+		bli_sba_release( sba_pool, cntl_params );
 	}
 
 	// Free the current node.
-	bli_cntl_free_node( pool, cntl );
+	bli_cntl_free_node( sba_pool, cntl );
 }
 
 // -----------------------------------------------------------------------------
 
 cntl_t* bli_cntl_copy
      (
-             pool_t* pool,
+             pool_t* sba_pool,
        const cntl_t* cntl
      )
 {
@@ -149,7 +149,7 @@ cntl_t* bli_cntl_copy
 	// field.
 	cntl_t* cntl_copy = bli_cntl_create_node
 	(
-	  pool,
+	  sba_pool,
 	  bli_cntl_family( cntl ),
 	  bli_cntl_bszid( cntl ),
 	  bli_cntl_var_func( cntl ),
@@ -165,7 +165,7 @@ cntl_t* bli_cntl_copy
 		// struct.
 		uint64_t params_size = bli_cntl_params_size( cntl );
 		void*    params_orig = bli_cntl_params( cntl );
-		void*    params_copy = bli_sba_acquire( pool, ( size_t )params_size );
+		void*    params_copy = bli_sba_acquire( sba_pool, ( size_t )params_size );
 
 		// Copy the original params struct to the new memory region.
 		memcpy( params_copy, params_orig, params_size );
@@ -180,7 +180,7 @@ cntl_t* bli_cntl_copy
 	{
 		cntl_t* sub_prenode_copy = bli_cntl_copy
 		(
-		  pool,
+		  sba_pool,
 		  bli_cntl_sub_prenode( cntl )
 		);
 
@@ -194,7 +194,7 @@ cntl_t* bli_cntl_copy
 	{
 		cntl_t* sub_node_copy = bli_cntl_copy
 		(
-		  pool,
+		  sba_pool,
 		  bli_cntl_sub_node( cntl )
 		);
 

--- a/frame/base/bli_sba.h
+++ b/frame/base/bli_sba.h
@@ -42,6 +42,18 @@ apool_t* bli_sba_query( void );
 void bli_sba_init( void );
 void bli_sba_finalize( void );
 
+void* bli_sba_acquire
+     (
+       pool_t* sba_pool,
+       siz_t   req_size
+     );
+
+void bli_sba_release
+     (
+       pool_t* sba_pool,
+       void*   block
+     );
+
 array_t* bli_sba_checkout_array
      (
        siz_t n_threads
@@ -52,16 +64,10 @@ void bli_sba_checkin_array
        array_t* array
      );
 
-void* bli_sba_acquire
+pool_t* bli_sba_array_elem
      (
-       pool_t* pool,
-       siz_t   req_size
-     );
-
-void bli_sba_release
-     (
-       pool_t* pool,
-       void*   block
+       siz_t    index,
+       array_t* array
      );
 
 #endif


### PR DESCRIPTION
Details:
- Previously, disabling the sba via `--disable-sba-pools` resulted in a segfault due to a sanity-check-triggering `abort()`. The problem was that the sba, as currently used in the l3 thread decorators, did not yet (fully) support pools being disabled. The solution entailed creating wrapper function, `bli_sba_array_elem()`, which either calls `bli_apool_array_elem()` (when sba pools are enabled at configure time) or returns a `NULL` `sba_pool` pointer (when sba pools are disabled), and calling `bli_sba_array_elem()` in place of `bli_apool_array_elem()`. Note that the `NULL` pointer returned by `bli_sba_array_elem()` when the sba pools are disabled does no harm since in that situation the pointer goes unreferenced when acquiring and releasing small blocks. Thanks to John Mather for reporting this bug.
- Guarded the bodies of `bli_sba_init()` and `bli_sba_finalize()` with `#ifdef BLIS_ENABLE_SBA_POOLS`. I don't think this was actually necessary to fix the aforementioned bug, but it seems like good practice.
- Moved the code in `bli_l3_thrinfo_create()` that checked that the `array*` pointer is non-`NULL` before calling `bli_sba_array_elem()` (previously `bli_apool_array_elem()`) into the definition of `bli_sba_array_elem()`.
- Renamed various instances of `pool` variables and function parameters to `sba_pool` to emphasize what kind of pool it represents.
- Whitespace changes.

cc: @jmather-sesi 