### PR TITLE
Fix SyntaxWarning messages from python 3.12

### DIFF
--- a/build/add-copyright.py
+++ b/build/add-copyright.py
@@ -200,7 +200,7 @@ def main():
 		file_string = "".join( file_lines )
 
 		# Search for an existing copyright line.
-		has_cr = re.search( 'Copyright \(C\)', file_string )
+		has_cr = re.search( r'Copyright \(C\)', file_string )
 
 		# If the file does not have any copyright notice in it already, we
 		# assume we don't need to update it.
@@ -210,7 +210,7 @@ def main():
 
 		# Check whether the file already has a copyright for the_org. We may
 		# need to use this information later.
-		has_org_cr = re.search( 'Copyright \(C\) ([0-9][0-9][0-9][0-9]), %s' % the_org, file_string )
+		has_org_cr = re.search( r'Copyright \(C\) ([0-9][0-9][0-9][0-9]), %s' % the_org, file_string )
 
 		# Initialize the list of processed (potentially modified) file lines.
 		mod_file_lines = []
@@ -225,7 +225,7 @@ def main():
 			# Iterate through the lines in the current file.
 			for line in file_lines:
 
-				result = re.search( 'Copyright \(C\) ([0-9][0-9][0-9][0-9]), %s' % the_org, line )
+				result = re.search( r'Copyright \(C\) ([0-9][0-9][0-9][0-9]), %s' % the_org, line )
 
 				# If the current line matches a copyright line for the_org...
 				if result:
@@ -284,8 +284,8 @@ def main():
 					line_next = file_lines[i]
 
 				# Try to match both the current line and the next line.
-				result  = re.search( 'Copyright \(C\) ([0-9][0-9][0-9][0-9]), (.*)', line )
-				resnext = re.search( 'Copyright \(C\) ([0-9][0-9][0-9][0-9]), (.*)', line_next )
+				result  = re.search( r'Copyright \(C\) ([0-9][0-9][0-9][0-9]), (.*)', line )
+				resnext = re.search( r'Copyright \(C\) ([0-9][0-9][0-9][0-9]), (.*)', line_next )
 
 				# Parse the results.
 				if result:

--- a/build/add-copyright.py
+++ b/build/add-copyright.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -253,7 +253,7 @@ def main():
 
 						# Add the unchanged line to the running list.
 						mod_file_lines += line
-							
+
 				else:
 					# Add the unchanged line to the running list.
 					mod_file_lines += line
@@ -301,7 +301,7 @@ def main():
 						# The current line matches but the next does not. Thus,
 						# this branch only executes for the *last* copyright line
 						# in the file.
-						
+
 						# Extract the year and organization from the matched
 						# string.
 						old_year = result.group(1)

--- a/build/flatten-headers.py
+++ b/build/flatten-headers.py
@@ -110,7 +110,7 @@ def print_usage():
 
 def canonicalize_ws( s ):
 
-	return re.sub( '\s+', ' ', s ).strip()
+	return re.sub( r'\s+', ' ', s ).strip()
 
 # ---
 
@@ -166,7 +166,7 @@ def list_contains_header( items ):
 	rval = False
 	for item in items:
 
-		is_h = re.search( "\.h", item )
+		is_h = re.search( r"\.h", item )
 
 		if is_h:
 			rval = True
@@ -198,7 +198,7 @@ def get_header_path( filename, header_dirpaths ):
 
 def strip_cstyle_comments( string ):
 
-	return re.sub( "/\*.*?\*/", "", string, flags=re.S )
+	return re.sub( r"/\*.*?\*/", "", string, flags=re.S )
 
 # ------------------------------------------------------------------------------
 
@@ -527,7 +527,7 @@ def main():
 	# Precompile the main regular expression used to isolate #include
 	# directives and the headers they reference. This regex object will
 	# get reused over and over again in flatten_header().
-	regex = re.compile( '^[\s]*#include (["<])([\w\.\-/]*)([">])' )
+	regex = re.compile( r'^[\s]*#include (["<])([\w\.\-/]*)([">])' )
 
 	# Recursively substitute headers for occurrences of #include directives.
 	final_string = flatten_header( inputfile, header_dirpaths, nestsp )


### PR DESCRIPTION
This fixes python 3.12 warnings during blis compilation:
```
/var/tmp/portage/sci-libs/blis-1.0/work/blis-1.0/./build/flatten-headers.py:113: SyntaxWarning: invalid escape sequence '\s'
  return re.sub( '\s+', ' ', s ).strip()
/var/tmp/portage/sci-libs/blis-1.0/work/blis-1.0/./build/flatten-headers.py:169: SyntaxWarning: invalid escape sequence '\.'
  is_h = re.search( "\.h", item )
/var/tmp/portage/sci-libs/blis-1.0/work/blis-1.0/./build/flatten-headers.py:201: SyntaxWarning: invalid escape sequence '\*'
  return re.sub( "/\*.*?\*/", "", string, flags=re.S )
/var/tmp/portage/sci-libs/blis-1.0/work/blis-1.0/./build/flatten-headers.py:530: SyntaxWarning: invalid escape sequence '\s'
  regex = re.compile( '^[\s]*#include (["<])([\w\.\-/]*)([">])' )
```

Note that in later Python version these warning [will be promoted to errors](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes).

Command to check: `python -m compileall -d . -f -q .`