### PR TITLE
Allow `test/3` drivers to use default `ind_t` method.

### DIFF
--- a/test/3/test_gemm.c
+++ b/test/3/test_gemm.c
@@ -171,9 +171,14 @@ int main( int argc, char** argv )
 		bli_copym( &c, &c_save );
 
 #ifdef BLIS
-		// Switch to the induced method specified by ind.
-		bli_ind_disable_all_dt( dt );
-		bli_ind_enable_dt( ind, dt );
+		// Switch to the induced method specified by ind, unless the 'auto'
+		// option was given, in which case we leave the induced method
+		// unchanged.
+		if ( params.im_is_auto == FALSE )
+		{
+			bli_ind_disable_all_dt( dt );
+			bli_ind_enable_dt( ind, dt );
+		}
 #endif
 
 #ifdef EIGEN

--- a/test/3/test_hemm.c
+++ b/test/3/test_hemm.c
@@ -168,9 +168,14 @@ int main( int argc, char** argv )
 		bli_copym( &c, &c_save );
 
 #ifdef BLIS
-		// Switch to the induced method specified by ind.
-		bli_ind_disable_all_dt( dt );
-		bli_ind_enable_dt( ind, dt );
+		// Switch to the induced method specified by ind, unless the 'auto'
+		// option was given, in which case we leave the induced method
+		// unchanged.
+		if ( params.im_is_auto == FALSE )
+		{
+			bli_ind_disable_all_dt( dt );
+			bli_ind_enable_dt( ind, dt );
+		}
 #endif
 
 		dtime_save = DBL_MAX;

--- a/test/3/test_herk.c
+++ b/test/3/test_herk.c
@@ -168,9 +168,14 @@ int main( int argc, char** argv )
 		bli_copym( &c, &c_save );
 
 #ifdef BLIS
-		// Switch to the induced method specified by ind.
-		bli_ind_disable_all_dt( dt );
-		bli_ind_enable_dt( ind, dt );
+		// Switch to the induced method specified by ind, unless the 'auto'
+		// option was given, in which case we leave the induced method
+		// unchanged.
+		if ( params.im_is_auto == FALSE )
+		{
+			bli_ind_disable_all_dt( dt );
+			bli_ind_enable_dt( ind, dt );
+		}
 #endif
 
 		dtime_save = DBL_MAX;

--- a/test/3/test_trmm.c
+++ b/test/3/test_trmm.c
@@ -171,9 +171,14 @@ int main( int argc, char** argv )
 		bli_copym( &c, &c_save );
 
 #ifdef BLIS
-		// Switch to the induced method specified by ind.
-		bli_ind_disable_all_dt( dt );
-		bli_ind_enable_dt( ind, dt );
+		// Switch to the induced method specified by ind, unless the 'auto'
+		// option was given, in which case we leave the induced method
+		// unchanged.
+		if ( params.im_is_auto == FALSE )
+		{
+			bli_ind_disable_all_dt( dt );
+			bli_ind_enable_dt( ind, dt );
+		}
 #endif
 
 		dtime_save = DBL_MAX;

--- a/test/3/test_trsm.c
+++ b/test/3/test_trsm.c
@@ -174,9 +174,14 @@ int main( int argc, char** argv )
 		bli_copym( &c, &c_save );
 
 #ifdef BLIS
-		// Switch to the induced method specified by ind.
-		bli_ind_disable_all_dt( dt );
-		bli_ind_enable_dt( ind, dt );
+		// Switch to the induced method specified by ind, unless the 'auto'
+		// option was given, in which case we leave the induced method
+		// unchanged.
+		if ( params.im_is_auto == FALSE )
+		{
+			bli_ind_disable_all_dt( dt );
+			bli_ind_enable_dt( ind, dt );
+		}
 #endif
 
 		dtime_save = DBL_MAX;

--- a/test/3/test_utils.c
+++ b/test/3/test_utils.c
@@ -38,7 +38,7 @@
 // Global string constants.
 const char* GLOB_DEF_DT_STR    = "d";
 const char* GLOB_DEF_SC_STR    = "ccc";
-const char* GLOB_DEF_IM_STR    = "native";
+const char* GLOB_DEF_IM_STR    = "auto";
 
 const char* GLOB_DEF_PS_STR    = "50 1000 50";
 const char* GLOB_DEF_M_STR     = "-1";
@@ -365,9 +365,10 @@ void parse_cl_params( int argc, char** argv, init_fp fp, params_t* params )
 				}
 				printf( "\n" );
 				printf( "    -i im\n" );
-				printf( "            Use native execution if im is 'native' (or 'nat'). Otherwise,\n" );
-				printf( "            if im is '1m', use the 1m method to induce complex computation\n" );
-				printf( "            using the equivalent real-domain microkernels.\n" );
+				printf( "            Use native execution if im is 'native' (or 'nat'). If im is '1m',\n" );
+				printf( "            use the 1m method to induce complex computation using the\n" );
+				printf( "            equivalent real-domain microkernels. If im is 'auto', do not\n" );
+				printf( "            explicitly set the induced method and instead use the default.\n" );
 				printf( "\n" );
 				printf( "    -p 'lo hi in'\n" );
 				printf( "            Perform a sweep of measurements of problem sizes ranging from \n" );
@@ -609,13 +610,21 @@ void proc_params( params_t* params )
 	bli_param_map_char_to_blis_dt( params->dt_str[0], &params->dt );
 
 	// Parse the induced method to the corresponding ind_t.
-	if      ( strncmp( params->im_str, "native", 6 ) == 0 )
+	if    ( strncmp( params->im_str, "native", 6 ) == 0 ||
+	        strncmp( params->im_str, "nat",    3 ) == 0 )
 	{
-		params->im = BLIS_NAT;
+		params->im         = BLIS_NAT;
+		params->im_is_auto = FALSE;
 	}
 	else if ( strncmp( params->im_str, "1m",     2 ) == 0 )
 	{
-		params->im = BLIS_1M;
+		params->im         = BLIS_1M;
+		params->im_is_auto = FALSE;
+	}
+	else if ( strncmp( params->im_str, "auto",   4 ) == 0 )
+	{
+		params->im         = BLIS_1M;
+		params->im_is_auto = TRUE;
 	}
 	else
 	{

--- a/test/3/test_utils.h
+++ b/test/3/test_utils.h
@@ -90,6 +90,7 @@ typedef struct params_s
 
 	const char* im_str;
 	ind_t im;
+	bool  im_is_auto;
 
 	// Problem size range and dimension specifiers.
 	const char* ps_str;


### PR DESCRIPTION
Details:
- Previously, the standalone performance drivers in `test/3` were written under the assumption that the user would want to explicitly test either native execution *or* 1m. But because the accompanying `runme.sh` script defaults to passing "native" in for the `-i` command line option (which explicitly sets the induced method type), using it without modification causes the test drivers to use reference microkernels on systems where native complex-domain microkernels are not registered. Furthermore, even if a user was aware of this, the test drivers did not support any single value for the `-i` option that would test BLIS using the library's default behavior -- that is, using 1m on systems where it is needed and native execution on systems that have native microkernels.
- This commit addresses the aforementioned issue by supporting a new value for the `-i` option: `"auto"`. The `"auto"` value causes the driver to avoid explicitly setting the induced method altogether, leaving BLIS's default behavior in place. This `"auto"` option is now the default setting within the `runme.sh` script. Thanks to Leick Robinson for finding and reporting this issue.
- Also added support for `"nat"` as a shorthand for `"native"`, which the help text already (erroneously) claimed was supported.