### PR TITLE
Include `bli_config.h` before `bli_system.h` in `cblas.h`.

### DIFF
--- a/frame/compat/cblas/src/cblas.h
+++ b/frame/compat/cblas/src/cblas.h
@@ -3,11 +3,16 @@
 #define CBLAS_H
 #include <stddef.h>
 
-// We need to #include "bli_type_defs.h" in order to pull in the
-// definition of f77_int. But in order to #include that header, we
-// also need to pull in the headers that precede it in blis.h.
-#include "bli_system.h"
+// We need to #include "bli_type_defs.h" in order to pull in the definition of
+// f77_int. But in order to #include that header, we also need to pull in the
+// headers that precede it in blis.h.
+
+// NOTE: bli_config.h must be included before any other BLIS header. It is
+// bootstrapped by ./configure and does not depend on later headers. Moreover
+// these configuration variables are necessary to change some default behaviors
+// (e.g. disable OS detection in bli_system.h in case of --disable-system).
 #include "bli_config.h"
+#include "bli_system.h"
 #include "bli_config_macro_defs.h"
 #include "bli_type_defs.h"
 

--- a/frame/include/blis.h
+++ b/frame/include/blis.h
@@ -50,11 +50,10 @@ extern "C" {
 
 // -- configure definitions --
 
-// NOTE: bli_config.h header must be included before any BLIS header.
-// It is bootstrapped by ./configure and does not depend on later
-// headers. Moreover, these configuration variables are necessary to change
-// some default behaviors (e.g. disable OS-detection in bli_system.h in case
-// of --disable-system).
+// NOTE: bli_config.h must be included before any other BLIS header. It is
+// bootstrapped by ./configure and does not depend on later headers. Moreover
+// these configuration variables are necessary to change some default behaviors
+// (e.g. disable OS detection in bli_system.h in case of --disable-system).
 #include "bli_config.h"
 
 // -- System and language-related headers --


### PR DESCRIPTION
Details:
- Previously, in `cblas.h`, `bli_config.h` was being `#included` *after* `bli_system.h`, which meant that the `BLIS_ENABLE_SYSTEM` macro was never defined in time for proper OS detection. This bug only affected `cblas.h` -- `blis.h` had been correctly including `bli_config.h` before `bli_system.h` since fb93d24. Thanks to Edward Smyth for reporting this bug and suggesting the fix.

cc: @edwsmyth