### PR TITLE
Fix some aspects of the control tre/plugin infrastructure

### DIFF
--- a/build/plugin/bli_plugin.h.in
+++ b/build/plugin/bli_plugin.h.in
@@ -137,10 +137,10 @@ INSERT_GENTCONF
 #undef GENTCONF
 #define GENTCONF( CONFIG, config ) \
 \
-void PASTEMAC(plugin_init,BLIS_PNAME_INFIX,_,config)( PASTECH(plugin,BLIS_PNAME_INFIX,_params) ); \
-void PASTEMAC(plugin_init,BLIS_PNAME_INFIX,_,config,BLIS_REF_SUFFIX)( PASTECH(plugin,BLIS_PNAME_INFIX,_params) );
+void PASTEMAC(plugin_init_@plugin_name@_,config)( plugin_@plugin_name@_params ); \
+void PASTEMAC(plugin_init_@plugin_name@_,config,BLIS_REF_SUFFIX)( plugin_@plugin_name@_params );
 
 INSERT_GENTCONF
 
-BLIS_EXPORT_BLIS err_t PASTEMAC(plugin_register,BLIS_PNAME_INFIX)( PASTECH(plugin,BLIS_PNAME_INFIX,_params) );
+BLIS_EXPORT_BLIS err_t bli_plugin_register_@plugin_name@( plugin_@plugin_name@_params );
 

--- a/build/plugin/bli_plugin_init_ref.c
+++ b/build/plugin/bli_plugin_init_ref.c
@@ -56,9 +56,9 @@ do { \
 
 // -----------------------------------------------------------------------------
 
-void PASTEMAC(plugin_init,BLIS_PNAME_INFIX,BLIS_CNAME_INFIX,BLIS_REF_SUFFIX)
+void PASTEMAC(plugin_init_@plugin_name@,BLIS_CNAME_INFIX,BLIS_REF_SUFFIX)
      (
-       PASTECH(plugin,BLIS_PNAME_INFIX,_params)
+       plugin_@plugin_name@_params
      )
 {
 	cntx_t* cntx = ( cntx_t* )bli_gks_lookup_id( PASTECH(BLIS_ARCH,BLIS_CNAME_UPPER_INFIX) );

--- a/build/plugin/bli_plugin_init_zen3.c
+++ b/build/plugin/bli_plugin_init_zen3.c
@@ -34,13 +34,18 @@
 
 #include @PLUGIN_HEADER@
 
-void PASTEMAC(plugin_init,BLIS_PNAME_INFIX,BLIS_CNAME_INFIX)
+void PASTEMAC(plugin_init_@plugin_name@,BLIS_CNAME_INFIX)
      (
-       PASTECH(plugin,BLIS_PNAME_INFIX,_params)
+       plugin_@plugin_name@_params
      )
 {
 	cntx_t* cntx = ( cntx_t* )bli_gks_lookup_id( PASTECH(BLIS_ARCH,BLIS_CNAME_UPPER_INFIX) );
 	( void )cntx;
+
+	PASTEMAC(plugin_init_@plugin_name@,BLIS_CNAME_INFIX,BLIS_REF_SUFFIX)
+    (
+      plugin_@plugin_name@_params_only
+    );
 
     // ------------------------------------------------------------------------>
 	// -- Example Initialization ---------------------------------------------->

--- a/build/plugin/bli_plugin_register.c
+++ b/build/plugin/bli_plugin_register.c
@@ -34,9 +34,9 @@
 
 #include @PLUGIN_HEADER@
 
-err_t PASTEMAC(plugin_register,BLIS_PNAME_INFIX)
+err_t bli_plugin_register_@plugin_name@
      (
-       PASTECH(plugin,BLIS_PNAME_INFIX,_params)
+       plugin_@plugin_name@_params
      )
 {
 	// ------------------------------------------------------------------------>
@@ -69,9 +69,9 @@ err_t PASTEMAC(plugin_register,BLIS_PNAME_INFIX)
 
 	#undef GENTCONF
 	#define GENTCONF( CONFIG, config ) \
-	PASTEMAC(plugin_init,BLIS_PNAME_INFIX,_,config,BLIS_REF_SUFFIX) \
+	PASTEMAC(plugin_init_@plugin_name@_,config) \
 	( \
-	  PASTECH(plugin,BLIS_PNAME_INFIX,_params_only) \
+	  plugin_@plugin_name@_params_only \
 	);
 
 	INSERT_GENTCONF

--- a/configure
+++ b/configure
@@ -5243,7 +5243,7 @@ plugin_main()
 			else
 				strip_examples ${sharedir}/blis/plugin/bli_plugin_register.c bli_plugin_register.c
 			fi
-			perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|" bli_plugin_register.c
+			perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" bli_plugin_register.c
 			maybe_echo "done"
 		fi
 
@@ -5279,7 +5279,7 @@ plugin_main()
 				else
 					strip_examples ${sharedir}/blis/plugin/${file} ref_kernels/${file}
 				fi
-				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|" ref_kernels/${file}
+				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" ref_kernels/${file}
 				done="false"
 			fi
 		done
@@ -5314,7 +5314,7 @@ plugin_main()
 				else
 					cp ${sharedir}/blis/plugin/bli_plugin_init_zen3.c config/${config}/bli_plugin_init_${config}.c
 				fi
-				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|" config/${config}/bli_plugin_init_${config}.c
+				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" config/${config}/bli_plugin_init_${config}.c
 			fi
 
 			if [ ! -e config/${config}/bli_kernel_defs_${config}.h ] || [ ${force_flag} == '1' ]; then
@@ -5340,7 +5340,7 @@ plugin_main()
 		if [ ${examples_flag} == '1' ]; then
 			if [ ! -e kernels/zen3/my_kernel_1_zen3.c ] || [ ${force_flag} == '1' ]; then
 				cp ${sharedir}/blis/plugin/my_kernel_1_zen3.c kernels/zen3
-				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|" kernels/zen3/my_kernel_1_zen3.c
+				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" kernels/zen3/my_kernel_1_zen3.c
 			fi
 		fi
 

--- a/frame/3/gemm/bli_gemm_cntl.c
+++ b/frame/3/gemm/bli_gemm_cntl.c
@@ -71,7 +71,7 @@ void bli_gemm_var_cntl_init_node
 	);
 }
 
-void bli_gemm_cntl_init
+bool bli_gemm_cntl_init
      (
              ind_t        im,
              opid_t       family,
@@ -559,6 +559,8 @@ void bli_gemm_cntl_init
 	  c,
 	  cntl
 	);
+
+	return needs_swap;
 }
 
 void bli_gemm_cntl_finalize

--- a/frame/3/gemm/bli_gemm_cntl.h
+++ b/frame/3/gemm/bli_gemm_cntl.h
@@ -200,7 +200,7 @@ typedef struct gemm_cntl_s gemm_cntl_t;
 
 // -----------------------------------------------------------------------------
 
-BLIS_EXPORT_BLIS void bli_gemm_cntl_init
+BLIS_EXPORT_BLIS bool bli_gemm_cntl_init
      (
              ind_t        im,
              opid_t       family,

--- a/frame/base/bli_cntx.c
+++ b/frame/base/bli_cntx.c
@@ -46,7 +46,7 @@ BLIS_EXPORT_BLIS err_t bli_cntx_init( cntx_t* cntx )
 	if ( error != BLIS_SUCCESS )
 		return error;
 
-	error = bli_stack_init( sizeof( bszid_t ), 32, 32, BLIS_NUM_BLKSZS, &cntx->bmults );
+	error = bli_stack_init( sizeof( siz_t ), 32, 32, BLIS_NUM_BLKSZS, &cntx->bmults );
 	if ( error != BLIS_SUCCESS )
 		return error;
 
@@ -118,9 +118,9 @@ void bli_cntx_set_blkszs( cntx_t* cntx, ... )
 	   void bli_cntx_set_blkszs
 	   (
 	     cntx_t* cntx,
-	     bszid_t bs0_id, blksz_t* blksz0, bszid_t bm0_id,
-	     bszid_t bs1_id, blksz_t* blksz1, bszid_t bm1_id,
-	     bszid_t bs2_id, blksz_t* blksz2, bszid_t bm2_id,
+	     siz_t bs0_id, blksz_t* blksz0, siz_t bm0_id,
+	     siz_t bs1_id, blksz_t* blksz1, siz_t bm1_id,
+	     siz_t bs2_id, blksz_t* blksz2, siz_t bm2_id,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -133,19 +133,18 @@ void bli_cntx_set_blkszs( cntx_t* cntx, ... )
 	// Process blocksizes until we get a BLIS_VA_END.
 	while ( true )
 	{
-		int bs_id0 = va_arg( args, int );
+		int bs_id = va_arg( args, siz_t );
 
-		// If we find a bszid_t id of BLIS_VA_END, then we are done.
-		if ( bs_id0 == BLIS_VA_END ) break;
+		// If we find a siz_t id of BLIS_VA_END, then we are done.
+		if ( bs_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the bszid_t of the blocksize we're about to process (already done),
+		// - the siz_t of the blocksize we're about to process (already done),
 		// - the address of the blksz_t object,
-		// - the bszid_t of the multiple we need to associate with
+		// - the siz_t of the multiple we need to associate with
 		//   the blksz_t object.
-		bszid_t  bs_id = ( bszid_t  )bs_id0;
 		blksz_t* blksz = ( blksz_t* )va_arg( args, blksz_t* );
-		bszid_t  bm_id = ( bszid_t  )va_arg( args, bszid_t  );
+		siz_t    bm_id = ( siz_t    )va_arg( args, siz_t    );
 
 		// Copy the blksz_t object contents into the appropriate
 		// location within the context's blksz_t array. Do the same
@@ -172,9 +171,9 @@ void bli_cntx_set_ukrs( cntx_t* cntx , ... )
 	   void bli_cntx_set_ukrs
 	   (
 	     cntx_t* cntx,
-	     ukr_t ukr0_id, num_t dt0, void_fp ukr0_fp,
-	     ukr_t ukr1_id, num_t dt1, void_fp ukr1_fp,
-	     ukr_t ukr2_id, num_t dt2, void_fp ukr2_fp,
+	     siz_t ukr0_id, num_t dt0, void_fp ukr0_fp,
+	     siz_t ukr1_id, num_t dt1, void_fp ukr1_fp,
+	     siz_t ukr2_id, num_t dt2, void_fp ukr2_fp,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -187,16 +186,15 @@ void bli_cntx_set_ukrs( cntx_t* cntx , ... )
 	// Process ukernels until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int ukr_id0 = va_arg( args, int );
+		const int ukr_id = va_arg( args, siz_t );
 
 		// If we find a ukernel id of BLIS_VA_END, then we are done.
-		if ( ukr_id0 == BLIS_VA_END ) break;
+		if ( ukr_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the ukr_t of the kernel we're about to process (already done),
+		// - the siz_t of the kernel we're about to process (already done),
 		// - the datatype of the kernel, and
 		// - the kernel function pointer
-		const ukr_t   ukr_id = ( ukr_t   )ukr_id0;
 		const num_t   ukr_dt = ( num_t   )va_arg( args, num_t   );
 		      void_fp ukr_fp = ( void_fp )va_arg( args, void_fp );
 
@@ -223,9 +221,9 @@ void bli_cntx_set_ukr2s( cntx_t* cntx , ... )
 	   void bli_cntx_set_ukr2s
 	   (
 	     cntx_t* cntx,
-	     ukr_t ukr0_id, num_t dt1_0, num_t dt2_0, void_fp ukr0_fp,
-	     ukr_t ukr1_id, num_t dt1_1, num_t dt2_1, void_fp ukr1_fp,
-	     ukr_t ukr2_id, num_t dt1_2, num_t dt2_2, void_fp ukr2_fp,
+	     siz_t ukr0_id, num_t dt1_0, num_t dt2_0, void_fp ukr0_fp,
+	     siz_t ukr1_id, num_t dt1_1, num_t dt2_1, void_fp ukr1_fp,
+	     siz_t ukr2_id, num_t dt1_2, num_t dt2_2, void_fp ukr2_fp,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -238,16 +236,15 @@ void bli_cntx_set_ukr2s( cntx_t* cntx , ... )
 	// Process ukernels until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int ukr_id0 = va_arg( args, int );
+		const int ukr_id = va_arg( args, siz_t );
 
 		// If we find a ukernel id of BLIS_VA_END, then we are done.
-		if ( ukr_id0 == BLIS_VA_END ) break;
+		if ( ukr_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the ukr_t of the kernel we're about to process (already done),
+		// - the siz_t of the kernel we're about to process (already done),
 		// - the datatype of the kernel, and
 		// - the kernel function pointer
-		const ukr_t   ukr_id  = ( ukr_t  )ukr_id0;
 		const num_t   ukr_dt1 = ( num_t   )va_arg( args, num_t   );
 		const num_t   ukr_dt2 = ( num_t   )va_arg( args, num_t   );
 		      void_fp ukr_fp  = ( void_fp )va_arg( args, void_fp );
@@ -275,9 +272,9 @@ void bli_cntx_set_ukr_prefs( cntx_t* cntx , ... )
 	   void bli_cntx_set_ukr_prefs
 	   (
 	     cntx_t* cntx,
-	     ukr_pref_t ukr_pref0_id, num_t dt0, bool ukr_pref0,
-	     ukr_pref_t ukr_pref1_id, num_t dt1, bool ukr_pref1,
-	     ukr_pref_t ukr_pref2_id, num_t dt2, bool ukr_pref2,
+	     siz_t ukr_pref0_id, num_t dt0, bool ukr_pref0,
+	     siz_t ukr_pref1_id, num_t dt1, bool ukr_pref1,
+	     siz_t ukr_pref2_id, num_t dt2, bool ukr_pref2,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -290,18 +287,17 @@ void bli_cntx_set_ukr_prefs( cntx_t* cntx , ... )
 	// Process ukernel preferences until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int ukr_pref_id0 = va_arg( args, int );
+		const int ukr_pref_id = va_arg( args, siz_t );
 
 		// If we find a ukernel pref id of BLIS_VA_END, then we are done.
-		if ( ukr_pref_id0 == BLIS_VA_END ) break;
+		if ( ukr_pref_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the ukr_t of the kernel we're about to process (already done),
+		// - the siz_t of the kernel we're about to process (already done),
 		// - the datatype of the kernel, and
 		// - the kernel function pointer
-		const ukr_pref_t ukr_pref_id = ( ukr_pref_t )ukr_pref_id0;
-		const num_t      ukr_pref_dt = ( num_t      )va_arg( args, num_t );
-		const bool       ukr_pref    = ( bool       )va_arg( args, int );
+		const num_t ukr_pref_dt = ( num_t )va_arg( args, num_t );
+		const bool  ukr_pref    = ( bool  )va_arg( args, int );
 
 		// Store the ukernel preference value into the context.
 		bli_cntx_set_ukr_pref_dt( ukr_pref, ukr_pref_dt, ukr_pref_id, cntx );
@@ -341,15 +337,14 @@ void bli_cntx_set_l3_sup_handlers( cntx_t* cntx, ... )
 	// Process sup handlers until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int op_id0 = va_arg( args, int );
+		const opid_t op_id = va_arg( args, siz_t );
 
 		// If we find an operation id of BLIS_VA_END, then we are done.
-		if ( op_id0 == BLIS_VA_END ) break;
+		if ( op_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
 		// - the opid_t of the operation we're about to process,
 		// - the sup handler function pointer
-		const opid_t  op_id = ( opid_t  )op_id0;
 		      void_fp op_fp = ( void_fp )va_arg( args, void_fp );
 
 		if ( op_id >= BLIS_NUM_LEVEL3_OPS )
@@ -368,7 +363,7 @@ void bli_cntx_set_l3_sup_handlers( cntx_t* cntx, ... )
 
 // -----------------------------------------------------------------------------
 
-err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, bszid_t bmult_id, cntx_t* cntx )
+err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, siz_t bmult_id, cntx_t* cntx )
 {
 	siz_t id_blksz;
 	err_t error = bli_stack_push( &id_blksz, &cntx->blkszs );

--- a/frame/base/bli_cntx.h
+++ b/frame/base/bli_cntx.h
@@ -44,7 +44,7 @@
 typedef struct cntx_s
 {
 	stck_t blkszs; // blksz_t
-	stck_t bmults; // bszid_t
+	stck_t bmults; // siz_t
 
 	stck_t ukrs; // func_t
 	stck_t ukr2s; // func2_t
@@ -60,7 +60,7 @@ typedef struct cntx_s
 // -- cntx_t query (complex) ---------------------------------------------------
 //
 
-BLIS_INLINE const blksz_t* bli_cntx_get_blksz( bszid_t bs_id, const cntx_t* cntx )
+BLIS_INLINE const blksz_t* bli_cntx_get_blksz( siz_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* blksz;
 	err_t error = bli_stack_get( bs_id, ( void** )&blksz, &cntx->blkszs );
@@ -69,7 +69,7 @@ BLIS_INLINE const blksz_t* bli_cntx_get_blksz( bszid_t bs_id, const cntx_t* cntx
 	return blksz;
 }
 
-BLIS_INLINE dim_t bli_cntx_get_blksz_def_dt( num_t dt, bszid_t bs_id, const cntx_t* cntx )
+BLIS_INLINE dim_t bli_cntx_get_blksz_def_dt( num_t dt, siz_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* blksz  = bli_cntx_get_blksz( bs_id, cntx );
 	dim_t          bs_dt  = bli_blksz_get_def( dt, blksz );
@@ -78,7 +78,7 @@ BLIS_INLINE dim_t bli_cntx_get_blksz_def_dt( num_t dt, bszid_t bs_id, const cntx
 	return bs_dt;
 }
 
-BLIS_INLINE dim_t bli_cntx_get_blksz_max_dt( num_t dt, bszid_t bs_id, const cntx_t* cntx )
+BLIS_INLINE dim_t bli_cntx_get_blksz_max_dt( num_t dt, siz_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* blksz  = bli_cntx_get_blksz( bs_id, cntx );
 	dim_t          bs_dt  = bli_blksz_get_max( dt, blksz );
@@ -87,24 +87,24 @@ BLIS_INLINE dim_t bli_cntx_get_blksz_max_dt( num_t dt, bszid_t bs_id, const cntx
 	return bs_dt;
 }
 
-BLIS_INLINE bszid_t bli_cntx_get_bmult_id( bszid_t bs_id, const cntx_t* cntx )
+BLIS_INLINE siz_t bli_cntx_get_bmult_id( siz_t bs_id, const cntx_t* cntx )
 {
-	const bszid_t* bsz;
+	const siz_t* bsz;
 	err_t error = bli_stack_get( bs_id, ( void** )&bsz, &cntx->bmults );
 	if ( error != BLIS_SUCCESS )
 		bli_check_error_code( error );
 	return *bsz;
 }
 
-BLIS_INLINE const blksz_t* bli_cntx_get_bmult( bszid_t bs_id, const cntx_t* cntx )
+BLIS_INLINE const blksz_t* bli_cntx_get_bmult( siz_t bs_id, const cntx_t* cntx )
 {
-	bszid_t        bm_id  = bli_cntx_get_bmult_id( bs_id, cntx );
+	siz_t          bm_id  = bli_cntx_get_bmult_id( bs_id, cntx );
 	const blksz_t* bmult  = bli_cntx_get_blksz( bm_id, cntx );
 
 	return bmult;
 }
 
-BLIS_INLINE dim_t bli_cntx_get_bmult_dt( num_t dt, bszid_t bs_id, const cntx_t* cntx )
+BLIS_INLINE dim_t bli_cntx_get_bmult_dt( num_t dt, siz_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* bmult  = bli_cntx_get_bmult( bs_id, cntx );
 	dim_t          bm_dt  = bli_blksz_get_def( dt, bmult );
@@ -114,7 +114,7 @@ BLIS_INLINE dim_t bli_cntx_get_bmult_dt( num_t dt, bszid_t bs_id, const cntx_t* 
 
 // -----------------------------------------------------------------------------
 
-BLIS_INLINE const func2_t* bli_cntx_get_ukr2s( ukr_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE const func2_t* bli_cntx_get_ukr2s( siz_t ukr_id, const cntx_t* cntx )
 {
 	const func2_t* ukr;
 	err_t error = bli_stack_get( bli_ker_idx( ukr_id ), ( void** )&ukr, &cntx->ukr2s );
@@ -123,7 +123,7 @@ BLIS_INLINE const func2_t* bli_cntx_get_ukr2s( ukr_t ukr_id, const cntx_t* cntx 
 	return ukr;
 }
 
-BLIS_INLINE void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, ukr_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, siz_t ukr_id, const cntx_t* cntx )
 {
 	const func2_t* func = bli_cntx_get_ukr2s( ukr_id, cntx );
 
@@ -132,11 +132,11 @@ BLIS_INLINE void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, ukr_t ukr_id, co
 
 // -----------------------------------------------------------------------------
 
-BLIS_INLINE const func_t* bli_cntx_get_ukrs( ukr_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE const func_t* bli_cntx_get_ukrs( siz_t ukr_id, const cntx_t* cntx )
 {
 	if ( bli_ker_ntype( ukr_id ) == 2 )
 	{
-		return ( const func_t* )bli_cntx_get_ukr2s( ( ukr_t )ukr_id, cntx );
+		return ( const func_t* )bli_cntx_get_ukr2s( ukr_id, cntx );
 	}
 	else
 	{
@@ -148,11 +148,11 @@ BLIS_INLINE const func_t* bli_cntx_get_ukrs( ukr_t ukr_id, const cntx_t* cntx )
 	}
 }
 
-BLIS_INLINE void_fp bli_cntx_get_ukr_dt( num_t dt, ukr_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE void_fp bli_cntx_get_ukr_dt( num_t dt, siz_t ukr_id, const cntx_t* cntx )
 {
 	if ( bli_ker_ntype( ukr_id ) == 2 )
 	{
-		return bli_cntx_get_ukr2_dt( dt, dt, ( ukr_t )ukr_id, cntx );
+		return bli_cntx_get_ukr2_dt( dt, dt, ukr_id, cntx );
 	}
 	else
 	{
@@ -164,7 +164,7 @@ BLIS_INLINE void_fp bli_cntx_get_ukr_dt( num_t dt, ukr_t ukr_id, const cntx_t* c
 
 // -----------------------------------------------------------------------------
 
-BLIS_INLINE const mbool_t* bli_cntx_get_ukr_prefs( ukr_pref_t pref_id, const cntx_t* cntx )
+BLIS_INLINE const mbool_t* bli_cntx_get_ukr_prefs( siz_t pref_id, const cntx_t* cntx )
 {
 	const mbool_t* ukr_prefs;
 	err_t error = bli_stack_get( pref_id, ( void** )&ukr_prefs, &cntx->ukr_prefs );
@@ -173,7 +173,7 @@ BLIS_INLINE const mbool_t* bli_cntx_get_ukr_prefs( ukr_pref_t pref_id, const cnt
 	return ukr_prefs;
 }
 
-BLIS_INLINE bool bli_cntx_get_ukr_prefs_dt( num_t dt, ukr_pref_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE bool bli_cntx_get_ukr_prefs_dt( num_t dt, siz_t ukr_id, const cntx_t* cntx )
 {
 	const mbool_t* mbool = bli_cntx_get_ukr_prefs( ukr_id, cntx );
 
@@ -262,14 +262,14 @@ BLIS_INLINE bool bli_cntx_dislikes_storage_of( const obj_t* obj, ukr_t ukr_id, c
 // NOTE: The framework does not use any of the following functions. We provide
 // them in order to facilitate creating/modifying custom contexts.
 
-BLIS_INLINE err_t bli_cntx_set_blksz( bszid_t bs_id, const blksz_t* blksz, bszid_t mult_id, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_blksz( siz_t bs_id, const blksz_t* blksz, siz_t mult_id, cntx_t* cntx )
 {
 	blksz_t* cntx_blksz;
 	err_t error = bli_stack_get( bs_id, ( void** )&cntx_blksz, &cntx->blkszs );
 	if ( error != BLIS_SUCCESS )
 		return error;
 
-	bszid_t* cntx_mult_id;
+	siz_t* cntx_mult_id;
 	error = bli_stack_get( bs_id, ( void** )&cntx_mult_id, &cntx->bmults );
 	if ( error != BLIS_SUCCESS )
 		return error;
@@ -280,38 +280,38 @@ BLIS_INLINE err_t bli_cntx_set_blksz( bszid_t bs_id, const blksz_t* blksz, bszid
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE void bli_cntx_set_blksz_def_dt( num_t dt, bszid_t bs_id, dim_t bs, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_blksz_def_dt( num_t dt, siz_t bs_id, dim_t bs, cntx_t* cntx )
 {
 	bli_blksz_set_def( bs, dt, ( blksz_t* )bli_cntx_get_blksz( bs_id, cntx ) );
 }
 
-BLIS_INLINE void bli_cntx_set_blksz_max_dt( num_t dt, bszid_t bs_id, dim_t bs, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_blksz_max_dt( num_t dt, siz_t bs_id, dim_t bs, cntx_t* cntx )
 {
 	bli_blksz_set_max( bs, dt, ( blksz_t* )bli_cntx_get_blksz( bs_id, cntx ) );
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr2( ukr_t ukr_id, const func2_t* func, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr2( siz_t ukr_id, const func2_t* func, cntx_t* cntx )
 {
 	*( func2_t* )bli_cntx_get_ukr2s( ukr_id, cntx ) = *func;
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE void bli_cntx_set_ukr2_dt( void_fp fp, num_t dt1, num_t dt2, ukr_t ker_id, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_ukr2_dt( void_fp fp, num_t dt1, num_t dt2, siz_t ker_id, cntx_t* cntx )
 {
 	bli_func2_set_dt( fp, dt1, dt2, ( func2_t* )bli_cntx_get_ukr2s( ker_id, cntx ) );
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr( ukr_t ukr_id, const func_t* func, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr( siz_t ukr_id, const func_t* func, cntx_t* cntx )
 {
 	*( func_t* )bli_cntx_get_ukrs( ukr_id, cntx ) = *func;
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, ukr_t ker_id, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, siz_t ker_id, cntx_t* cntx )
 {
 	if ( bli_ker_ntype( ker_id ) == 2 )
 	{
-		bli_cntx_set_ukr2_dt( fp, dt, dt, (ukr_t)ker_id, cntx );
+		bli_cntx_set_ukr2_dt( fp, dt, dt, ker_id, cntx );
 	}
 	else
 	{
@@ -319,13 +319,13 @@ BLIS_INLINE void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, ukr_t ker_id, cntx_t
 	}
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr_pref( ukr_pref_t ukr_id, const mbool_t* prefs, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr_pref( siz_t ukr_id, const mbool_t* prefs, cntx_t* cntx )
 {
 	*( mbool_t* )bli_cntx_get_ukr_prefs( ukr_id, cntx ) = *prefs;
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr_pref_dt( bool pref, num_t dt, ukr_pref_t ukr_id, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr_pref_dt( bool pref, num_t dt, siz_t ukr_id, cntx_t* cntx )
 {
 	bli_mbool_set_dt( pref, dt, ( mbool_t* )bli_cntx_get_ukr_prefs( ukr_id, cntx ));
 	return BLIS_SUCCESS;
@@ -400,7 +400,7 @@ BLIS_EXPORT_BLIS void bli_cntx_print( const cntx_t* cntx );
 
 BLIS_EXPORT_BLIS void bli_cntx_set_l3_sup_handlers( cntx_t* cntx, ... );
 
-BLIS_EXPORT_BLIS err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, bszid_t bmult_id, cntx_t* cntx );
+BLIS_EXPORT_BLIS err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, siz_t bmult_id, cntx_t* cntx );
 
 BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr( siz_t* ukr_id, const func_t* ukr, cntx_t* cntx );
 

--- a/frame/include/bli_misc_macro_defs.h
+++ b/frame/include/bli_misc_macro_defs.h
@@ -186,12 +186,6 @@ BLIS_INLINE void bli_toggle_bool( bool* b )
 #define bli_iformatspec() "%6d"
 
 
-// Sentinel constant used to indicate the end of a variable argument function
-// (See bli_cntx.c)
-
-#define BLIS_VA_END  ((siz_t)-1)
-
-
 // Static assertion compatible with any version of C/C++
 #define bli_static_assert(cond) while(0){struct s {int STATIC_ASSERT_FAILED : !!(cond);};}
 

--- a/frame/include/bli_misc_macro_defs.h
+++ b/frame/include/bli_misc_macro_defs.h
@@ -189,7 +189,7 @@ BLIS_INLINE void bli_toggle_bool( bool* b )
 // Sentinel constant used to indicate the end of a variable argument function
 // (See bli_cntx.c)
 
-#define BLIS_VA_END  (-1)
+#define BLIS_VA_END  ((siz_t)-1)
 
 
 // Static assertion compatible with any version of C/C++

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -675,7 +675,7 @@ typedef enum
 	BLIS_GEMMSUP_CCC_UKR,
 	BLIS_GEMMSUP_XXX_UKR,
 
-	// BLIS_NUM_UKRS must be last!
+	// BLIS_NUM_UKRS must after all 1-type kernels and before 2-type kernels!
 	BLIS_NUM_UKRS_, BLIS_NUM_UKRS = bli_ker_idx( BLIS_NUM_UKRS_ ),
 
 	// -- Two-type kernels --
@@ -702,8 +702,11 @@ typedef enum
 	BLIS_GEMM_RCC_UKR,
 	BLIS_GEMM_CRR_UKR,
 
-	// BLIS_NUM_UKR2S must be last!
-	BLIS_NUM_UKR2S_, BLIS_NUM_UKR2S = bli_ker_idx( BLIS_NUM_UKR2S_ )
+	// BLIS_NUM_UKR2S must come after all kernels!
+	BLIS_NUM_UKR2S_, BLIS_NUM_UKR2S = bli_ker_idx( BLIS_NUM_UKR2S_ ),
+
+	// Force the size of ukr_t values to be as large as siz_t
+	BLIS_UKRS_END_ = BLIS_VA_END
 } ukr_t;
 
 
@@ -728,9 +731,11 @@ typedef enum
 	BLIS_GEMMSUP_XXX_UKR_ROW_PREF,
 
     // BLIS_NUM_UKR_PREFS must be last!
-    BLIS_NUM_UKR_PREFS
-} ukr_pref_t;
+    BLIS_NUM_UKR_PREFS,
 
+	// Force the size of ukr_pref_t values to be as large as siz_t
+	BLIS_UKR_PREFS_END_ = BLIS_VA_END
+} ukr_pref_t;
 
 typedef enum
 {
@@ -864,7 +869,10 @@ typedef enum
 
 	// BLIS_NOID (= BLIS_NUM_LEVEL3_OPS) must be last!
 	BLIS_NOID,
-	BLIS_NUM_LEVEL3_OPS = BLIS_NOID
+	BLIS_NUM_LEVEL3_OPS = BLIS_NOID,
+
+	// Force the size of opid_t values to be as large as siz_t
+	BLIS_LEVEL3_OPS_END_ = BLIS_VA_END
 } opid_t;
 
 
@@ -911,7 +919,10 @@ typedef enum
 	// BLIS_NO_PART (= BLIS_NUM_BLKSZS) must be last!
 	BLIS_NO_PART, // used as a placeholder when blocksizes are not applicable,
 	              // such as when characterizing a packm operation.
-	BLIS_NUM_BLKSZS = BLIS_NO_PART
+	BLIS_NUM_BLKSZS = BLIS_NO_PART,
+
+	// Force the size of bszid_t values to be as large as siz_t
+	BLIS_BLKSZS_END_ = BLIS_VA_END
 } bszid_t;
 
 

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -626,6 +626,11 @@ typedef enum
 #define bli_ker_idx( ker )	 ((ker) & ~BLIS_NTYPE_KER_BITS)
 #define bli_ker_ntype( ker ) ((((ker) & BLIS_NTYPE_KER_BITS) >> BLIS_NTYPE_KER_SHIFT) + 1)
 
+// Sentinel constant used to indicate the end of a variable argument function
+// (See bli_cntx.c)
+
+#define BLIS_VA_END  ((siz_t)-1)
+
 typedef enum
 {
 	// -- Single-type kernels --


### PR DESCRIPTION
1. Use configure-time variable substitution rather than the `PNAME` macro to generate symbol names in plugins. This makes it much easier for uses to see what names their symbols will have (and to change them if desired).
2. Use `siz_t` rather than `ukr_t` for anything dealing with kernel IDs (and similar for blocksizes and kernel preferences). Because users can now register new kernels, the values of the IDs for their custom kernels are no longer enumerated in `ukr_t`, which causes type conversion problems. This requires also being careful about the type of `BLIS_VA_END` and forcing existing enumerations like `ukr_t` to be represented using integers of the same width as `siz_t`.
3. Modify the `gemm` control tree initialization function to indicate whether or not the operation as a whole was transposed. This is needed if users have to treat the initial `A` and `B` differently in the control tree, for example in a tensor times matrix operation (if transposed to matrix times tensor, we need to know which "matrix" object is now the tensor).