### PR TITLE
clarified OMP_NUM_THREADS

### DIFF
--- a/docs/Multithreading.md
+++ b/docs/Multithreading.md
@@ -147,7 +147,14 @@ $ GOMP_CPU_AFFINITY="0-15" BLIS_NUM_THREADS=16 ./my_blis_program
 ```
 Either of these approaches causes BLIS to automatically determine a reasonable threading strategy based on what is known about the operation and problem size. If `BLIS_NUM_THREADS` is not set, BLIS will attempt to query the value of `BLIS_NT` (a shorthand alternative to `BLIS_NUM_THREADS`). If neither variable is defined, then BLIS will attempt to read `OMP_NUM_THREADS`. If none of these variables is set, the default number of threads is 1.
 
-**Note**: We *highly* discourage use of the `OMP_NUM_THREADS` environment variable to specify multithreading within BLIS and may remove support for it in the future. If you wish to set parallelism globally via environment variables, please use `BLIS_NUM_THREADS`.
+**Note**: If none of `BLIS_NT`/`BLIS_NUM_THREADS` are defined, BLIS will fall back to use
+the standardized `OMP_NUM_THREADS` environment variable.
+By having an application specific environment variable one can fine-tune the thread
+utilization, e.g. to run OpenMP constructs using 4 threads, and BLIS with 2 threads:
+```
+$ OMP_NUM_THREADS=4 BLIS_NUM_THREADS=2 ./my_omp_blis_program
+```
+
 
 ### Environment variables: the manual way
 


### PR DESCRIPTION
Removed description of possible deprecation of OMP_NUM_THREADS.

After discussion in #825 it was agreed to:

- lax the deprecation warning, OMP_NUM_THREADS will always be a fall-bock.
- Clarified with a simple example on how to do different regions of thread-counts.