### PR TITLE
Fixed out-of-bounds read bug in sup haswell ukr.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -57,7 +57,7 @@ but many others have contributed code, ideas, and feedback, including
   Stefan Husmann           @stefanhusmann
   Aaron Hutchinson         @Aaron-Hutchinson          (SiFive)
   Francisco Igual          @figual                    (Universidad Complutense de Madrid)
-  John Mather              @jmather-sesi              (SideFX Software)
+                           @j-bm
   Madeesh Kannan           @shadeMe
   Tony Kelman              @tkelman
   Lee Killough             @leekillough               (Tactical Computing Labs)
@@ -77,6 +77,7 @@ but many others have contributed code, ideas, and feedback, including
   Giorgos Margaritis
   Bryan Marker             @bamarker                  (The University of Texas at Austin)
   Simon Lukas Märtens      @ACSimon33                 (RWTH Aachen University)
+  John Mather              @jmather-sesi              (SideFX Software)
   Devin Matthews           @devinamatthews            (The University of Texas at Austin)
   Stefanos Mavros          @smavros
   Mithun Mohan             @MithunMohanKadavil        (AMD)

--- a/kernels/haswell/3/sup/bli_gemmsup_rd_haswell_asm_s6x16n.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rd_haswell_asm_s6x16n.c
@@ -2211,7 +2211,6 @@ void bli_sgemmsup_rd_haswell_asm_1x16n
 	                                   // which would destory intermediate results.
 
 	vmovss(mem(rax       ), xmm0)
-	vmovss(mem(rax, r8, 1), xmm1)
 	add(imm(1*4), rax)                 // a += 1*cs_a = 1*4;
 
 	vmovss(mem(rbx        ), xmm3)
@@ -2412,5 +2411,6 @@ void bli_sgemmsup_rd_haswell_asm_1x16n
 			#endif
 		}
 	}
+
 }
 


### PR DESCRIPTION
Details:
- Fixed a bug in the `bli_sgemmsup_rd_haswell_asm_1x16n()` millikernel. The kernel was erroneously performing an out-of-bounds read whenever the singleton edge case loop executed (that is, whenever the k dimension of the millikernel problem was not a multiple of 8). This OOB error was the result of a copy-paste bug; when developing the `s1x16n` function, I started from a copy of the `s2x16n` function, but then failed to delete the instruction that reads the second element of A in the code that handles the PR loop's edge case. Thanks to @j-bm for reporting this bug in Issue #821 and helping narrow down the cause to the `rax` register.