### PR TITLE
Add a ScaLAPACK compatibility mode.

### DIFF
--- a/build/bli_config.h.in
+++ b/build/bli_config.h.in
@@ -110,6 +110,12 @@
 #define BLIS_DISABLE_MEM_TRACING
 #endif
 
+#if @scalapack_compat@
+#define BLIS_ENABLE_SCALAPACK_COMPAT
+#else
+#define BLIS_DISABLE_SCALAPACK_COMPAT
+#endif
+
 #if @int_type_size@ == 64
 #define BLIS_INT_TYPE_SIZE 64
 #elif @int_type_size@ == 32

--- a/configure
+++ b/configure
@@ -303,6 +303,12 @@ print_usage()
                  which are determined by the BLIS subconfiguration used at
                  runtime.) By default, these customized files are disabled.
 
+   --enable-scalapack-compat, --disable-scalapack-compat
+
+                 Enable strict compatibility with ScaLAPACK, which may
+                 requiring disabling certain conflicting functionality
+                 available throught the BLAS and/or CBLAS interfaces.
+
    -a NAME --enable-addon=NAME
 
                  Enable the code provided by an addon. An addon consists
@@ -3011,6 +3017,7 @@ blis_main()
 	enable_trsm_preinversion='yes'
 	force_version='no'
 	complex_return='default'
+	scalapack_compat='no'
 
 	# The addon flag and names.
 	addon_flag=''
@@ -3263,6 +3270,13 @@ blis_main()
 							;;
 						disable-amd-frame-tweaks)
 							enable_amd_frame_tweaks='no'
+							;;
+
+						enable-scalapack-compat)
+							scalapack_compat='yes'
+							;;
+						disable-scalapack-compat)
+							scalapack_compat='no'
 							;;
 
 						with-memkind)
@@ -3933,6 +3947,13 @@ blis_main()
 		echo "${script_name}: memory tracing output is disabled."
 		enable_mem_tracing_01=0
 	fi
+	if [[ ${scalapack_compat} = yes ]]; then
+		echo "${script_name}: ScaLAPACK compatibility is enabled."
+		scalapack_compat_01=1
+	else
+		echo "${script_name}: ScaLAPACK compatibility is disabled."
+		scalapack_compat_01=0
+	fi
 	if [[ ${has_memkind} = yes ]]; then
 		if [[ -z ${enable_memkind} ]]; then
 			# If no explicit option was given for libmemkind one way or the other,
@@ -4311,6 +4332,7 @@ blis_main()
 	add_config_var complex_return_intel      complex_return_intel01
 	add_config_var addon_list_includes
 	add_config_var enable_addons             enable_addons_01
+	add_config_var scalapack_compat          scalapack_compat_01
 
 	generate_config_file "${config_mk_in_path}"    "${config_mk_out_path}"
 	generate_config_file "${bli_config_h_in_path}" "${bli_config_h_out_path}"

--- a/frame/compat/bla_symv.c
+++ b/frame/compat/bla_symv.c
@@ -39,6 +39,8 @@
 // Define BLAS-to-BLIS interfaces.
 //
 #undef  GENTFUNC
+#undef  GENTFUNCRO
+#define GENTFUNCRO GENTFUNC
 #define GENTFUNC( ftype, ch, blasname, blisname ) \
 \
 void PASTEF77(ch,blasname) \
@@ -110,6 +112,10 @@ void PASTEF77(ch,blasname) \
 }
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
+INSERT_GENTFUNCRO_BLAS( symv, symv )
+#else
 INSERT_GENTFUNC_BLAS( symv, symv )
+#endif
 #endif
 

--- a/frame/compat/bla_symv.h
+++ b/frame/compat/bla_symv.h
@@ -38,6 +38,8 @@
 // Prototype BLAS-to-BLIS interfaces.
 //
 #undef  GENTPROT
+#undef  GENTPROTRO
+#define GENTPROTRO GENTPROT
 #define GENTPROT( ftype, ch, blasname ) \
 \
 BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
@@ -52,7 +54,11 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      );
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
+INSERT_GENTPROTRO_BLAS( symv )
+#else
 INSERT_GENTPROT_BLAS( symv )
+#endif
 #endif
 
 #endif

--- a/frame/compat/bla_syr.c
+++ b/frame/compat/bla_syr.c
@@ -39,6 +39,8 @@
 // Define BLAS-to-BLIS interfaces.
 //
 #undef  GENTFUNC
+#undef  GENTFUNCRO
+#define GENTFUNCRO GENTFUNC
 #define GENTFUNC( ftype, ch, blasname, blisname ) \
 \
 void PASTEF77(ch,blasname) \
@@ -101,6 +103,10 @@ void PASTEF77(ch,blasname) \
 }
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
+INSERT_GENTFUNCRO_BLAS( syr, syr )
+#else
 INSERT_GENTFUNC_BLAS( syr, syr )
+#endif
 #endif
 

--- a/frame/compat/bla_syr.h
+++ b/frame/compat/bla_syr.h
@@ -38,6 +38,8 @@
 // Prototype BLAS-to-BLIS interfaces.
 //
 #undef  GENTPROT
+#undef  GENTPROTRO
+#define GENTPROTRO GENTPROT
 #define GENTPROT( ftype, ch, blasname ) \
 \
 BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
@@ -50,7 +52,11 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      );
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
+INSERT_GENTPROTRO_BLAS( syr )
+#else
 INSERT_GENTPROT_BLAS( syr )
+#endif
 #endif
 
 #endif

--- a/frame/compat/bla_syr2.c
+++ b/frame/compat/bla_syr2.c
@@ -38,8 +38,10 @@
 //
 // Define BLAS-to-BLIS interfaces.
 //
+#undef  GENTFUNC
 #undef  GENTFUNCRO
-#define GENTFUNCRO( ftype, ch, blasname, blisname ) \
+#define GENTFUNCRO GENTFUNC
+#define GENTFUNC( ftype, ch, blasname, blisname ) \
 \
 void PASTEF77(ch,blasname) \
      ( \
@@ -109,6 +111,10 @@ void PASTEF77(ch,blasname) \
 }
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
 INSERT_GENTFUNCRO_BLAS( syr2, syr2 )
+#else
+INSERT_GENTFUNC_BLAS( syr2, syr2 )
+#endif
 #endif
 

--- a/frame/compat/bla_syr2.h
+++ b/frame/compat/bla_syr2.h
@@ -37,8 +37,10 @@
 //
 // Prototype BLAS-to-BLIS interfaces.
 //
+#undef  GENTPROT
 #undef  GENTPROTRO
-#define GENTPROTRO( ftype, ch, blasname ) \
+#define GENTPROTRO GENTPROT
+#define GENTPROT( ftype, ch, blasname ) \
 \
 BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      ( \
@@ -51,7 +53,11 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      );
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
 INSERT_GENTPROTRO_BLAS( syr2 )
+#else
+INSERT_GENTPROT_BLAS( syr2 )
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
Details:
- Add configure options `--enable-scalapack-compat` and `--disabled-scalapack-compat`
  (default disabled).
- Add a macro `BLIS_{ENABLE,DISABLE}_SCALAPACK_COMPAT` to bli_config.h.
- This option and macro control any changes to the API necessary to maintain compatibility
  with ScaLAPACK. Currently, this only means disabling the complex versions of `syr`, `syr2`,
  and `symv`. In the future, other changes could be controlled by the same flag.
- Complex `syr2` wasn't enabled at the same time that complex `syr` and `symv` were.
  This is now corrected.
- Fixes #812.