### PR TITLE
Implemented `--omit-symbols=LIST` `configure` option.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -19,6 +19,7 @@ but many others have contributed code, ideas, and feedback, including
   Abhishek Bagusetty       @abagusetty                (Argonne National Laboratory)
   Satish Balay             @balay                     (Argonne National Laboratory)
   Kihiro Bando             @bandokihiro
+  Timo Betcke              @tbetcke                   (University College London)
   Matthew Brett            @matthew-brett             (University of Birmingham)
   Jérémie du Boisberranger @jeremiedbb
   Jed Brown                @jedbrown                  (Argonne National Laboratory)

--- a/build/bli_config.h.in
+++ b/build/bli_config.h.in
@@ -45,6 +45,9 @@
 // Enabled kernel sets (kernel_list)
 @kernel_list_defines@
 
+// Disabled symbols (symbol_omit_list)
+@omit_symbol_list_defines@
+
 #define BLIS_VERSION_STRING "@version@"
 
 #if @enable_system@

--- a/configure
+++ b/configure
@@ -144,6 +144,50 @@ print_usage()
                  library. If the shared library build is disabled, the
                  static library build must remain enabled.
 
+   --omit-symbols=LIST
+
+                 Omit a custom set of compatibility symbols when building
+                 BLIS. When given, LIST is parsed as a comma-separated
+                 list of symbol names (excluding any trailing underscore).
+                 This option is useful when (1) the user is planning to
+                 link BLIS with another library that provides conflicting
+                 symbols, and (2) the user wishes the symbols in this
+                 other library to prevail at link time without relying on
+                 weak/strong symbol semantics. Note that currently ONLY
+                 the following symbols are supported for omission:
+
+                           crot    zrot    lsame
+                           csymv   zsymv   xerbla
+                           csyr    zsyr    xerbla_array
+                           csyr2   zsyr2
+
+   --enable-lapack-compat, --disable-lapack-compat
+
+                 Enable strict compatibility with LAPACK. This option
+                 causes BLIS to be built without some routines that we
+                 consider to be BLAS compatibility routines but that
+                 also happen to be provided by LAPACK. This option is
+                 equivalent to using the --omit-symbols=LIST option
+                 where LIST contains the following symbols:
+
+                           crot    zrot    lsame
+                           csymv   zsymv   xerbla
+                           csyr    zsyr    xerbla_array
+                           csyr2   zsyr2
+
+   --enable-scalapack-compat, --disable-scalapack-compat
+
+                 Enable strict compatibility with ScaLAPACK. This option
+                 causes BLIS to be built without some routines that we
+                 consider to be BLAS compatibility routines but that
+                 also happen to be provided by ScaLAPACK. This option is
+                 equivalent to using the --omit-symbols=LIST option
+                 where LIST contains the following symbols:
+
+                           csymv   zsymv
+                           csyr    zsyr
+                           csyr2   zsyr2
+
    --enable-rpath, --disable-rpath
 
                  Enable (disabled by default) setting an install_name for
@@ -302,12 +346,6 @@ print_usage()
                  option is NOT to be confused with enabling AMD *kernels*,
                  which are determined by the BLIS subconfiguration used at
                  runtime.) By default, these customized files are disabled.
-
-   --enable-scalapack-compat, --disable-scalapack-compat
-
-                 Enable strict compatibility with ScaLAPACK, which may
-                 requiring disabling certain conflicting functionality
-                 available through the BLAS and/or CBLAS interfaces.
 
    -a NAME --enable-addon=NAME
 
@@ -3015,9 +3053,13 @@ blis_main()
 	enable_amd_frame_tweaks='no'
 	enable_memkind='' # The default memkind value is determined later on.
 	enable_trsm_preinversion='yes'
+	enable_lapack_compat='no'
 	enable_scalapack_compat='no'
 	force_version='no'
 	complex_return='default'
+
+	# The symbol omission list.
+	omit_symbol_list=''
 
 	# The addon flag and names.
 	addon_flag=''
@@ -3155,6 +3197,10 @@ blis_main()
 							enable_shared='no'
 							;;
 
+						omit-symbols=*)
+							omit_symbol_list=${OPTARG#*=}
+							;;
+
 						enable-rpath)
 							enable_rpath='yes'
 							;;
@@ -3270,6 +3316,13 @@ blis_main()
 							;;
 						disable-amd-frame-tweaks)
 							enable_amd_frame_tweaks='no'
+							;;
+
+						enable-lapack-compat)
+							enable_lapack_compat='yes'
+							;;
+						disable-lapack-compat)
+							enable_lapack_compat='no'
 							;;
 
 						enable-scalapack-compat)
@@ -3675,6 +3728,54 @@ blis_main()
 		exit 1
 	fi
 
+	# Check for the LAPACK compatibility option before the option for symbol
+	# omission since the former can imply/augment the latter.
+	if [[ ${enable_lapack_compat} = yes ]]; then
+		echo "${script_name}: LAPACK compatibility is enabled."
+		enable_lapack_compat_01=1
+		problematic_symbols="crot,zrot,csymv,zsymv,csyr,zsyr,csyr2,zsyr2,lsame,xerbla,xerbla_array"
+		omit_symbol_list="${omit_symbol_list},${problematic_symbols}"
+	else
+		echo "${script_name}: LAPACK compatibility is disabled."
+		enable_lapack_compat_01=0
+	fi
+
+	# Check for the ScaLAPACK compatibility option before the option for symbol
+	# omission since the former can imply/augment the latter.
+	if [[ ${enable_scalapack_compat} = yes ]]; then
+		echo "${script_name}: ScaLAPACK compatibility is enabled."
+		enable_scalapack_compat_01=1
+		problematic_symbols="csymv,zsymv,csyr,zsyr,csyr2,zsyr2"
+		omit_symbol_list="${omit_symbol_list},${problematic_symbols}"
+	else
+		echo "${script_name}: ScaLAPACK compatibility is disabled."
+		enable_scalapack_compat_01=0
+	fi
+
+	# Check if we are omitting any symbols.
+	if [[ ${omit_symbol_list} != "" ]]; then
+
+		# Create a list of #defines, one for each symbol the user requested
+		# that we omit. Note that first we convert the list's commas into
+		# spaces.
+
+		# Start by changing the comma-separated list to a space-separated list.
+		omit_symbol_list=$(echo "${omit_symbol_list}" | sed -e "s/,/ /g")
+
+		# Remove duplicates.
+		#omit_symbol_list=$(rm_duplicate_words_simple "${omit_symbol_list}")
+
+		# Sort the list, removing duplicates (via -u).
+		omit_symbol_list=$(echo "${omit_symbol_list}" | xargs -n1 | sort -u)
+
+		echo "${script_name}: omitting the following symbols from BLIS:"
+		for omit_symbol_name in ${omit_symbol_list}; do
+			echo "${script_name}:   ${omit_symbol_name}"
+		done
+	else
+		echo "${script_name}: no symbols will be omitted."
+	fi
+
 	# Check if we are building with or without operating system support.
 	if [[ ${enable_system} = yes ]]; then
 		echo "${script_name}: enabling operating system support."
@@ -3947,13 +4048,6 @@ blis_main()
 		echo "${script_name}: memory tracing output is disabled."
 		enable_mem_tracing_01=0
 	fi
-	if [[ ${enable_scalapack_compat} = yes ]]; then
-		echo "${script_name}: ScaLAPACK compatibility is enabled."
-		enable_scalapack_compat_01=1
-	else
-		echo "${script_name}: ScaLAPACK compatibility is disabled."
-		enable_scalapack_compat_01=0
-	fi
 	if [[ ${has_memkind} = yes ]]; then
 		if [[ -z ${enable_memkind} ]]; then
 			# If no explicit option was given for libmemkind one way or the other,
@@ -4216,6 +4310,28 @@ blis_main()
 		addon_list_includes="${addon_list_includes}#include ${addon_header}\n"
 	done
 
+	# Make sure that omit_symbol_list only contains lowercase letters, digits,
+	# underscores, and commas.
+	omit_symbol_list_check=$(echo "${omit_symbol_list}" | sed -e "s/[a-z0-9_, ]//g")
+
+	if [[ "${omit_symbol_list_check}" != "" ]]; then
+		echo "${script_name}: --omit-symbol=LIST option contains unexpected characters: ${omit_symbol_list_check}"
+		exit 1
+	fi
+
+	# Create a list of #defines, one for each symbol the user requested that we
+	# omit. Note that first we convert the list's commas into spaces.
+	omit_symbol_list=$(echo "${omit_symbol_list}" | sed -e "s/,/ /g")
+	for sym in ${omit_symbol_list}; do
+
+		# Convert the current config name to uppercase.
+		sym=$(echo "${sym}" | tr '[:lower:]' '[:upper:]')
+
+		# Create a #define and add it to the running list.
+		omit_define="BLIS_DISABLE_${sym}"
+		omit_symbol_list_defines="${omit_symbol_list_defines}#define ${omit_define}\n"
+	done
+
 
 	# -- Determine whether we are performing an out-of-tree build --------------
 
@@ -4310,6 +4426,7 @@ blis_main()
 	add_config_var config_name_define
 	add_config_var config_list_defines
 	add_config_var kernel_list_defines
+	add_config_var omit_symbol_list_defines
 	add_config_var enable_tls                enable_tls_01
 	add_config_var enable_openmp             enable_openmp_01
 	add_config_var enable_openmp_as_def      enable_openmp_as_def_01

--- a/frame/compat/bla_symv.c
+++ b/frame/compat/bla_symv.c
@@ -112,10 +112,12 @@ void PASTEF77(ch,blasname) \
 }
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
-INSERT_GENTFUNCRO_BLAS( symv, symv )
-#else
-INSERT_GENTFUNC_BLAS( symv, symv )
+GENTFUNC( float,    s, symv, symv )
+GENTFUNC( double,   d, symv, symv )
+#ifdef BLIS_ENABLE_CSYMV
+GENTFUNC( scomplex, c, symv, symv )
+#endif
+#ifdef BLIS_ENABLE_ZSYMV
+GENTFUNC( dcomplex, z, symv, symv )
 #endif
 #endif
-

--- a/frame/compat/bla_symv.c
+++ b/frame/compat/bla_symv.c
@@ -114,10 +114,10 @@ void PASTEF77(ch,blasname) \
 #ifdef BLIS_ENABLE_BLAS
 GENTFUNC( float,    s, symv, symv )
 GENTFUNC( double,   d, symv, symv )
-#ifdef BLIS_ENABLE_CSYMV
+#ifndef BLIS_DISABLE_CSYMV
 GENTFUNC( scomplex, c, symv, symv )
 #endif
-#ifdef BLIS_ENABLE_ZSYMV
+#ifndef BLIS_DISABLE_ZSYMV
 GENTFUNC( dcomplex, z, symv, symv )
 #endif
 #endif

--- a/frame/compat/bla_symv.h
+++ b/frame/compat/bla_symv.h
@@ -52,10 +52,10 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 #ifdef BLIS_ENABLE_BLAS
 GENTPROT( float,    s, symv )
 GENTPROT( double,   d, symv )
-#ifdef BLIS_ENABLE_CSYMV
+#ifndef BLIS_DISABLE_CSYMV
 GENTPROT( scomplex, c, symv )
 #endif
-#ifdef BLIS_ENABLE_ZSYMV
+#ifndef BLIS_DISABLE_ZSYMV
 GENTPROT( dcomplex, z, symv )
 #endif
 #endif

--- a/frame/compat/bla_symv.h
+++ b/frame/compat/bla_symv.h
@@ -32,14 +32,10 @@
 
 */
 
-#if 1
-
 //
 // Prototype BLAS-to-BLIS interfaces.
 //
 #undef  GENTPROT
-#undef  GENTPROTRO
-#define GENTPROTRO GENTPROT
 #define GENTPROT( ftype, ch, blasname ) \
 \
 BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
@@ -54,12 +50,12 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      );
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
-INSERT_GENTPROTRO_BLAS( symv )
-#else
-INSERT_GENTPROT_BLAS( symv )
+GENTPROT( float,    s, symv )
+GENTPROT( double,   d, symv )
+#ifdef BLIS_ENABLE_CSYMV
+GENTPROT( scomplex, c, symv )
+#endif
+#ifdef BLIS_ENABLE_ZSYMV
+GENTPROT( dcomplex, z, symv )
 #endif
 #endif
-
-#endif
-

--- a/frame/compat/bla_syr.c
+++ b/frame/compat/bla_syr.c
@@ -103,10 +103,12 @@ void PASTEF77(ch,blasname) \
 }
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
-INSERT_GENTFUNCRO_BLAS( syr, syr )
-#else
-INSERT_GENTFUNC_BLAS( syr, syr )
+GENTFUNC( float,    s, syr, syr )
+GENTFUNC( double,   d, syr, syr )
+#ifdef BLIS_ENABLE_CSYR
+GENTFUNC( scomplex, c, syr, syr )
+#endif
+#ifdef BLIS_ENABLE_ZSYR
+GENTFUNC( dcomplex, z, syr, syr )
 #endif
 #endif
-

--- a/frame/compat/bla_syr.c
+++ b/frame/compat/bla_syr.c
@@ -105,10 +105,10 @@ void PASTEF77(ch,blasname) \
 #ifdef BLIS_ENABLE_BLAS
 GENTFUNC( float,    s, syr, syr )
 GENTFUNC( double,   d, syr, syr )
-#ifdef BLIS_ENABLE_CSYR
+#ifndef BLIS_DISABLE_CSYR
 GENTFUNC( scomplex, c, syr, syr )
 #endif
-#ifdef BLIS_ENABLE_ZSYR
+#ifndef BLIS_DISABLE_ZSYR
 GENTFUNC( dcomplex, z, syr, syr )
 #endif
 #endif

--- a/frame/compat/bla_syr.h
+++ b/frame/compat/bla_syr.h
@@ -32,14 +32,10 @@
 
 */
 
-#if 1
-
 //
 // Prototype BLAS-to-BLIS interfaces.
 //
 #undef  GENTPROT
-#undef  GENTPROTRO
-#define GENTPROTRO GENTPROT
 #define GENTPROT( ftype, ch, blasname ) \
 \
 BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
@@ -52,12 +48,12 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      );
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
-INSERT_GENTPROTRO_BLAS( syr )
-#else
-INSERT_GENTPROT_BLAS( syr )
+GENTPROT( float,    s, syr )
+GENTPROT( double,   d, syr )
+#ifdef BLIS_ENABLE_CSYMV
+GENTPROT( scomplex, c, syr )
+#endif
+#ifdef BLIS_ENABLE_ZSYMV
+GENTPROT( dcomplex, z, syr )
 #endif
 #endif
-
-#endif
-

--- a/frame/compat/bla_syr.h
+++ b/frame/compat/bla_syr.h
@@ -50,10 +50,10 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 #ifdef BLIS_ENABLE_BLAS
 GENTPROT( float,    s, syr )
 GENTPROT( double,   d, syr )
-#ifdef BLIS_ENABLE_CSYMV
+#ifndef BLIS_DISABLE_CSYR
 GENTPROT( scomplex, c, syr )
 #endif
-#ifdef BLIS_ENABLE_ZSYMV
+#ifndef BLIS_DISABLE_ZSYR
 GENTPROT( dcomplex, z, syr )
 #endif
 #endif

--- a/frame/compat/bla_syr2.c
+++ b/frame/compat/bla_syr2.c
@@ -111,10 +111,10 @@ void PASTEF77(ch,blasname) \
 #ifdef BLIS_ENABLE_BLAS
 GENTFUNC( float,    s, syr2, syr2 )
 GENTFUNC( double,   d, syr2, syr2 )
-#ifdef BLIS_ENABLE_CSYR2
+#ifndef BLIS_DISABLE_CSYR2
 GENTFUNC( scomplex, c, syr2, syr2 )
 #endif
-#ifdef BLIS_ENABLE_ZSYR2
+#ifndef BLIS_DISABLE_ZSYR2
 GENTFUNC( dcomplex, z, syr2, syr2 )
 #endif
 #endif

--- a/frame/compat/bla_syr2.c
+++ b/frame/compat/bla_syr2.c
@@ -39,8 +39,6 @@
 // Define BLAS-to-BLIS interfaces.
 //
 #undef  GENTFUNC
-#undef  GENTFUNCRO
-#define GENTFUNCRO GENTFUNC
 #define GENTFUNC( ftype, ch, blasname, blisname ) \
 \
 void PASTEF77(ch,blasname) \
@@ -111,10 +109,12 @@ void PASTEF77(ch,blasname) \
 }
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
-INSERT_GENTFUNCRO_BLAS( syr2, syr2 )
-#else
-INSERT_GENTFUNC_BLAS( syr2, syr2 )
+GENTFUNC( float,    s, syr2, syr2 )
+GENTFUNC( double,   d, syr2, syr2 )
+#ifdef BLIS_ENABLE_CSYR2
+GENTFUNC( scomplex, c, syr2, syr2 )
+#endif
+#ifdef BLIS_ENABLE_ZSYR2
+GENTFUNC( dcomplex, z, syr2, syr2 )
 #endif
 #endif
-

--- a/frame/compat/bla_syr2.h
+++ b/frame/compat/bla_syr2.h
@@ -51,10 +51,10 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 #ifdef BLIS_ENABLE_BLAS
 GENTPROT( float,    s, syr2 )
 GENTPROT( double,   d, syr2 )
-#ifdef BLIS_ENABLE_CSYR2
+#ifndef BLIS_DISABLE_CSYR2
 GENTPROT( scomplex, c, syr2 )
 #endif
-#ifdef BLIS_ENABLE_ZSYR2
+#ifndef BLIS_DISABLE_ZSYR2
 GENTPROT( dcomplex, z, syr2 )
 #endif
 #endif

--- a/frame/compat/bla_syr2.h
+++ b/frame/compat/bla_syr2.h
@@ -32,14 +32,10 @@
 
 */
 
-#if 1
-
 //
 // Prototype BLAS-to-BLIS interfaces.
 //
 #undef  GENTPROT
-#undef  GENTPROTRO
-#define GENTPROTRO GENTPROT
 #define GENTPROT( ftype, ch, blasname ) \
 \
 BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
@@ -53,12 +49,12 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
      );
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_SCALAPACK_COMPAT
-INSERT_GENTPROTRO_BLAS( syr2 )
-#else
-INSERT_GENTPROT_BLAS( syr2 )
+GENTPROT( float,    s, syr2 )
+GENTPROT( double,   d, syr2 )
+#ifdef BLIS_ENABLE_CSYR2
+GENTPROT( scomplex, c, syr2 )
+#endif
+#ifdef BLIS_ENABLE_ZSYR2
+GENTPROT( dcomplex, z, syr2 )
 #endif
 #endif
-
-#endif
-

--- a/frame/compat/f2c/bla_lsame.c
+++ b/frame/compat/f2c/bla_lsame.c
@@ -35,6 +35,7 @@
 #include "blis.h"
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_LSAME
 
 /* lsame.f -- translated by f2c (version 19991025).
    You must link the resulting object file with the libraries:
@@ -150,5 +151,6 @@ int PASTEF77(lsame)(const char *ca, const char *cb, int ca_len, int cb_len)
     return ret_val;
 } /* lsame */
 
+#endif
 #endif
 

--- a/frame/compat/f2c/bla_lsame.c
+++ b/frame/compat/f2c/bla_lsame.c
@@ -35,13 +35,13 @@
 #include "blis.h"
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_LSAME
 
 /* lsame.f -- translated by f2c (version 19991025).
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
 
+#ifndef BLIS_DISABLE_LSAME
 
 #ifdef LAPACK_ILP64
 long PASTEF77(lsame)(const char *ca, const char *cb, long ca_len, long cb_len)

--- a/frame/compat/f2c/bla_lsame.h
+++ b/frame/compat/f2c/bla_lsame.h
@@ -32,7 +32,13 @@
 
 */
 
-#ifdef BLIS_ENABLE_LSAME
+// NOTE: We prototype lsame_() and xerbla_() even when those symbols are
+// omitted via the --omit-symbols=LIST configure option. This is done because
+// the BLAS compatibility layer calls lsame_() and xerbla_() within its _check()
+// functions, and we prefer to give the compiler a chance to do type checking
+// against a function prototype (and *not* output a warning) even if those
+// routines are not going to be compiled within BLIS.
+//#ifndef BLIS_DISABLE_LSAME
 
 #ifdef LAPACK_ILP64
 long PASTEF77(lsame)(const char *ca, const char *cb, long ca_len, long cb_len);
@@ -40,4 +46,4 @@ long PASTEF77(lsame)(const char *ca, const char *cb, long ca_len, long cb_len);
 BLIS_EXPORT_BLAS int PASTEF77(lsame)(const char *ca, const char *cb, int ca_len, int cb_len);
 #endif
 
-#endif
+//#endif

--- a/frame/compat/f2c/bla_lsame.h
+++ b/frame/compat/f2c/bla_lsame.h
@@ -32,7 +32,7 @@
 
 */
 
-#if 1
+#ifdef BLIS_ENABLE_LSAME
 
 #ifdef LAPACK_ILP64
 long PASTEF77(lsame)(const char *ca, const char *cb, long ca_len, long cb_len);

--- a/frame/compat/f2c/bla_rot.c
+++ b/frame/compat/f2c/bla_rot.c
@@ -360,6 +360,7 @@ L20:
 } /* zdrot_ */
 
 
+#ifdef BLIS_ENABLE_CROT
 /* crot.f -- translated by f2c (version 20100827).
    You must link the resulting object file with libf2c:
 	on Microsoft Windows system, link with libf2c.lib;
@@ -597,8 +598,10 @@ L20:
     }
     return 0;
 } /* crot_ */
+#endif
 
 
+#ifdef BLIS_ENABLE_ZROT
 /* zrot.f -- translated by f2c (version 20100827).
    You must link the resulting object file with libf2c:
 	on Microsoft Windows system, link with libf2c.lib;
@@ -836,6 +839,7 @@ L20:
     }
     return 0;
 } /* zrot_ */
+#endif
 
 
 #endif

--- a/frame/compat/f2c/bla_rot.c
+++ b/frame/compat/f2c/bla_rot.c
@@ -360,7 +360,7 @@ L20:
 } /* zdrot_ */
 
 
-#ifdef BLIS_ENABLE_CROT
+#ifndef BLIS_DISABLE_CROT
 /* crot.f -- translated by f2c (version 20100827).
    You must link the resulting object file with libf2c:
 	on Microsoft Windows system, link with libf2c.lib;
@@ -601,7 +601,7 @@ L20:
 #endif
 
 
-#ifdef BLIS_ENABLE_ZROT
+#ifndef BLIS_DISABLE_ZROT
 /* zrot.f -- translated by f2c (version 20100827).
    You must link the resulting object file with libf2c:
 	on Microsoft Windows system, link with libf2c.lib;

--- a/frame/compat/f2c/bla_rot.h
+++ b/frame/compat/f2c/bla_rot.h
@@ -36,9 +36,10 @@ BLIS_EXPORT_BLAS int PASTEF77(s,rot)(const bla_integer *n, bla_real *sx, const b
 BLIS_EXPORT_BLAS int PASTEF77(d,rot)(const bla_integer *n, bla_double *dx, const bla_integer *incx, bla_double *dy, const bla_integer *incy, const bla_double *c__, const bla_double *s);
 BLIS_EXPORT_BLAS int PASTEF77(cs,rot)(const bla_integer *n, bla_scomplex *cx, const bla_integer *incx, bla_scomplex *cy, const bla_integer *incy, const bla_real *c__, const bla_real *s);
 BLIS_EXPORT_BLAS int PASTEF77(zd,rot)(const bla_integer *n, bla_dcomplex *zx, const bla_integer *incx, bla_dcomplex *zy, const bla_integer *incy, const bla_double *c__, const bla_double *s);
-#ifdef BLIS_ENABLE_CROT
+#ifndef BLIS_DISABLE_CROT
 BLIS_EXPORT_BLAS int PASTEF77(c,rot)(const bla_integer *n, bla_scomplex *cx, const bla_integer *incx, bla_scomplex *cy, const bla_integer *incy, const bla_real *c__, const bla_scomplex *s);
 #endif
-#ifdef BLIS_ENABLE_ZROT
+#ifndef BLIS_DISABLE_ZROT
 BLIS_EXPORT_BLAS int PASTEF77(z,rot)(const bla_integer *n, bla_dcomplex *cx, const bla_integer *incx, bla_dcomplex *cy, const bla_integer *incy, const bla_double *c__, const bla_dcomplex *s);
 #endif
+

--- a/frame/compat/f2c/bla_rot.h
+++ b/frame/compat/f2c/bla_rot.h
@@ -32,13 +32,13 @@
 
 */
 
-#if 1
-
 BLIS_EXPORT_BLAS int PASTEF77(s,rot)(const bla_integer *n, bla_real *sx, const bla_integer *incx, bla_real *sy, const bla_integer *incy, const bla_real *c__, const bla_real *s);
 BLIS_EXPORT_BLAS int PASTEF77(d,rot)(const bla_integer *n, bla_double *dx, const bla_integer *incx, bla_double *dy, const bla_integer *incy, const bla_double *c__, const bla_double *s);
 BLIS_EXPORT_BLAS int PASTEF77(cs,rot)(const bla_integer *n, bla_scomplex *cx, const bla_integer *incx, bla_scomplex *cy, const bla_integer *incy, const bla_real *c__, const bla_real *s);
 BLIS_EXPORT_BLAS int PASTEF77(zd,rot)(const bla_integer *n, bla_dcomplex *zx, const bla_integer *incx, bla_dcomplex *zy, const bla_integer *incy, const bla_double *c__, const bla_double *s);
+#ifdef BLIS_ENABLE_CROT
 BLIS_EXPORT_BLAS int PASTEF77(c,rot)(const bla_integer *n, bla_scomplex *cx, const bla_integer *incx, bla_scomplex *cy, const bla_integer *incy, const bla_real *c__, const bla_scomplex *s);
+#endif
+#ifdef BLIS_ENABLE_ZROT
 BLIS_EXPORT_BLAS int PASTEF77(z,rot)(const bla_integer *n, bla_dcomplex *cx, const bla_integer *incx, bla_dcomplex *cy, const bla_integer *incy, const bla_double *c__, const bla_dcomplex *s);
-
 #endif

--- a/frame/compat/f2c/bla_xerbla.c
+++ b/frame/compat/f2c/bla_xerbla.c
@@ -35,7 +35,6 @@
 #include "blis.h"
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_XERBLA
 
 /* xerbla.f -- translated by f2c (version 19991025).
    You must link the resulting object file with the libraries:
@@ -44,6 +43,7 @@
 
 /* Table of constant values */
 
+#ifndef BLIS_DISABLE_XERBLA
 /* Subroutine */ int PASTEF77(xerbla)(const bla_character *srname, const bla_integer *info, ftnlen srname_len)
 {
 /*  -- LAPACK auxiliary routine (preliminary version) -- */

--- a/frame/compat/f2c/bla_xerbla.c
+++ b/frame/compat/f2c/bla_xerbla.c
@@ -35,6 +35,7 @@
 #include "blis.h"
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_XERBLA
 
 /* xerbla.f -- translated by f2c (version 19991025).
    You must link the resulting object file with the libraries:
@@ -87,5 +88,6 @@
     return 0;
 } /* xerbla */
 
+#endif
 #endif
 

--- a/frame/compat/f2c/bla_xerbla.h
+++ b/frame/compat/f2c/bla_xerbla.h
@@ -32,7 +32,7 @@
 
 */
 
-#if 1
+#ifdef BLIS_ENABLE_XERBLA
 
 BLIS_EXPORT_BLAS BLIS_OVERRIDABLE int PASTEF77(xerbla)(const bla_character *srname, const bla_integer *info, ftnlen srname_len);
 

--- a/frame/compat/f2c/bla_xerbla.h
+++ b/frame/compat/f2c/bla_xerbla.h
@@ -32,8 +32,14 @@
 
 */
 
-#ifdef BLIS_ENABLE_XERBLA
+// NOTE: We prototype lsame_() and xerbla_() even when those symbols are
+// omitted via the --omit-symbols=LIST configure option. This is done because
+// the BLAS compatibility layer calls lsame_() and xerbla_() within its _check()
+// functions, and we prefer to give the compiler a chance to do type checking
+// against a function prototype (and *not* output a warning) even if those
+// routines are not going to be compiled within BLIS.
+//#ifndef BLIS_DISABLE_XERBLA
 
 BLIS_EXPORT_BLAS BLIS_OVERRIDABLE int PASTEF77(xerbla)(const bla_character *srname, const bla_integer *info, ftnlen srname_len);
 
-#endif
+//#endif

--- a/frame/compat/f2c/bla_xerbla_array.c
+++ b/frame/compat/f2c/bla_xerbla_array.c
@@ -35,10 +35,10 @@
 #include "blis.h"
 
 #ifdef BLIS_ENABLE_BLAS
-#ifdef BLIS_ENABLE_XERBLA_ARRAY
 
 #define MAX_NUM_CHARS 32
 
+#ifndef BLIS_DISABLE_XERBLA_ARRAY
 int PASTEF77(xerbla_array)(const bla_character *srname_array, const bla_integer srname_len, const bla_integer *info)
 {
 	int  i;

--- a/frame/compat/f2c/bla_xerbla_array.c
+++ b/frame/compat/f2c/bla_xerbla_array.c
@@ -35,6 +35,7 @@
 #include "blis.h"
 
 #ifdef BLIS_ENABLE_BLAS
+#ifdef BLIS_ENABLE_XERBLA_ARRAY
 
 #define MAX_NUM_CHARS 32
 
@@ -70,5 +71,6 @@ int PASTEF77(xerbla_array)(const bla_character *srname_array, const bla_integer 
 	return 0;
 }
 
+#endif
 #endif
 

--- a/frame/compat/f2c/bla_xerbla_array.h
+++ b/frame/compat/f2c/bla_xerbla_array.h
@@ -32,7 +32,7 @@
 
 */
 
-#ifdef BLIS_ENABLE_XERBLA_ARRAY
+#ifndef BLIS_DISABLE_XERBLA_ARRAY
 
 BLIS_EXPORT_BLAS int PASTEF77(xerbla_array)(const bla_character *srname, const bla_integer srname_len, const bla_integer *info);
 

--- a/frame/compat/f2c/bla_xerbla_array.h
+++ b/frame/compat/f2c/bla_xerbla_array.h
@@ -32,7 +32,7 @@
 
 */
 
-#if 1
+#ifdef BLIS_ENABLE_XERBLA_ARRAY
 
 BLIS_EXPORT_BLAS int PASTEF77(xerbla_array)(const bla_character *srname, const bla_integer srname_len, const bla_integer *info);
 


### PR DESCRIPTION
Details:
- Added a new option to `configure` that allows the user to specify a list of symbols to omit from the library. The format of the option is `--omit-symbols=LIST` where `LIST` is a comma-separated list of symbol names (excluding any trailing underscore). This list is parsed into a list of `#define` directives that causes the relevant parts of BLIS to be ignored (or not). As such, the nature of this option is to only support omitting symbols which have been pre-identified as potential troublemakers when linking BLIS with other libraries such as LAPACK or ScaLAPACK. (This list may grow in the future as additional symbols are identified.)
- Re-implemented the `--enable-scalapack-compat` `configure` option to utilize the underlying `--omit-symbols=LIST` infrastructure.
- Implemented an `--enable-lapack-compat` option, which omits all of the known problematic symbols currently supported for omission.
- This commit addresses Issue #816. Thanks to Timo Betcke for bringing it to our attention and to Devin Matthews for his advice and for his initial implementation of `--enable-scalapack-compat` (PR #813).
- CREDITS file update.

cc @tbetcke