### PR TITLE
Fix errors and typos in docs/BLIS*API.md

### DIFF
--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -1284,6 +1284,7 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `uplo(A)`.
 ```c
 void bli_scal2m
      (
+       obj_t*  alpha,
        obj_t*  a,
        obj_t*  b
      );
@@ -1403,7 +1404,7 @@ void bli_axpy2v
 ```
 Perform
 ```
-  y := y + conj?(alphax) * conj?(x) + conj?(alphay) * conj?(y)
+  z := z + conj?(alphax) * conj?(x) + conj?(alphay) * conj?(y)
 ```
 where `x`, `y`, and `z` are vectors of length _m_. The kernel, if optimized, is implemented as a fused pair of calls to [axpyv](BLISObjectAPI.md#axpyv).
 
@@ -1425,7 +1426,7 @@ void bli_dotaxpyv
 Perform
 ```
   rho := conj?(x)^T * conj?(y)
-  y   := y + conj?(alpha) * conj?(x)
+  z   := z + conj?(alpha) * conj?(x)
 ```
 where `x`, `y`, and `z` are vectors of length _m_ and `alpha` and `rho` are scalars. The kernel, if optimized, is implemented as a fusion of calls to [dotv](BLISObjectAPI.md#dotv) and [axpyv](BLISObjectAPI.md#axpyv).
 
@@ -2198,7 +2199,7 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 err_t bli_getijv
       (
         dim_t   i,
-        obj_t*  b,
+        obj_t*  x,
         double* ar,
         double* ai
       )
@@ -2228,8 +2229,8 @@ If either the row offset `i` is beyond the _m_ dimension of `b` or less than zer
 ```c
 void bli_setsc
      (
-       double* zeta_r,
-       double* zeta_i,
+       double  zeta_r,
+       double  zeta_i,
        obj_t*  chi
      );
 ```
@@ -2272,8 +2273,8 @@ If either the row offset `i` is beyond the _m_ dimension of `b` or less than zer
 ```c
 void bli_eqsc
      (
-       obj_t  chi,
-       obj_t  psi,
+       obj_t* chi,
+       obj_t* psi,
        bool*  is_eq
      );
 ```
@@ -2288,8 +2289,8 @@ Observed object properties: `conj?(chi)`, `conj?(psi)`.
 ```c
 void bli_eqv
      (
-       obj_t  x,
-       obj_t  y,
+       obj_t* x,
+       obj_t* y,
        bool*  is_eq
      );
 ```
@@ -2304,8 +2305,8 @@ Observed object properties: `conj?(x)`, `conj?(y)`.
 ```c
 void bli_eqm
      (
-       obj_t  a,
-       obj_t  b,
+       obj_t* a,
+       obj_t* b,
        bool*  is_eq
      );
 ```

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -177,24 +177,24 @@ The functions listed in this document belong to the "basic" interface subset of 
 ```c
 void bli_gemm
      (
-       obj_t* alpha,
-       obj_t* a,
-       obj_t* b,
-       obj_t* beta,
-       obj_t* c,
+       obj_t*  alpha,
+       obj_t*  a,
+       obj_t*  b,
+       obj_t*  beta,
+       obj_t*  c,
      );
 ```
 while the expert interface is:
 ```c
 void bli_gemm_ex
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c,
-       cntx_t* cntx,
-       rntm_t* rntm
+       obj_t*   alpha,
+       obj_t*   a,
+       obj_t*   b,
+       obj_t*   beta,
+       obj_t*   c,
+       cntx_t*  cntx,
+       rntm_t*  rntm
      );
 ```
 The expert interface contains two additional parameters: a `cntx_t*` and `rntm_t*`. Note that calling a function from the expert interface with the `cntx_t*` and `rntm_t*` arguments each set to `NULL` is equivalent to calling the corresponding basic interface. Specifically, a `NULL` value passed in for the `cntx_t*` results in a valid context being queried from BLIS, and a `NULL` value passed in for the `rntm_t*` results in the current global settings for multithreading to be used.
@@ -254,12 +254,12 @@ Only objects that were created with automatic allocation must be freed via BLIS 
 ```c
 void bli_obj_create
      (
-       num_t  dt,
-       dim_t  m,
-       dim_t  n,
-       inc_t  rs,
-       inc_t  cs,
-       obj_t* obj
+       num_t   dt,
+       dim_t   m,
+       dim_t   n,
+       inc_t   rs,
+       inc_t   cs,
+       obj_t*  obj
      );
 ```
 Initialize an _m x n_ object `obj` and allocate sufficient storage to hold _mn_ elements whose storage type is specified by `dt` and with row and column strides `rs` and `cs`, respectively. This function allocates enough space to enforce alignment of leading dimensions, where the alignment factor is specific to the configuration being used, though the alignment factor is almost always equal to the size of the hardware's SIMD registers.
@@ -271,7 +271,7 @@ After an object created via `bli_obj_create()` is no longer needed, it should be
 ```c
 void bli_obj_free
      (
-       obj_t* obj
+       obj_t*  obj
      );
 ```
 Deallocate (release) an object `obj` that was previously created, typically via `bli_obj_create()`.
@@ -281,10 +281,10 @@ Deallocate (release) an object `obj` that was previously created, typically via 
 ```c
 void bli_obj_create_without_buffer
      (
-       num_t  dt,
-       dim_t  m,
-       dim_t  n,
-       obj_t* obj
+       num_t   dt,
+       dim_t   m,
+       dim_t   n,
+       obj_t*  obj
      );
 ```
 Partially initialize an _m x n_ object `obj` that will eventually contain elements whose storage type is specified by `dt`. This function does not result in any memory allocation. Before `obj` can be used, the object must be fully initialized by attaching a buffer via `bli_obj_attach_buffer()`. This function is useful when the user wishes to encapsulate existing buffers into one or more `obj_t` objects.
@@ -295,11 +295,11 @@ An object (partially) initialized via this function should generally not be pass
 ```c
 void bli_obj_attach_buffer
      (
-       void*  p,
-       inc_t  rs,
-       inc_t  cs,
-       inc_t  is,
-       obj_t* obj
+       void*   p,
+       inc_t   rs,
+       inc_t   cs,
+       inc_t   is,
+       obj_t*  obj
      );
 ```
 Given a partially initialized object (i.e., one that has already been passed to `bli_obj_create_without_buffer()`), attach the buffer pointed to by `p` to the object referenced by `obj` and initialize `obj` as containing elements with row and column strides `rs` and `cs`, respectively. The function also initializes the imaginary stride as `is`, which is experimental and not consistently used by all parts of BLIS.
@@ -309,13 +309,13 @@ Given a partially initialized object (i.e., one that has already been passed to 
 ```c
 void bli_obj_create_with_attached_buffer
      (
-       num_t  dt,
-       dim_t  m,
-       dim_t  n,
-       void*  p,
-       inc_t  rs,
-       inc_t  cs,
-       obj_t* obj
+       num_t   dt,
+       dim_t   m,
+       dim_t   n,
+       void*   p,
+       inc_t   rs,
+       inc_t   cs,
+       obj_t*  obj
      );
 ```
 Initialize an _m x n_ object `obj` as containing _mn_ elements whose storage type is specified by `dt` and with row and column strides `rs` and `cs`, respectively. The function does not allocate any memory and instead attaches the buffer pointed to by `p`. Note that calling this function is effectively equivalent to calling
@@ -330,10 +330,10 @@ Objects initialized via this function should generally not be passed to `bli_obj
 ```c
 void bli_obj_alloc_buffer
      (
-       inc_t  rs,
-       inc_t  cs,
-       inc_t  is,
-       obj_t* obj
+       inc_t   rs,
+       inc_t   cs,
+       inc_t   is,
+       obj_t*  obj
      );
 ```
 Given a partially initialized _m x n_ object, allocate and attach a buffer large enough to contain _mn_ elements with the row and column strides `rs` and `cs`, respectively. This function allocates enough space to enforce alignment of leading dimensions, where the alignment factor is specific to the configuration being used, though the alignment factor is almost always equal to the size of the hardware's SIMD registers.
@@ -349,8 +349,8 @@ Very few users will likely have a need to call this function. We provide documen
 ```c
 void bli_obj_create_1x1
      (
-       num_t  dt,
-       obj_t* obj
+       num_t   dt,
+       obj_t*  obj
      );
 ```
 Initialize a _1 x 1_ object `obj` and allocate sufficient storage to hold one element whose storage type is specified by `dt`.
@@ -368,9 +368,9 @@ After an object created via `bli_obj_create_1x1()` is no longer needed, it shoul
 ```c
 void bli_obj_create_1x1_with_attached_buffer
      (
-       num_t  dt,
-       void*  p,
-       obj_t* obj
+       num_t   dt,
+       void*   p,
+       obj_t*  obj
      );
 ```
 Initialize a _1 x 1_ object `obj` as containing one element whose storage type is specified by `dt`. The function does not allocate any memory and instead attaches the buffer pointed to by `p`. Note that calling this function is effectively equivalent to calling
@@ -385,8 +385,8 @@ Objects initialized via this function should generally not be passed to `bli_obj
 ```c
 void bli_obj_create_conf_to
      (
-       obj_t* s,
-       obj_t* d
+       obj_t*  s,
+       obj_t*  d
      );
 ```
 Initialize an object `d` with dimensions conformal to those of an existing object `s`. Object `d` is initialized with the same row and column strides as those of `s`. However, the structure, uplo, conjugation, and transposition properties of `s` are **not** inherited by `d`.
@@ -408,8 +408,8 @@ After an object created via `bli_obj_create_conf_to()` is no longer needed, it s
 ```c
 void bli_obj_scalar_init_detached
      (
-       num_t  dt,
-       obj_t* obj
+       num_t   dt,
+       obj_t*  obj
      );
 ```
 Initialize a _1 x 1_ object `obj` using internal storage sufficient to hold one element whose storage type is specified by `dt`. (Internal storage is present within every `obj_t` and is capable of holding on element of any supported type.) This function is similar to `bli_obj_create_1x1()`, except that the object does not trigger any dynamic memory allocation.
@@ -2185,9 +2185,9 @@ where, on entry, `scale` and `sumsq` contain `scale_old` and `sumsq_old`, respec
 ```c
 void bli_getsc
      (
-       obj_t*  chi,
-       double* zeta_r,
-       double* zeta_i
+       obj_t*   chi,
+       double*  zeta_r,
+       double*  zeta_i
      );
 ```
 Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and `zeta_i`. If `chi` is stored as a real type, then `zeta_i` is set to zero. (If `chi` is stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -2198,10 +2198,10 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 ```c
 err_t bli_getijv
       (
-        dim_t   i,
-        obj_t*  x,
-        double* ar,
-        double* ai
+        dim_t    i,
+        obj_t*   x,
+        double*  ar,
+        double*  ai
       )
 ```
 Copy the real and imaginary values at the `i`th element of vector object `x` to `ar` and `ai`. If elements of `x` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -2213,11 +2213,11 @@ If either the element offset `i` is beyond the vector dimension of `x` or less t
 ```c
 err_t bli_getijm
       (
-        dim_t   i,
-        dim_t   j,
-        obj_t*  b,
-        double* ar,
-        double* ai
+        dim_t    i,
+        dim_t    j,
+        obj_t*   b,
+        double*  ar,
+        double*  ai
       )
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. If elements of `b` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -2273,9 +2273,9 @@ If either the row offset `i` is beyond the _m_ dimension of `b` or less than zer
 ```c
 void bli_eqsc
      (
-       obj_t* chi,
-       obj_t* psi,
-       bool*  is_eq
+       obj_t*  chi,
+       obj_t*  psi,
+       bool*   is_eq
      );
 ```
 Perform an element-wise comparison between scalars `chi` and `psi` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -2289,9 +2289,9 @@ Observed object properties: `conj?(chi)`, `conj?(psi)`.
 ```c
 void bli_eqv
      (
-       obj_t* x,
-       obj_t* y,
-       bool*  is_eq
+       obj_t*  x,
+       obj_t*  y,
+       bool*   is_eq
      );
 ```
 Perform an element-wise comparison between vectors `x` and `y` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -2305,9 +2305,9 @@ Observed object properties: `conj?(x)`, `conj?(y)`.
 ```c
 void bli_eqm
      (
-       obj_t* a,
-       obj_t* b,
-       bool*  is_eq
+       obj_t*  a,
+       obj_t*  b,
+       bool*   is_eq
      );
 ```
 Perform an element-wise comparison between matrices `A` and `B` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -2418,8 +2418,8 @@ Return the amount of time that has elapsed since some fixed time in the past. Th
 ```c
 double bli_clock_min_diff
      (
-       double time_prev_min,
-       double time_start
+       double  time_prev_min,
+       double  time_start
      );
 ```
 This function computes an intermediate value, `time_diff`, equal to `bli_clock() - time_start`, and then tentatively prepares to return the minimum value of `time_diff` and `time_min`. If that minimum value is extremely small (close to zero), the function returns `time_min` instead.

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -120,34 +120,34 @@ The functions listed in this document belong to the "basic" interface subset of 
 ```c
 void bli_?gemm
      (
-       trans_t transa,
-       trans_t transb,
-       dim_t   m,
-       dim_t   n,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       trans_t  transa,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    n,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 while the expert interface is:
 ```c
 void bli_?gemm_ex
      (
-       trans_t transa,
-       trans_t transb,
-       dim_t   m,
-       dim_t   n,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc,
-       cntx_t* cntx,
-       rntm_t* rntm
+       trans_t  transa,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    n,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc,
+       cntx_t*  cntx,
+       rntm_t*  rntm
      );
 ```
 The expert interface contains two additional parameters: a `cntx_t*` and `rntm_t*`. Note that calling a function from the expert interface with the `cntx_t*` and `rntm_t*` arguments each set to `NULL` is equivalent to calling the corresponding basic interface. Specifically, a `NULL` value passed in for the `cntx_t*` results in a valid context being queried from BLIS, and a `NULL` value passed in for the `rntm_t*` results in the current global settings for multithreading to be used.
@@ -508,13 +508,13 @@ Most of these operations are similar to level-1m counterparts, except they only 
 ```c
 void bli_?addd
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -524,14 +524,14 @@ void bli_?addd
 ```c
 void bli_?axpyd
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -541,13 +541,13 @@ void bli_?axpyd
 ```c
 void bli_?copyd
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -600,14 +600,14 @@ void bli_?scald
 ```c
 void bli_?scal2d
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -632,11 +632,11 @@ void bli_?setd
 ```c
 void bli_?setid
      (
-       doff_t   diagoffa,
-       dim_t    m,
-       dim_t    n,
-       ctype_r* alpha,
-       ctype*   a, inc_t rsa, inc_t csa
+       doff_t    diagoffa,
+       dim_t     m,
+       dim_t     n,
+       ctype_r*  alpha,
+       ctype*    a, inc_t rsa, inc_t csa
      );
 ```
 Set the imaginary components of every element along the diagonal of `a`, as
@@ -666,13 +666,13 @@ specified by `diagoffa`.
 ```c
 void bli_?subd
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -682,14 +682,14 @@ void bli_?subd
 ```c
 void bli_?xpbyd
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  beta,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   beta,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -707,14 +707,14 @@ Level-1m operations perform various level-1 BLAS-like operations on matrices (he
 ```c
 void bli_?addm
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       uplo_t   uploa,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -729,15 +729,15 @@ where `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or up
 ```c
 void bli_?axpym
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       uplo_t   uploa,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -752,14 +752,14 @@ where `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or up
 ```c
 void bli_?copym
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       uplo_t   uploa,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -816,15 +816,15 @@ where `A` is an _m x n_ matrix stored as a dense matrix, or lower- or upper-tria
 ```c
 void bli_?scal2m
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       uplo_t   uploa,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -857,14 +857,14 @@ Set all elements of an _m x n_ matrix `A` to `conjalpha(alpha)`, where `A` is st
 ```c
 void bli_?subm
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       doff_t   diagoffa,
+       diag_t   diaga,
+       uplo_t   uploa,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -1019,15 +1019,15 @@ Level-2 operations perform various level-2 BLAS-like operations.
 ```c
 void bli_?gemv
      (
-       trans_t transa,
-       conj_t  conjx,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy
+       trans_t  transa,
+       conj_t   conjx,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   x, inc_t incx,
+       ctype*   beta,
+       ctype*   y, inc_t incy
      );
 ```
 Perform
@@ -1196,13 +1196,13 @@ where `A` is an _m x m_ symmetric matrix stored in the lower or upper triangle a
 ```c
 void bli_?trmv
      (
-       uplo_t  uploa,
-       trans_t transa,
-       diag_t  diaga,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  x, inc_t incx
+       uplo_t   uploa,
+       trans_t  transa,
+       diag_t   diaga,
+       dim_t    m,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   x, inc_t incx
      );
 ```
 Perform
@@ -1217,13 +1217,13 @@ where `A` is an _m x m_ triangular matrix stored in the lower or upper triangle 
 ```c
 void bli_?trsv
      (
-       uplo_t  uploa,
-       trans_t transa,
-       diag_t  diaga,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  y, inc_t incy
+       uplo_t   uploa,
+       trans_t  transa,
+       diag_t   diaga,
+       dim_t    m,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   y, inc_t incy
      );
 ```
 Solve the linear system
@@ -1248,16 +1248,16 @@ Level-3 operations perform various level-3 BLAS-like operations.
 ```c
 void bli_?gemm
      (
-       trans_t transa,
-       trans_t transb,
-       dim_t   m,
-       dim_t   n,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       trans_t  transa,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    n,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1272,16 +1272,16 @@ where C is an _m x n_ matrix, `transa(A)` is an _m x k_ matrix, and `transb(B)` 
 ```c
 void bli_?gemmt
      (
-       uplo_t  uploc,
-       trans_t transa,
-       trans_t transb,
-       dim_t   m,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       uplo_t   uploc,
+       trans_t  transa,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1296,17 +1296,17 @@ where C is an _m x m_ matrix, `transa(A)` is an _m x k_ matrix, and `transb(B)` 
 ```c
 void bli_?hemm
      (
-       side_t  sidea,
-       uplo_t  uploa,
-       conj_t  conja,
-       trans_t transb,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       side_t   sidea,
+       uplo_t   uploa,
+       conj_t   conja,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1325,14 +1325,14 @@ if `sidea` is `BLIS_RIGHT`, where `C` and `B` are _m x n_ matrices and `A` is a 
 ```c
 void bli_?herk
      (
-       uplo_t  uploc,
-       trans_t transa,
-       dim_t   m,
-       dim_t   k,
-       rtype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       rtype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       uplo_t   uploc,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    k,
+       rtype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       rtype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1349,16 +1349,16 @@ where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as 
 ```c
 void bli_?her2k
      (
-       uplo_t  uploc,
-       trans_t transa,
-       trans_t transb,
-       dim_t   m,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       rtype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       uplo_t   uploc,
+       trans_t  transa,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       rtype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1375,17 +1375,17 @@ where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as 
 ```c
 void bli_?symm
      (
-       side_t  sidea,
-       uplo_t  uploa,
-       conj_t  conja,
-       trans_t transb,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       side_t   sidea,
+       uplo_t   uploa,
+       conj_t   conja,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1404,14 +1404,14 @@ if `sidea` is `BLIS_RIGHT`, where `C` and `B` are _m x n_ matrices and `A` is a 
 ```c
 void bli_?syrk
      (
-       uplo_t  uploc,
-       trans_t transa,
-       dim_t   m,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       uplo_t   uploc,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1426,16 +1426,16 @@ where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as 
 ```c
 void bli_?syr2k
      (
-       uplo_t  uploc,
-       trans_t transa,
-       trans_t transb,
-       dim_t   m,
-       dim_t   k,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       uplo_t   uploc,
+       trans_t  transa,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    k,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1450,15 +1450,15 @@ where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as 
 ```c
 void bli_?trmm
      (
-       side_t  sidea,
-       uplo_t  uploa,
-       trans_t transa,
-       diag_t  diaga,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       side_t   sidea,
+       uplo_t   uploa,
+       trans_t  transa,
+       diag_t   diaga,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -1477,18 +1477,18 @@ if `sidea` is `BLIS_RIGHT`, where `B` is an _m x n_ matrix and `A` is a triangul
 ```c
 void bli_?trmm3
      (
-       side_t  sidea,
-       uplo_t  uploa,
-       trans_t transa,
-       diag_t  diaga,
-       trans_t transb,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb,
-       ctype*  beta,
-       ctype*  c, inc_t rsc, inc_t csc
+       side_t   sidea,
+       uplo_t   uploa,
+       trans_t  transa,
+       diag_t   diaga,
+       trans_t  transb,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb,
+       ctype*   beta,
+       ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1507,15 +1507,15 @@ if `sidea` is `BLIS_RIGHT`, where `C` and `transb(B)` are _m x n_ matrices and `
 ```c
 void bli_?trsm
      (
-       side_t  sidea,
-       uplo_t  uploa,
-       trans_t transa,
-       diag_t  diaga,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  b, inc_t rsb, inc_t csb
+       side_t   sidea,
+       uplo_t   uploa,
+       trans_t  transa,
+       diag_t   diaga,
+       dim_t    m,
+       dim_t    n,
+       ctype*   alpha,
+       ctype*   a, inc_t rsa, inc_t csa,
+       ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Solve the linear system with multiple right-hand sides
@@ -1753,9 +1753,9 @@ where, on entry, `scale` and `sumsq` contain `scale_old` and `sumsq_old`, respec
 ```c
 void bli_?getsc
      (
-       ctype*  chi,
-       double* zeta_r,
-       double* zeta_i
+       ctype*   chi,
+       double*  zeta_r,
+       double*  zeta_i
      );
 ```
 Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and `zeta_i`. If `chi` is stored as a real type, then `zeta_i` is set to zero. (If `chi` is stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -1766,10 +1766,10 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 ```c
 err_t bli_?getijv
      (
-       dim_t   i,
+       dim_t    i,
        ctype*   x, inc_t incx,
-       double* ar,
-       double* ai
+       double*  ar,
+       double*  ai
      );
 ```
 Copy the real and imaginary values at the `i`th element of vector `x` to `ar` and `ai`. For real domain invocations, only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -1781,11 +1781,11 @@ Note that the object-based analogue of [getijv](BLISObjectAPI.md#getijv) does bo
 ```c
 err_t bli_?getijm
      (
-       dim_t   i,
-       dim_t   j,
-       ctype*  b, inc_t rs_b, inc_t cs_b,
-       double* ar,
-       double* ai
+       dim_t    i,
+       dim_t    j,
+       ctype*   b, inc_t rs_b, inc_t cs_b,
+       double*  ar,
+       double*  ai
      );
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. For real domain invocations, only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -1841,10 +1841,10 @@ Note that the object-based analogue of [setijm](BLISObjectAPI.md#setijm) does bo
 ```c
 void bli_?eqsc
      (
-       conj_t conjchi,
-       ctype* chi,
-       ctype* psi,
-       bool*  is_eq
+       conj_t  conjchi,
+       ctype*  chi,
+       ctype*  psi,
+       bool*   is_eq
      );
 ```
 Perform an element-wise comparison between scalars `chi` and `psi` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -1872,15 +1872,15 @@ If `conjx` indicates a conjugation, `x` will be implicitly conjugated for purpos
 ```c
 void bli_?eqm
      (
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       trans_t transa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rs_a, inc_t cs_a,
-       ctype*  b, inc_t rs_b, inc_t cs_b,
-       bool*   is_eq
+       doff_t   diagoffa,
+       diag_t   diaga,
+       uplo_t   uploa,
+       trans_t  transa,
+       dim_t    m,
+       dim_t    n,
+       ctype*   a, inc_t rs_a, inc_t cs_a,
+       ctype*   b, inc_t rs_b, inc_t cs_b,
+       bool*    is_eq
      );
 ```
 Perform an element-wise comparison between matrices `A` and `B` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -1903,14 +1903,14 @@ If `transa` indicates a conjugation and/or transposition, then `A` will be conju
 ```c
 void bli_?gemm_*
      (
-       dim_t               k,
-       ctype*     restrict alpha,
-       ctype*     restrict a1,
-       ctype*     restrict b1,
-       ctype*     restrict beta,
-       ctype*     restrict c11, inc_t rsc, inc_t csc,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       dim_t                k,
+       ctype*      restrict alpha,
+       ctype*      restrict a1,
+       ctype*      restrict b1,
+       ctype*      restrict beta,
+       ctype*      restrict c11, inc_t rsc, inc_t csc,
+       auxinfo_t*  restrict data,
+       cntx_t*     restrict cntx
      );
 ```
 Perform
@@ -1928,20 +1928,20 @@ Please see the [Kernel Guide](KernelsHowTo.md) for more information on the `gemm
 ```c
 void bli_?trsm_l_*
      (
-       ctype*     restrict a11,
-       ctype*     restrict b11,
-       ctype*     restrict c11, inc_t rsc, inc_t csc
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       ctype*      restrict a11,
+       ctype*      restrict b11,
+       ctype*      restrict c11, inc_t rsc, inc_t csc
+       auxinfo_t*  restrict data,
+       cntx_t*     restrict cntx
      );
 
 void bli_?trsm_u_*
      (
-       ctype*     restrict a11,
-       ctype*     restrict b11,
-       ctype*     restrict c11, inc_t rsc, inc_t csc
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       ctype*      restrict a11,
+       ctype*      restrict b11,
+       ctype*      restrict c11, inc_t rsc, inc_t csc
+       auxinfo_t*  restrict data,
+       cntx_t*     restrict cntx
      );
 ```
 Perform
@@ -1959,28 +1959,28 @@ Please see the [Kernel Guide](KernelsHowTo.md) for more information on the `trsm
 ```c
 void bli_?gemmtrsm_l_*
      (
-       dim_t               k,
-       ctype*     restrict alpha,
-       ctype*     restrict a10,
-       ctype*     restrict a11,
-       ctype*     restrict b01,
-       ctype*     restrict b11,
-       ctype*     restrict c11, inc_t rs_c, inc_t cs_c,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       dim_t                k,
+       ctype*      restrict alpha,
+       ctype*      restrict a10,
+       ctype*      restrict a11,
+       ctype*      restrict b01,
+       ctype*      restrict b11,
+       ctype*      restrict c11, inc_t rs_c, inc_t cs_c,
+       auxinfo_t*  restrict data,
+       cntx_t*     restrict cntx
      );
 
 void bli_?gemmtrsm_u_*
      (
-       dim_t               k,
-       ctype*     restrict alpha,
-       ctype*     restrict a12,
-       ctype*     restrict a11,
-       ctype*     restrict b21,
-       ctype*     restrict b11,
-       ctype*     restrict c11, inc_t rs_c, inc_t cs_c,
-       auxinfo_t* restrict data,
-       cntx_t*    restrict cntx
+       dim_t                k,
+       ctype*      restrict alpha,
+       ctype*      restrict a12,
+       ctype*      restrict a11,
+       ctype*      restrict b21,
+       ctype*      restrict b11,
+       ctype*      restrict c11, inc_t rs_c, inc_t cs_c,
+       auxinfo_t*  restrict data,
+       cntx_t*     restrict cntx
      );
 ```
 Perform
@@ -2118,8 +2118,8 @@ Return the amount of time that has elapsed since some fixed time in the past. Th
 ```c
 double bli_clock_min_diff
      (
-       double time_prev_min,
-       double time_start
+       double  time_prev_min,
+       double  time_start
      );
 ```
 This function computes an intermediate value, `time_diff`, equal to `bli_clock() - time_start`, and then tentatively prepares to return the minimum value of `time_diff` and `time_min`. If that minimum value is extremely small (close to zero), the function returns `time_min` instead.

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -905,7 +905,7 @@ void bli_?axpy2v
 ```
 Perform
 ```
-  z := y + alphax * conjx(x) + alphay * conjy(y)
+  z := z + alphax * conjx(x) + alphay * conjy(y)
 ```
 where `x`, `y`, and `z` are vectors of length _m_. The kernel, if optimized, is implemented as a fused pair of calls to [axpyv](BLISTypedAPI.md#axpyv).
 
@@ -929,7 +929,7 @@ void bli_?dotaxpyv
 Perform
 ```
   rho := conjxt(x^T) * conjy(y)
-  y   := y + alpha * conjx(x)
+  z   := z + alpha * conjx(x)
 ```
 where `x`, `y`, and `z` are vectors of length _m_ and `alpha` and `rho` are scalars. The kernel, if optimized, is implemented as a fusion of calls to [dotv](BLISTypedAPI.md#dotv) and [axpyv](BLISTypedAPI.md#axpyv).
 
@@ -974,7 +974,7 @@ void bli_?dotxf
 ```
 Perform
 ```
-  y := y + alpha * conjat(A^T) * conjx(x)
+  y := beta * y + alpha * conjat(A^T) * conjx(x)
 ```
 where `A` is an _m x b_ matrix, and `y` and `x` are vectors. The kernel, if optimized, is implemented as a fused series of calls to [dotxv](BLISTypedAPI.md#dotxv) where _b_ is less than or equal to an implementation-dependent fusing factor specific to `dotxf`.
 
@@ -1751,7 +1751,7 @@ where, on entry, `scale` and `sumsq` contain `scale_old` and `sumsq_old`, respec
 
 #### getsc
 ```c
-void bli_getsc
+void bli_?getsc
      (
        ctype*  chi,
        double* zeta_r,
@@ -1767,7 +1767,7 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 err_t bli_?getijv
      (
        dim_t   i,
-       ctype*  x, incx,
+       ctype*   x, inc_t incx,
        double* ar,
        double* ai
      );
@@ -1795,10 +1795,10 @@ Note that the object-based analogue of [getijm](BLISObjectAPI.md#getijm) does bo
 
 #### setsc
 ```c
-void bli_setsc
+void bli_?setsc
      (
-       double* zeta_r,
-       double* zeta_i,
+       double  zeta_r,
+       double  zeta_i,
        ctype*  chi
      );
 ```
@@ -1813,7 +1813,7 @@ err_t bli_?setijv
        double  ar,
        double  ai,
        dim_t   i,
-       ctype*  x, incx
+       ctype*  x, inc_t incx
      );
 ```
 Copy real and imaginary values `ar` and `ai` to the `i`th element of vector object `x`. For real domain invocations, only `ar` is copied and `ai` is ignored. (If `x` contains elements stored in single precision, the corresponding elements are typecast/demoted during the copy.)


### PR DESCRIPTION
1. Fix errors and typos.
2. Unify formatting (two spaces between formal parameter's type and name).