### PR TITLE
Fixed random segfault in `test/3` drivers.

### DIFF
--- a/test/3/test_hemm.c
+++ b/test/3/test_hemm.c
@@ -358,6 +358,7 @@ void init_def_params( params_t* params )
 	params->ps_str    = GLOB_DEF_PS_STR;
 	params->m_str     = GLOB_DEF_M_STR;
 	params->n_str     = GLOB_DEF_N_STR;
+	params->k_str     = GLOB_DEF_K_STR;
 
 	params->nr_str    = GLOB_DEF_NR_STR;
 

--- a/test/3/test_herk.c
+++ b/test/3/test_herk.c
@@ -336,6 +336,7 @@ void init_def_params( params_t* params )
 
 	params->ps_str    = GLOB_DEF_PS_STR;
 	params->m_str     = GLOB_DEF_M_STR;
+	params->n_str     = GLOB_DEF_N_STR;
 	params->k_str     = GLOB_DEF_K_STR;
 
 	params->nr_str    = GLOB_DEF_NR_STR;

--- a/test/3/test_trmm.c
+++ b/test/3/test_trmm.c
@@ -340,6 +340,7 @@ void init_def_params( params_t* params )
 	params->ps_str    = GLOB_DEF_PS_STR;
 	params->m_str     = GLOB_DEF_M_STR;
 	params->n_str     = GLOB_DEF_N_STR;
+	params->k_str     = GLOB_DEF_K_STR;
 
 	params->nr_str    = GLOB_DEF_NR_STR;
 

--- a/test/3/test_trsm.c
+++ b/test/3/test_trsm.c
@@ -343,6 +343,7 @@ void init_def_params( params_t* params )
 	params->ps_str    = GLOB_DEF_PS_STR;
 	params->m_str     = GLOB_DEF_M_STR;
 	params->n_str     = GLOB_DEF_N_STR;
+	params->k_str     = GLOB_DEF_K_STR;
 
 	params->nr_str    = GLOB_DEF_NR_STR;
 


### PR DESCRIPTION
Details:
- Fixed a segfault in the non-`gemm` test drivers in `test/3` that was the result of sometimes leaving either `.n_str` or `.k_str` fields of the `params_t` struct uninitialized, depending on the operation in question. For example, in `test_hemm.c`, `init_def_params()` would only initialize the `.m_str` and `.n_str` fields, but not the `.k_str` field. Even though `hemm` doesn't use a k dimension, the `proc_params()` function (called via `parse_cl_params()`) universally attempts to convert all three into integers via `sscanf()`, which was understandably failing when one of those strings was a `NULL` pointer. I'm not sure how this code ever worked to begin with. Special thanks to Leick Robinson for finding and reporting this bug.