### PR TITLE
Fixed bug in sup threshold registration.

### DIFF
--- a/config/bgq/bli_cntx_init_bgq.c
+++ b/config/bgq/bli_cntx_init_bgq.c
@@ -69,11 +69,11 @@ void bli_cntx_init_bgq( cntx_t* cntx )
 
 	// Initialize level-3 blocksize objects with architecture-specific values.
 	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     0,     8,     0,     4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     0,     8,     0,     4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],     0,  1024,     0,   768 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],     0,  2048,     0,  1536 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],     0, 10240,     0, 10240 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],    -1,     8,    -1,     4 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    -1,     8,    -1,     4 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],    -1,  1024,    -1,   768 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],    -1,  2048,    -1,  1536 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],    -1, 10240,    -1, 10240 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.

--- a/config/cortexa9/bli_cntx_init_cortexa9.c
+++ b/config/cortexa9/bli_cntx_init_cortexa9.c
@@ -69,11 +69,11 @@ void bli_cntx_init_cortexa9( cntx_t* cntx )
 
 	// Initialize level-3 blocksize objects with architecture-specific values.
 	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     4,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     4,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   432,   176,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   352,   368,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4096,  4096,     0,     0 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     4,     4,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     4,     4,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   432,   176,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   352,   368,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4096,  4096,    -1,    -1 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.

--- a/config/knc/bli_cntx_init_knc.c
+++ b/config/knc/bli_cntx_init_knc.c
@@ -67,13 +67,13 @@ void bli_cntx_init_knc( cntx_t* cntx )
 
 	// Initialize level-3 blocksize objects with architecture-specific values.
 	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     0,    30,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     0,     8,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],     0,   120,     0,     0,
-	                                             0,   160,     0,     0 );
-	bli_blksz_init     ( &blkszs[ BLIS_KC ],     0,   240,     0,     0,
-	                                             0,   300,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],     0, 14400,     0,     0 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],    -1,    30,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    -1,     8,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],    -1,   120,    -1,    -1,
+	                                            -1,   160,    -1,    -1 );
+	bli_blksz_init     ( &blkszs[ BLIS_KC ],    -1,   240,    -1,    -1,
+	                                            -1,   300,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],    -1, 14400,    -1,    -1 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.

--- a/config/penryn/bli_cntx_init_penryn.c
+++ b/config/penryn/bli_cntx_init_penryn.c
@@ -77,11 +77,11 @@ void bli_cntx_init_penryn( cntx_t* cntx )
 
 	// Initialize level-3 blocksize objects with architecture-specific values.
 	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     8,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     4,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   768,   384,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   384,   384,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4096,  4096,     0,     0 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     8,     4,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     4,     4,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],   768,   384,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],   384,   384,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],  4096,  4096,    -1,    -1 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.

--- a/config/power7/bli_cntx_init_power7.c
+++ b/config/power7/bli_cntx_init_power7.c
@@ -67,11 +67,11 @@ void bli_cntx_init_power7( cntx_t* cntx )
 
 	// Initialize level-3 blocksize objects with architecture-specific values.
 	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     0,     8,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     0,     4,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],     0,    64,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],     0,   256,     0,     0 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],     0,  4096,     0,     0 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],    -1,     8,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    -1,     4,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],    -1,    64,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],    -1,   256,    -1,    -1 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],    -1,  4096,    -1,    -1 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.

--- a/config/template/bli_cntx_init_template.c
+++ b/config/template/bli_cntx_init_template.c
@@ -87,11 +87,11 @@ void bli_cntx_init_template( cntx_t* cntx )
 
 	// Initialize level-3 blocksize objects with architecture-specific values.
 	//                                           s      d      c      z
-	bli_blksz_init_easy( &blkszs[ BLIS_MR ],     0,     0,     0,     4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NR ],     0,     0,     0,     4 );
-	bli_blksz_init_easy( &blkszs[ BLIS_MC ],     0,     0,     0,   128 );
-	bli_blksz_init_easy( &blkszs[ BLIS_KC ],     0,     0,     0,   256 );
-	bli_blksz_init_easy( &blkszs[ BLIS_NC ],     0,     0,     0,  4096 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MR ],    -1,    -1,    -1,     4 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NR ],    -1,    -1,    -1,     4 );
+	bli_blksz_init_easy( &blkszs[ BLIS_MC ],    -1,    -1,    -1,   128 );
+	bli_blksz_init_easy( &blkszs[ BLIS_KC ],    -1,    -1,    -1,   256 );
+	bli_blksz_init_easy( &blkszs[ BLIS_NC ],    -1,    -1,    -1,  4096 );
 
 	// Update the context with the current architecture's register and cache
 	// blocksizes (and multiples) for native execution.

--- a/frame/base/bli_blksz.h
+++ b/frame/base/bli_blksz.h
@@ -84,14 +84,15 @@ BLIS_INLINE void bli_blksz_copy
 	*b_dst = *b_src;
 }
 
-BLIS_INLINE void bli_blksz_copy_if_pos
+BLIS_INLINE void bli_blksz_copy_if_nonneg
      (
        const blksz_t* b_src,
              blksz_t* b_dst
      )
 {
-	// Copy the blocksize values over to b_dst one-by-one so that
-	// we can skip the ones that are non-positive.
+	// Copy the blocksize values over to b_dst one-by-one. Note that we
+	// only copy valuse that are zero or positive (and skip copying any
+	// values that are negative).
 
 	const dim_t v_s = bli_blksz_get_def( BLIS_FLOAT,    b_src );
 	const dim_t v_d = bli_blksz_get_def( BLIS_DOUBLE,   b_src );
@@ -103,15 +104,15 @@ BLIS_INLINE void bli_blksz_copy_if_pos
 	const dim_t e_c = bli_blksz_get_max( BLIS_SCOMPLEX, b_src );
 	const dim_t e_z = bli_blksz_get_max( BLIS_DCOMPLEX, b_src );
 
-	if ( v_s > 0 ) bli_blksz_set_def( v_s, BLIS_FLOAT,    b_dst );
-	if ( v_d > 0 ) bli_blksz_set_def( v_d, BLIS_DOUBLE,   b_dst );
-	if ( v_c > 0 ) bli_blksz_set_def( v_c, BLIS_SCOMPLEX, b_dst );
-	if ( v_z > 0 ) bli_blksz_set_def( v_z, BLIS_DCOMPLEX, b_dst );
+	if ( v_s >= 0 ) bli_blksz_set_def( v_s, BLIS_FLOAT,    b_dst );
+	if ( v_d >= 0 ) bli_blksz_set_def( v_d, BLIS_DOUBLE,   b_dst );
+	if ( v_c >= 0 ) bli_blksz_set_def( v_c, BLIS_SCOMPLEX, b_dst );
+	if ( v_z >= 0 ) bli_blksz_set_def( v_z, BLIS_DCOMPLEX, b_dst );
 
-	if ( e_s > 0 ) bli_blksz_set_max( e_s, BLIS_FLOAT,    b_dst );
-	if ( e_d > 0 ) bli_blksz_set_max( e_d, BLIS_DOUBLE,   b_dst );
-	if ( e_c > 0 ) bli_blksz_set_max( e_c, BLIS_SCOMPLEX, b_dst );
-	if ( e_z > 0 ) bli_blksz_set_max( e_z, BLIS_DCOMPLEX, b_dst );
+	if ( e_s >= 0 ) bli_blksz_set_max( e_s, BLIS_FLOAT,    b_dst );
+	if ( e_d >= 0 ) bli_blksz_set_max( e_d, BLIS_DOUBLE,   b_dst );
+	if ( e_c >= 0 ) bli_blksz_set_max( e_c, BLIS_SCOMPLEX, b_dst );
+	if ( e_z >= 0 ) bli_blksz_set_max( e_z, BLIS_DCOMPLEX, b_dst );
 }
 
 BLIS_INLINE void bli_blksz_copy_def_dt

--- a/frame/base/bli_cntx.c
+++ b/frame/base/bli_cntx.c
@@ -100,7 +100,7 @@ void bli_cntx_set_blkszs( cntx_t* cntx, ... )
 		//cntx_blkszs[ bs_id ] = *blksz;
 		//bli_blksz_copy( blksz, cntx_blksz );
 		blksz_t* cntx_blksz = &cntx_blkszs[ bs_id ];
-		bli_blksz_copy_if_pos( blksz, cntx_blksz );
+		bli_blksz_copy_if_nonneg( blksz, cntx_blksz );
 
 		// Copy the blocksize multiple id into the context.
 		cntx_bmults[ bs_id ] = bm_id;


### PR DESCRIPTION
Details:
- Fixed a bug that resulted in BLIS non-deterministically calling the `gemmsup` handler, irrespective of the thresholds that are registered via `bli_cntx_set_blkszs()`.
- Deep dive: In `bli_cntx_init_ref.c`, the default values for the `gemmsup` thresholds (`BLIS_[MNK]T` blocksizes) were being set to zero so that no operation ever matched the criteria for `gemmsup` (unless specific sup thresholds are registered). HOWEVER, these thresholds are set via `bli_cntx_set_blkszs()` which calls `bli_blksz_copy_if_pos()`, which was only coping the thresholds into the gks' `cntx_t` if the values were strictly positive. Thus, the zero values passed into `bli_cntx_set_blkszs()` were being ignored and those threshold slots within the gks were left uninitialized. The upshot of this is that the reference `gemmsup` handler was being called for `gemm` problems essentially at random (and as it turns out, very rarely the reference `gemmsup` implementation would encounter a divide-by-zero error).
- The problem was fixed by changing `bli_blksz_copy_if_pos()` so that it copies values that are non-negative (values >= 0 instead of > 0). The function was also renamed to `bli_blksz_copy_if_nonneg()`.
- Fixes #781. Thanks to Devin Matthews for identifying, diagnosing, and proposing a fix for this issue.