### PR TITLE
Install helper headers to INCDIR prefix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,9 +284,12 @@ endif
 # Define a list of headers to install. The default is to only install blis.h.
 HEADERS_TO_INSTALL      := $(BLIS_H_FLAT)
 
-# If CBLAS is enabled, we also install cblas.h so the user does not need to
-# change their source code to #include "blis.h" in order to access the CBLAS
-# function prototypes and enums.
+# If CBLAS is enabled, we also install cblas.h. This allows the user to continue
+# using #include "cblas.h" in their application, if they wish. (NOTE: Even if we
+# didn't install cblas.h, the user could *still* access CBLAS definitions and
+# function prototypes, but they would have to update their source code to use
+# #include "blis.h" instead of #include "cblas.h" since the latter header file
+# would not exist.)
 ifeq ($(MK_ENABLE_CBLAS),yes)
 HEADERS_TO_INSTALL += $(CBLAS_H_FLAT)
 endif

--- a/Makefile
+++ b/Makefile
@@ -1067,7 +1067,7 @@ install-helper-headers: check-env $(HELP_HEADERS_INSTALLED)
 
 # A rule to install a helper header file.
 define make-helper-header-rule
-$(INSTALL_INCDIR)/$(notdir $(1)): $(BUILD_DIR)/$(notdir $(1)) $(CONFIG_MK_FILE)
+$(INSTALL_INCDIR)/$(notdir $(1)): $(BUILD_PATH)/$(notdir $(1)) $(CONFIG_MK_FILE)
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(INSTALL_INCDIR)
 	$(INSTALL) -m 0644 $$(<) $$(@)

--- a/Makefile
+++ b/Makefile
@@ -1070,11 +1070,11 @@ define make-helper-header-rule
 $(INSTALL_INCDIR)/$(notdir $(1)): $(BUILD_DIR)/$(notdir $(1)) $(CONFIG_MK_FILE)
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(INSTALL_INCDIR)
-	$(INSTALL) -m 0644 -T $$(<) $$(@)
+	$(INSTALL) -m 0644 $$(<) $$(@)
 else
 	@$(MKDIR) $(INSTALL_INCDIR)
 	@echo "Installing $$(@F) helper header into $(INSTALL_INCDIR)/"
-	@$(INSTALL) -m 0644 -T $$(<) $$(@)
+	@$(INSTALL) -m 0644 $$(<) $$(@)
 endif
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@
         testblis testblis-fast testblis-md testblis-salt \
         check checkblas \
         checkblis checkblis-fast checkblis-md checkblis-salt \
-        install-headers install-libs install-lib-symlinks \
+        install-headers install-helper-headers install-libs install-lib-symlinks \
         showconfig \
         clean cleanmk cleanh cleanlib distclean \
         cleantest cleanblastest cleanblistest \
@@ -282,7 +282,7 @@ endif
 #
 
 # Define a list of headers to install. The default is to only install blis.h.
-HEADERS_TO_INSTALL := $(BLIS_H_FLAT)
+HEADERS_TO_INSTALL      := $(BLIS_H_FLAT)
 
 # If CBLAS is enabled, we also install cblas.h so the user does not need to
 # change their source code to #include "blis.h" in order to access the CBLAS
@@ -295,6 +295,19 @@ endif
 # to install.
 ifeq ($(INSTALL_HH),yes)
 HEADERS_TO_INSTALL += $(wildcard $(VEND_CPP_PATH)/*.hh)
+endif
+
+# Define a list of so-called helper headers to install. These helper headers
+# are very simple headers that go one directory up from INCDIR/blis (which
+# by default is PREFIX/include/blis, where PREFIX is the install prefix). The
+# default is to only install the blis.h helper header.
+HELP_HEADERS_TO_INSTALL := $(HELP_BLIS_H_PATH)
+HELP_HEADERS_INSTALLED  := $(INSTALL_INCDIR)/$(BLIS_H)
+
+# If CBLAS is enabled, we also install the cblas.h helper header.
+ifeq ($(MK_ENABLE_CBLAS),yes)
+HELP_HEADERS_TO_INSTALL += $(HELP_CBLAS_H_PATH)
+HELP_HEADERS_INSTALLED  += $(INSTALL_INCDIR)/$(CBLAS_H)
 endif
 
 
@@ -1034,8 +1047,9 @@ endif
 
 # --- Install header rules ---
 
-install-headers: check-env $(MK_INCL_DIR_INST)
+install-headers: check-env $(MK_INCL_DIR_INST) install-helper-headers
 
+# Rule for installing main headers.
 $(MK_INCL_DIR_INST): $(HEADERS_TO_INSTALL) $(CONFIG_MK_FILE)
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(@)
@@ -1046,6 +1060,23 @@ else
 	@$(INSTALL) -m 0644 $(HEADERS_TO_INSTALL) $(@)
 endif
 
+install-helper-headers: check-env $(HELP_HEADERS_INSTALLED)
+
+# A rule to install a helper header file.
+define make-helper-header-rule
+$(INSTALL_INCDIR)/$(notdir $(1)): $(BUILD_DIR)/$(notdir $(1)) $(CONFIG_MK_FILE)
+ifeq ($(ENABLE_VERBOSE),yes)
+	$(MKDIR) $(INSTALL_INCDIR)
+	$(INSTALL) -m 0644 -T $$(<) $$(@)
+else
+	@$(MKDIR) $(INSTALL_INCDIR)
+	@echo "Installing $$(@F) helper header into $(INSTALL_INCDIR)/"
+	@$(INSTALL) -m 0644 -T $$(<) $$(@)
+endif
+endef
+
+# Instantiate the rule above for each helper header file to install.
+$(foreach h, $(HELP_HEADERS_TO_INSTALL), $(eval $(call make-helper-header-rule,$(h))))
 
 # --- Install share rules ---
 
@@ -1068,11 +1099,9 @@ else
 	               $(@)/$(CONFIG_DIR)/$(CONFIG_NAME)/
 endif
 
-$(PC_SHARE_DIR_INST):  $(PC_IN_FILE)
+$(PC_SHARE_DIR_INST): $(PC_IN_FILE)
+ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(@)
-ifeq ($(ENABLE_VERBOSE),no)
-	@echo "Installing $(PC_OUT_FILE) into $(@)/"
-endif
 	$(shell cat "$(PC_IN_FILE)" \
 	| sed -e "s#@PACKAGE_VERSION@#$(VERSION)#g" \
 	| sed -e "s#@prefix@#$(prefix)#g" \
@@ -1082,6 +1111,19 @@ endif
 	| sed -e "s#@LDFLAGS@#$(LDFLAGS)#g" \
 	> "$(PC_OUT_FILE)" )
 	$(INSTALL) -m 0644 $(PC_OUT_FILE) $(@)
+else
+	@$(MKDIR) $(@)
+	@echo "Installing $(PC_OUT_FILE) into $(@)/"
+	@$(shell cat "$(PC_IN_FILE)" \
+	| sed -e "s#@PACKAGE_VERSION@#$(VERSION)#g" \
+	| sed -e "s#@prefix@#$(prefix)#g" \
+	| sed -e "s#@exec_prefix@#$(exec_prefix)#g" \
+	| sed -e "s#@libdir@#$(libdir)#g" \
+	| sed -e "s#@includedir@#$(includedir)#g" \
+	| sed -e "s#@LDFLAGS@#$(LDFLAGS)#g" \
+	> "$(PC_OUT_FILE)" )
+	@$(INSTALL) -m 0644 $(PC_OUT_FILE) $(@)
+endif
 
 # --- Install library rules ---
 
@@ -1401,9 +1443,12 @@ endif
 uninstall-headers: check-env
 ifeq ($(ENABLE_VERBOSE),yes)
 	- $(RM_RF) $(MK_INCL_DIR_INST)
+	- $(RM_RF) $(HELP_HEADERS_INSTALLED)
 else
 	@echo "Uninstalling directory '$(notdir $(MK_INCL_DIR_INST))' from $(dir $(MK_INCL_DIR_INST))"
 	@- $(RM_RF) $(MK_INCL_DIR_INST)
+	@echo "Uninstalling $(notdir $(HELP_HEADERS_INSTALLED)) from $(dir $(INSTALL_INCDIR))"
+	@- $(RM_RF) $(HELP_HEADERS_INSTALLED)
 endif
 
 uninstall-share: check-env

--- a/build/blis.h
+++ b/build/blis.h
@@ -1,0 +1,1 @@
+#include "blis/blis.h"

--- a/build/blis.h
+++ b/build/blis.h
@@ -1,1 +1,1 @@
-#include "blis/blis.h"
+#include <blis/blis.h>

--- a/build/cblas.h
+++ b/build/cblas.h
@@ -1,1 +1,1 @@
-#include "blis/cblas.h"
+#include <blis/cblas.h>

--- a/build/cblas.h
+++ b/build/cblas.h
@@ -1,0 +1,1 @@
+#include "blis/cblas.h"

--- a/common.mk
+++ b/common.mk
@@ -1179,6 +1179,10 @@ BLIS_H_SRC_PATH := $(filter %/$(BLIS_H), $(FRAME_H99_FILES))
 # blis.h file.
 BLIS_H_FLAT     := $(BASE_INC_PATH)/$(BLIS_H)
 
+# Construct the path to the helper blis.h file that will reside one directory
+# up from the installed copy of blis.h.
+HELP_BLIS_H_PATH := $(BUILD_DIR)/$(BLIS_H)
+
 
 #
 # --- cblas.h header definitions -----------------------------------------------
@@ -1193,7 +1197,11 @@ CBLAS_H_DIRPATH  := $(dir $(CBLAS_H_SRC_PATH))
 
 # Construct the path to what will be the intermediate flattened/monolithic
 # cblas.h file.
-CBLAS_H_FLAT    := $(BASE_INC_PATH)/$(CBLAS_H)
+CBLAS_H_FLAT      := $(BASE_INC_PATH)/$(CBLAS_H)
+
+# Construct the path to the helper cblas.h file that will reside one directory
+# up from the installed copy of cblas.h.
+HELP_CBLAS_H_PATH := $(BUILD_DIR)/$(CBLAS_H)
 
 
 #


### PR DESCRIPTION
Details:
- Install one-line headers to `INCDIR` whose entire purpose is to `#include` the actual headers within the local `blis` header directory so that applications can `#include "blis.h"` instead of `#include "blis/blis.h"` (and/or `"cblas.h"` instead of `"blis/cblas.h"` if CBLAS is enabled) when headers are installed to global paths. (Note that `INCDIR` is the installation prefix for headers as specified by `--includedir=INCDIR`, which defaults to `PREFIX/include` if not specified.) Not sure how this problem went unreported for so long, since presumably any user trying to `#include "blis.h"` from a global installation would have encountered a compiler error.
- The one-line `blis.h` and `cblas.h` headers now reside in the `build` directory, ready to install as is.
- Thanks to to Jed Brown for reporting this via Issue #786, and for Devin Matthews and Mo Zhou for their engagement.
- Harmonized the rule in the top-level Makefile for installing `blis.pc` into `SHAREDIR/pkgconfig` with conventions for others vis-a-vis verbosity/non-verbosity.

cc: @jedbrown @cdluminate 