### PR TITLE
Update BLIS_*_INITIALIZER macros for C++ compatibility.

### DIFF
--- a/frame/base/bli_mem.h
+++ b/frame/base/bli_mem.h
@@ -136,38 +136,19 @@ BLIS_INLINE void bli_mem_set_size( siz_t size, mem_t* mem )
 // removed from the mem_t type definition. An alternative to the initializer is
 // calling bli_mem_clear() at runtime.
 
-#ifdef __cplusplus
 #define BLIS_MEM_INITIALIZER \
         { \
-          .pblk        = BLIS_PBLK_INITIALIZER, \
-          /* When using C++, which is strongly typed, we avoid use of -1 as a
-             packbuf_t value since it will result in a compile-time error. */ \
-          .buf_type    = BLIS_BUFFER_FOR_GEN_USE, \
-          .pool        = NULL, \
-          .size        = 0, \
+          BLIS_PBLK_INITIALIZER, \
+          BLIS_BUFFER_FOR_GEN_USE, \
+          NULL, \
+          0, \
         }
-#else // C99
-#define BLIS_MEM_INITIALIZER \
-        { \
-          .pblk        = BLIS_PBLK_INITIALIZER, \
-          .buf_type    = -1, \
-          .pool        = NULL, \
-          .size        = 0, \
-        }
-#endif
 
 
 BLIS_INLINE void bli_mem_clear( mem_t* mem )
 {
 	bli_mem_set_buffer( NULL, mem );
-#ifdef __cplusplus
-	const packbuf_t pb = BLIS_BUFFER_FOR_GEN_USE;
-	// When using C++, which is strongly typed, we avoid use of -1 as a
-	// packbuf_t value since it will result in a compile-time error.
-	bli_mem_set_buf_type( pb, mem );
-#else
-	bli_mem_set_buf_type( ( packbuf_t )-1, mem );
-#endif
+	bli_mem_set_buf_type( BLIS_BUFFER_FOR_GEN_USE, mem );
 	bli_mem_set_pool( NULL, mem );
 	bli_mem_set_size( 0, mem );
 }

--- a/frame/base/bli_mem.h
+++ b/frame/base/bli_mem.h
@@ -138,10 +138,10 @@ BLIS_INLINE void bli_mem_set_size( siz_t size, mem_t* mem )
 
 #define BLIS_MEM_INITIALIZER \
         { \
-          BLIS_PBLK_INITIALIZER, \
-          BLIS_BUFFER_FOR_GEN_USE, \
-          NULL, \
-          0, \
+          /* .pblk     = */ BLIS_PBLK_INITIALIZER, \
+          /* .buf_type = */ BLIS_BUFFER_FOR_GEN_USE, \
+          /* .pool     = */ NULL, \
+          /* .size     = */ 0, \
         }
 
 

--- a/frame/base/bli_pool.h
+++ b/frame/base/bli_pool.h
@@ -102,8 +102,8 @@ BLIS_INLINE void bli_pblk_set_block_size( siz_t block_size, pblk_t* pblk )
 
 #define BLIS_PBLK_INITIALIZER \
         { \
-          NULL, \
-          0, \
+          /* .buf        = */ NULL, \
+          /* .block_size = */ 0, \
         }  \
 
 BLIS_INLINE void bli_pblk_clear( pblk_t* pblk )

--- a/frame/base/bli_pool.h
+++ b/frame/base/bli_pool.h
@@ -102,8 +102,8 @@ BLIS_INLINE void bli_pblk_set_block_size( siz_t block_size, pblk_t* pblk )
 
 #define BLIS_PBLK_INITIALIZER \
         { \
-          .buf        = NULL, \
-          .block_size = 0, \
+          NULL, \
+          0, \
         }  \
 
 BLIS_INLINE void bli_pblk_clear( pblk_t* pblk )

--- a/frame/base/bli_rntm.h
+++ b/frame/base/bli_rntm.h
@@ -258,13 +258,15 @@ BLIS_INLINE void bli_rntm_clear_l3_sup( rntm_t* rntm )
 
 #define BLIS_RNTM_INITIALIZER \
         { \
-          .thread_impl = BLIS_SINGLE, \
-          .num_threads = 1, \
-          .thrloop     = { 1, 1, 1, 1, 1, 1 }, \
-          .auto_factor = FALSE, \
-          .pack_a      = FALSE, \
-          .pack_b      = FALSE, \
-          .l3_sup      = TRUE, \
+          BLIS_SINGLE, \
+\
+          FALSE, \
+\
+          1, \
+          { 1, 1, 1, 1, 1, 1 }, \
+          FALSE, \
+          FALSE, \
+          TRUE, \
         }  \
 
 #if 0

--- a/frame/base/bli_rntm.h
+++ b/frame/base/bli_rntm.h
@@ -258,15 +258,15 @@ BLIS_INLINE void bli_rntm_clear_l3_sup( rntm_t* rntm )
 
 #define BLIS_RNTM_INITIALIZER \
         { \
-          BLIS_SINGLE, \
+          /* .thread_impl */ = BLIS_SINGLE, \
 \
-          FALSE, \
+          /* .auto_factor */ = FALSE, \
 \
-          1, \
-          { 1, 1, 1, 1, 1, 1 }, \
-          FALSE, \
-          FALSE, \
-          TRUE, \
+          /* .num_threads */ = 1, \
+          /* .thrloop     */ = { 1, 1, 1, 1, 1, 1 }, \
+          /* .pack_a      */ = FALSE, \
+          /* .pack_b      */ = FALSE, \
+          /* .l3_sup      */ = TRUE, \
         }  \
 
 #if 0

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -1292,68 +1292,68 @@ typedef struct obj_s
 
 #define BLIS_OBJECT_INITIALIZER \
 { \
-	NULL, \
+	/* .root        */ = NULL, \
 \
-	{ 0, 0 }, \
-	{ 0, 0 }, \
-	0, \
+	/* .off         */ = { 0, 0 }, \
+	/* .dim         */ = { 0, 0 }, \
+	/* .diag_off    */ = 0, \
 \
-	0x0 | BLIS_BITVAL_DENSE      | \
-	      BLIS_BITVAL_GENERAL, \
-	0x0, \
-	sizeof( float ), /* this is changed later. */ \
+	/* .info        */ = 0x0 | BLIS_BITVAL_DENSE      | \
+	/*              */         BLIS_BITVAL_GENERAL, \
+	/* .info2       */ = 0x0, \
+	/* .elem_size   */ = sizeof( float ), /* this is changed later. */ \
 \
-	NULL, \
-	0, \
-	0, \
-	1,  \
+	/* .buffer      */ = NULL, \
+	/* .rs          */ = 0, \
+	/* .cs          */ = 0, \
+	/* .is          */ = 1,  \
 \
-	{ 0.0, 0.0 }, \
+	/* .scalar      */ = { 0.0, 0.0 }, \
 \
-	0, \
-	0, \
-	0, \
-	0, \
-	0, \
-	0, \
+	/* .m_padded    */ = 0, \
+	/* .n_padded    */ = 0, \
+	/* .ps          */ = 0, \
+	/* .pd          */ = 0, \
+	/* .m_panel     */ = 0, \
+	/* .n_panel     */ = 0, \
 \
-	NULL, \
-	NULL, \
-	NULL, \
-	NULL  \
+	/* .pack_fn     */ = NULL, \
+	/* .pack_params */ = NULL, \
+	/* .ker_fn      */ = NULL, \
+	/* .ker_params  */ = NULL  \
 }
 
 #define BLIS_OBJECT_INITIALIZER_1X1 \
 { \
-	NULL, \
+	/* .root        */ = NULL, \
 \
-	{ 0, 0 }, \
-	{ 1, 1 }, \
-	0, \
+	/* .off         */ = { 0, 0 }, \
+	/* .dim         */ = { 1, 1 }, \
+	/* .diag_off    */ = 0, \
 \
-	0x0 | BLIS_BITVAL_DENSE      | \
-	      BLIS_BITVAL_GENERAL, \
-	0x0, \
-	sizeof( float ), /* this is changed later. */ \
+	/* .info        */ = 0x0 | BLIS_BITVAL_DENSE      | \
+	/*              */         BLIS_BITVAL_GENERAL, \
+	/* .info2       */ = 0x0, \
+	/* .elem_size   */ = sizeof( float ), /* this is changed later. */ \
 \
-	NULL, \
-	0, \
-	0, \
-	1,  \
+	/* .buffer      */ = NULL, \
+	/* .rs          */ = 0, \
+	/* .cs          */ = 0, \
+	/* .is          */ = 1,  \
 \
-	{ 0.0, 0.0 }, \
+	/* .scalar      */ = { 0.0, 0.0 }, \
 \
-	0, \
-	0, \
-	0, \
-	0, \
-	0, \
-	0, \
+	/* .m_padded    */ = 0, \
+	/* .n_padded    */ = 0, \
+	/* .ps          */ = 0, \
+	/* .pd          */ = 0, \
+	/* .m_panel     */ = 0, \
+	/* .n_panel     */ = 0, \
 \
-	NULL, \
-	NULL, \
-	NULL, \
-	NULL  \
+	/* .pack_fn     */ = NULL, \
+	/* .pack_params */ = NULL, \
+	/* .ker_fn      */ = NULL, \
+	/* .ker_params  */ = NULL  \
 }
 
 // Define these macros here since they must be updated if contents of

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -1292,68 +1292,68 @@ typedef struct obj_s
 
 #define BLIS_OBJECT_INITIALIZER \
 { \
-	.root        = NULL, \
+	NULL, \
 \
-	.off         = { 0, 0 }, \
-	.dim         = { 0, 0 }, \
-	.diag_off    = 0, \
+	{ 0, 0 }, \
+	{ 0, 0 }, \
+	0, \
 \
-	.info        = 0x0 | BLIS_BITVAL_DENSE      | \
-	                     BLIS_BITVAL_GENERAL, \
-	.info2       = 0x0, \
-	.elem_size   = sizeof( float ), /* this is changed later. */ \
+	0x0 | BLIS_BITVAL_DENSE      | \
+	      BLIS_BITVAL_GENERAL, \
+	0x0, \
+	sizeof( float ), /* this is changed later. */ \
 \
-	.buffer      = NULL, \
-	.rs          = 0, \
-	.cs          = 0, \
-	.is          = 1,  \
+	NULL, \
+	0, \
+	0, \
+	1,  \
 \
-	.scalar      = { 0.0, 0.0 }, \
+	{ 0.0, 0.0 }, \
 \
-	.m_padded    = 0, \
-	.n_padded    = 0, \
-	.ps          = 0, \
-	.pd          = 0, \
-	.m_panel     = 0, \
-	.n_panel     = 0, \
+	0, \
+	0, \
+	0, \
+	0, \
+	0, \
+	0, \
 \
-	.pack_fn     = NULL, \
-	.pack_params = NULL, \
-	.ker_fn      = NULL, \
-	.ker_params  = NULL  \
+	NULL, \
+	NULL, \
+	NULL, \
+	NULL  \
 }
 
 #define BLIS_OBJECT_INITIALIZER_1X1 \
 { \
-	.root        = NULL, \
+	NULL, \
 \
-	.off         = { 0, 0 }, \
-	.dim         = { 1, 1 }, \
-	.diag_off    = 0, \
+	{ 0, 0 }, \
+	{ 1, 1 }, \
+	0, \
 \
-	.info        = 0x0 | BLIS_BITVAL_DENSE      | \
-	                     BLIS_BITVAL_GENERAL, \
-	.info2       = 0x0, \
-	.elem_size   = sizeof( float ), /* this is changed later. */ \
+	0x0 | BLIS_BITVAL_DENSE      | \
+	      BLIS_BITVAL_GENERAL, \
+	0x0, \
+	sizeof( float ), /* this is changed later. */ \
 \
-	.buffer      = NULL, \
-	.rs          = 0, \
-	.cs          = 0, \
-	.is          = 1,  \
+	NULL, \
+	0, \
+	0, \
+	1,  \
 \
-	.scalar      = { 0.0, 0.0 }, \
+	{ 0.0, 0.0 }, \
 \
-	.m_padded    = 0, \
-	.n_padded    = 0, \
-	.ps          = 0, \
-	.pd          = 0, \
-	.m_panel     = 0, \
-	.n_panel     = 0, \
+	0, \
+	0, \
+	0, \
+	0, \
+	0, \
+	0, \
 \
-	.pack_fn     = NULL, \
-	.pack_params = NULL, \
-	.ker_fn      = NULL, \
-	.ker_params  = NULL  \
+	NULL, \
+	NULL, \
+	NULL, \
+	NULL  \
 }
 
 // Define these macros here since they must be updated if contents of


### PR DESCRIPTION
- Remove designated initializer syntax. This isn't officially supported until C++20.
- Put initializers in the order in which they are defined in the struct. Even with standard or extension support for designated initializers, initializing non-static members out-of-order is an error in C++.
- Remove the conditional code which uses `-1` as the default value of the `pack_buf` member of `mem_t` in C, but `BLIS_BUFFER_FOR_GEN_USE` in C++. Simply use the latter as a common-sense default.