### PR TITLE
Create a new type to represent IDs for all kernels, blocksizes, etc.

### DIFF
--- a/build/plugin/bli_plugin.h.in
+++ b/build/plugin/bli_plugin.h.in
@@ -41,9 +41,9 @@
 
 #define plugin_@plugin_name@_params \
 \
-       siz_t* bszids, /* <----- Example arguments       */ \
-       siz_t* kerids, /* <----- for plugin registration */ \
-       siz_t* prefids /* <----- and initialization.     */
+       kerid_t* bszids, /* <----- Example arguments       */ \
+       kerid_t* kerids, /* <----- for plugin registration */ \
+       kerid_t* prefids /* <----- and initialization.     */
 
 #define plugin_@plugin_name@_params_only \
 \

--- a/build/plugin/bli_plugin_init_ref.c
+++ b/build/plugin/bli_plugin_init_ref.c
@@ -69,7 +69,7 @@ void PASTEMAC(plugin_init_@plugin_name@,BLIS_CNAME_INFIX,BLIS_REF_SUFFIX)
 	// ------------------------------------------------------------------------>
 
 	blksz_t blkszs[ MY_NUM_BLOCK_SIZES ];
-	siz_t   bmults[ MY_NUM_BLOCK_SIZES ];
+	kerid_t bmults[ MY_NUM_BLOCK_SIZES ];
 	func_t  funcs[ MY_NUM_KERNELS ];
 	mbool_t mbools[ MY_NUM_KERNEL_PREFS ];
 

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -82,6 +82,7 @@ The following tables list various types used throughout the BLIS object API.
 | `inc_t`           | `gint_t`                 | matrix row/column strides and vector increments.                     |
 | `doff_t`          | `gint_t`                 | matrix diagonal offset: if _k_ < 0, diagonal begins at element (-_k_,0); otherwise diagonal begins at element (0,_k_). |
 | `siz_t`           | `guint_t`                | a byte size or byte offset.                                          |
+| `kerid_t`         | `uint32_t`               | a kernel, block size, operation, or kernel preference ID.        |
 
 ### Floating-point types
 

--- a/docs/PluginHowTo.md
+++ b/docs/PluginHowTo.md
@@ -722,7 +722,7 @@ void dsyrkd
 ## Registration
 
 ```C++
-err_t bli_gks_register_ukr( siz_t* ukr_id );
+err_t bli_gks_register_ukr( kerid_t* ukr_id );
 ```
 
 Register a new microkernel, which may have a different implementation for each supported data type.
@@ -733,7 +733,7 @@ Register a new microkernel, which may have a different implementation for each s
 </table>
 
 ```C++
-err_t bli_gks_register_ukr2( siz_t* ukr_id );
+err_t bli_gks_register_ukr2( kerid_t* ukr_id );
 ```
 
 Register a new microkernel, which may have a different implementation for each *pair* of supported data types.
@@ -744,7 +744,7 @@ Register a new microkernel, which may have a different implementation for each *
 </table>
 
 ```C++
-err_t bli_gks_register_blksz( siz_t* bs_id );
+err_t bli_gks_register_blksz( kerid_t* bs_id );
 ```
 
 Register a new blocksize, which may have a different integral value for each supported data type.
@@ -755,7 +755,7 @@ Register a new blocksize, which may have a different integral value for each sup
 </table>
 
 ```C++
-err_t bli_gks_register_ukr_pref( siz_t* ukr_pref_id );
+err_t bli_gks_register_ukr_pref( kerid_t* ukr_pref_id );
 ```
 
 Register a new microkernel preference, which may have a different logical value for each supported data type.
@@ -976,73 +976,73 @@ void bli_mbool_free( mbool_t* b );
 ## Context Initialization
 
 ```C++
-err_t bli_cntx_set_ukr( siz_t ukr_id, const func_t* func, cntx_t* cntx );
+err_t bli_cntx_set_ukr( kerid_t ukr_id, const func_t* func, cntx_t* cntx );
 ```
 
 ```C++
-void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, siz_t ukr_id, const func_t* func, cntx_t* cntx );
+void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, kerid_t ukr_id, const func_t* func, cntx_t* cntx );
 ```
 
 ```C++
-err_t bli_cntx_set_ukr2( siz_t ukr_id, const func2_t* func, cntx_t* cntx );
+err_t bli_cntx_set_ukr2( kerid_t ukr_id, const func2_t* func, cntx_t* cntx );
 ```
 
 ```C++
-void bli_cntx_set_ukr2_dt( void_fp fp, num_t dt1, num_t dt2, siz_t ukr_id, const func_t* func, cntx_t* cntx );
+void bli_cntx_set_ukr2_dt( void_fp fp, num_t dt1, num_t dt2, kerid_t ukr_id, const func_t* func, cntx_t* cntx );
 ```
 
 ```C++
-err_t bli_cntx_set_blksz( siz_t bs_id, const blksz_t* blksz, siz_t mult_id, cntx_t* cntx );
+err_t bli_cntx_set_blksz( kerid_t bs_id, const blksz_t* blksz, kerid_t mult_id, cntx_t* cntx );
 ```
 
 ```C++
-void bli_cntx_set_blksz_def_dt( num_t dt, siz_t bs_id, dim_t bs, cntx_t* cntx );
+void bli_cntx_set_blksz_def_dt( num_t dt, kerid_t bs_id, dim_t bs, cntx_t* cntx );
 ```
 
 ```C++
-void bli_cntx_set_blksz_max_dt( num_t dt, siz_t bs_id, dim_t bs, cntx_t* cntx );
+void bli_cntx_set_blksz_max_dt( num_t dt, kerid_t bs_id, dim_t bs, cntx_t* cntx );
 ```
 
 ```C++
-err_t bli_cntx_set_ukr_pref( siz_t ukr_pref_id, const mbool_t* prefs, cntx_t* cntx );
+err_t bli_cntx_set_ukr_pref( kerid_t ukr_pref_id, const mbool_t* prefs, cntx_t* cntx );
 ```
 
 ```C++
-err_t bli_cntx_set_ukr_pref_dt( bool pref, num_t dt, siz_t ukr_pref_id, cntx_t* cntx );
+err_t bli_cntx_set_ukr_pref_dt( bool pref, num_t dt, kerid_t ukr_pref_id, cntx_t* cntx );
 ```
 
 ```C++
 void bli_cntx_set_ukrs( cntx_t* cntx,
-                        siz_t ukr0_id, num_t dt0, void_fp ukr0_fp,
-                        siz_t ukr1_id, num_t dt1, void_fp ukr1_fp,
-                        siz_t ukr2_id, num_t dt2, void_fp ukr2_fp,
+                        kerid_t ukr0_id, num_t dt0, void_fp ukr0_fp,
+                        kerid_t ukr1_id, num_t dt1, void_fp ukr1_fp,
+                        kerid_t ukr2_id, num_t dt2, void_fp ukr2_fp,
                         ...,
                         BLIS_VA_END );
 ```
 
 ```C++
 void bli_cntx_set_ukr2s( cntx_t* cntx,
-                         siz_t ukr0_id, num_t dt1_0, num_t dt2_0, void_fp ukr0_fp,
-                         siz_t ukr1_id, num_t dt1_1, num_t dt2_1, void_fp ukr1_fp,
-                         siz_t ukr2_id, num_t dt1_2, num_t dt2_2, void_fp ukr2_fp,
+                         kerid_t ukr0_id, num_t dt1_0, num_t dt2_0, void_fp ukr0_fp,
+                         kerid_t ukr1_id, num_t dt1_1, num_t dt2_1, void_fp ukr1_fp,
+                         kerid_t ukr2_id, num_t dt1_2, num_t dt2_2, void_fp ukr2_fp,
                          ...,
                          BLIS_VA_END );
 ```
 
 ```C++
 void bli_cntx_set_blksz( cntx_t* cntx,
-                         siz_t bs0_id, const blksz_t* blksz0, siz_t bm0_id,
-                         siz_t bs1_id, const blksz_t* blksz1, siz_t bm1_id,
-                         siz_t bs2_id, const blksz_t* blksz2, siz_t bm2_id,
+                         kerid_t bs0_id, const blksz_t* blksz0, kerid_t bm0_id,
+                         kerid_t bs1_id, const blksz_t* blksz1, kerid_t bm1_id,
+                         kerid_t bs2_id, const blksz_t* blksz2, kerid_t bm2_id,
                          ...,
                          BLIS_VA_END );
 ```
 
 ```C++
 void bli_cntx_set_ukr_prefs( cntx_t* cntx,
-                             siz_t ukr_pref0_id, num_t dt0, bool ukr_pref0,
-                             siz_t ukr_pref1_id, num_t dt1, bool ukr_pref1,
-                             siz_t ukr_pref2_id, num_t dt2, bool ukr_pref2,
+                             kerid_t ukr_pref0_id, num_t dt0, bool ukr_pref0,
+                             kerid_t ukr_pref1_id, num_t dt1, bool ukr_pref1,
+                             kerid_t ukr_pref2_id, num_t dt2, bool ukr_pref2,
                              ...,
                              BLIS_VA_END );
 ```
@@ -1058,51 +1058,51 @@ const cntx_t* bli_gks_lookup_id( arch_t id );
 ```
 
 ```C++
-const func_t* bli_cntx_get_ukrs( siz_t ukr_id, const cntx_t* cntx );
+const func_t* bli_cntx_get_ukrs( kerid_t ukr_id, const cntx_t* cntx );
 ```
 
 ```C++
-void_fp bli_cntx_get_ukr_dt( num_t dt, siz_t ukr_id, const cntx_t* cntx );
+void_fp bli_cntx_get_ukr_dt( num_t dt, kerid_t ukr_id, const cntx_t* cntx );
 ```
 
 ```C++
-const func2_t* bli_cntx_get_ukr2s( siz_t ukr_id, const cntx_t* cntx );
+const func2_t* bli_cntx_get_ukr2s( kerid_t ukr_id, const cntx_t* cntx );
 ```
 
 ```C++
-void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, siz_t ukr_id, const cntx_t* cntx );
+void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, kerid_t ukr_id, const cntx_t* cntx );
 ```
 
 ```C++
-const blksz_t* bli_cntx_get_blksz( siz_t bs_id, const cntx_t* cntx );
+const blksz_t* bli_cntx_get_blksz( kerid_t bs_id, const cntx_t* cntx );
 ```
 
 ```C++
-dim_t bli_cntx_get_blksz_def_dt( num_t dt, siz_t bs_id, const cntx_t* cntx );
+dim_t bli_cntx_get_blksz_def_dt( num_t dt, kerid_t bs_id, const cntx_t* cntx );
 ```
 
 ```C++
-dim_t bli_cntx_get_blksz_max_dt( num_t dt, siz_t bs_id, const cntx_t* cntx );
+dim_t bli_cntx_get_blksz_max_dt( num_t dt, kerid_t bs_id, const cntx_t* cntx );
 ```
 
 ```C++
-siz_t bli_cntx_get_bmult_id( siz_t bs_id, const cntx_t* cntx );
+kerid_t bli_cntx_get_bmult_id( kerid_t bs_id, const cntx_t* cntx );
 ```
 
 ```C++
-const blksz_t* bli_cntx_get_bmult( siz_t bs_id, const cntx_t* cntx );
+const blksz_t* bli_cntx_get_bmult( kerid_t bs_id, const cntx_t* cntx );
 ```
 
 ```C++
-dim_t bli_cntx_get_bmult_dt( num_t dt, siz_t bs_id, const cntx_t* cntx );
+dim_t bli_cntx_get_bmult_dt( num_t dt, kerid_t bs_id, const cntx_t* cntx );
 ```
 
 ```C++
-const mbool_t* bli_cntx_get_ukr_prefs( siz_t ukr_pref_id, const cntx_t* cntx );
+const mbool_t* bli_cntx_get_ukr_prefs( kerid_t ukr_pref_id, const cntx_t* cntx );
 ```
 
 ```C++
-bool bli_cntx_get_ukr_prefs_dt( num_t dt, siz_t ukr_pref_id, const cntx_t* cntx );
+bool bli_cntx_get_ukr_prefs_dt( num_t dt, kerid_t ukr_pref_id, const cntx_t* cntx );
 ```
 
 ## Control tree modification

--- a/frame/base/bli_cntx.c
+++ b/frame/base/bli_cntx.c
@@ -46,7 +46,7 @@ BLIS_EXPORT_BLIS err_t bli_cntx_init( cntx_t* cntx )
 	if ( error != BLIS_SUCCESS )
 		return error;
 
-	error = bli_stack_init( sizeof( siz_t ), 32, 32, BLIS_NUM_BLKSZS, &cntx->bmults );
+	error = bli_stack_init( sizeof( kerid_t ), 32, 32, BLIS_NUM_BLKSZS, &cntx->bmults );
 	if ( error != BLIS_SUCCESS )
 		return error;
 
@@ -118,9 +118,9 @@ void bli_cntx_set_blkszs( cntx_t* cntx, ... )
 	   void bli_cntx_set_blkszs
 	   (
 	     cntx_t* cntx,
-	     siz_t bs0_id, blksz_t* blksz0, siz_t bm0_id,
-	     siz_t bs1_id, blksz_t* blksz1, siz_t bm1_id,
-	     siz_t bs2_id, blksz_t* blksz2, siz_t bm2_id,
+	     kerid_t bs0_id, blksz_t* blksz0, kerid_t bm0_id,
+	     kerid_t bs1_id, blksz_t* blksz1, kerid_t bm1_id,
+	     kerid_t bs2_id, blksz_t* blksz2, kerid_t bm2_id,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -133,18 +133,18 @@ void bli_cntx_set_blkszs( cntx_t* cntx, ... )
 	// Process blocksizes until we get a BLIS_VA_END.
 	while ( true )
 	{
-		int bs_id = va_arg( args, siz_t );
+		kerid_t bs_id = ( kerid_t )va_arg( args, kerid_t );
 
-		// If we find a siz_t id of BLIS_VA_END, then we are done.
+		// If we find a block size id of BLIS_VA_END, then we are done.
 		if ( bs_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the siz_t of the blocksize we're about to process (already done),
+		// - the kerid_t of the blocksize we're about to process (already done),
 		// - the address of the blksz_t object,
-		// - the siz_t of the multiple we need to associate with
+		// - the kerid_t of the multiple we need to associate with
 		//   the blksz_t object.
 		blksz_t* blksz = ( blksz_t* )va_arg( args, blksz_t* );
-		siz_t    bm_id = ( siz_t    )va_arg( args, siz_t    );
+		kerid_t  bm_id = ( kerid_t  )va_arg( args, kerid_t );
 
 		// Copy the blksz_t object contents into the appropriate
 		// location within the context's blksz_t array. Do the same
@@ -171,9 +171,9 @@ void bli_cntx_set_ukrs( cntx_t* cntx , ... )
 	   void bli_cntx_set_ukrs
 	   (
 	     cntx_t* cntx,
-	     siz_t ukr0_id, num_t dt0, void_fp ukr0_fp,
-	     siz_t ukr1_id, num_t dt1, void_fp ukr1_fp,
-	     siz_t ukr2_id, num_t dt2, void_fp ukr2_fp,
+	     kerid_t ukr0_id, num_t dt0, void_fp ukr0_fp,
+	     kerid_t ukr1_id, num_t dt1, void_fp ukr1_fp,
+	     kerid_t ukr2_id, num_t dt2, void_fp ukr2_fp,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -186,17 +186,17 @@ void bli_cntx_set_ukrs( cntx_t* cntx , ... )
 	// Process ukernels until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int ukr_id = va_arg( args, siz_t );
+		kerid_t ukr_id = ( kerid_t )va_arg( args, kerid_t );
 
 		// If we find a ukernel id of BLIS_VA_END, then we are done.
 		if ( ukr_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the siz_t of the kernel we're about to process (already done),
+		// - the kerid_t of the kernel we're about to process (already done),
 		// - the datatype of the kernel, and
 		// - the kernel function pointer
-		const num_t   ukr_dt = ( num_t   )va_arg( args, num_t   );
-		      void_fp ukr_fp = ( void_fp )va_arg( args, void_fp );
+		num_t   ukr_dt = ( num_t   )va_arg( args, num_t   );
+		void_fp ukr_fp = ( void_fp )va_arg( args, void_fp );
 
 		// Store the ukernel function pointer into the context.
 		bli_cntx_set_ukr_dt( ukr_fp, ukr_dt, ukr_id, cntx );
@@ -221,9 +221,9 @@ void bli_cntx_set_ukr2s( cntx_t* cntx , ... )
 	   void bli_cntx_set_ukr2s
 	   (
 	     cntx_t* cntx,
-	     siz_t ukr0_id, num_t dt1_0, num_t dt2_0, void_fp ukr0_fp,
-	     siz_t ukr1_id, num_t dt1_1, num_t dt2_1, void_fp ukr1_fp,
-	     siz_t ukr2_id, num_t dt1_2, num_t dt2_2, void_fp ukr2_fp,
+	     kerid_t ukr0_id, num_t dt1_0, num_t dt2_0, void_fp ukr0_fp,
+	     kerid_t ukr1_id, num_t dt1_1, num_t dt2_1, void_fp ukr1_fp,
+	     kerid_t ukr2_id, num_t dt1_2, num_t dt2_2, void_fp ukr2_fp,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -236,18 +236,18 @@ void bli_cntx_set_ukr2s( cntx_t* cntx , ... )
 	// Process ukernels until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int ukr_id = va_arg( args, siz_t );
+		kerid_t ukr_id = ( kerid_t )va_arg( args, kerid_t );
 
 		// If we find a ukernel id of BLIS_VA_END, then we are done.
 		if ( ukr_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the siz_t of the kernel we're about to process (already done),
+		// - the kerid_t of the kernel we're about to process (already done),
 		// - the datatype of the kernel, and
 		// - the kernel function pointer
-		const num_t   ukr_dt1 = ( num_t   )va_arg( args, num_t   );
-		const num_t   ukr_dt2 = ( num_t   )va_arg( args, num_t   );
-		      void_fp ukr_fp  = ( void_fp )va_arg( args, void_fp );
+		num_t   ukr_dt1 = ( num_t   )va_arg( args, num_t   );
+		num_t   ukr_dt2 = ( num_t   )va_arg( args, num_t   );
+		void_fp ukr_fp  = ( void_fp )va_arg( args, void_fp );
 
 		// Store the ukernel function pointer into the context.
 		bli_cntx_set_ukr2_dt( ukr_fp, ukr_dt1, ukr_dt2, ukr_id, cntx );
@@ -272,9 +272,9 @@ void bli_cntx_set_ukr_prefs( cntx_t* cntx , ... )
 	   void bli_cntx_set_ukr_prefs
 	   (
 	     cntx_t* cntx,
-	     siz_t ukr_pref0_id, num_t dt0, bool ukr_pref0,
-	     siz_t ukr_pref1_id, num_t dt1, bool ukr_pref1,
-	     siz_t ukr_pref2_id, num_t dt2, bool ukr_pref2,
+	     kerid_t ukr_pref0_id, num_t dt0, bool ukr_pref0,
+	     kerid_t ukr_pref1_id, num_t dt1, bool ukr_pref1,
+	     kerid_t ukr_pref2_id, num_t dt2, bool ukr_pref2,
 	     ...,
 	     BLIS_VA_END
 	   );
@@ -287,17 +287,17 @@ void bli_cntx_set_ukr_prefs( cntx_t* cntx , ... )
 	// Process ukernel preferences until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const int ukr_pref_id = va_arg( args, siz_t );
+		kerid_t ukr_pref_id = ( kerid_t )va_arg( args, kerid_t );
 
 		// If we find a ukernel pref id of BLIS_VA_END, then we are done.
 		if ( ukr_pref_id == BLIS_VA_END ) break;
 
 		// Here, we query the variable argument list for:
-		// - the siz_t of the kernel we're about to process (already done),
+		// - the kerid_t of the kernel we're about to process (already done),
 		// - the datatype of the kernel, and
 		// - the kernel function pointer
-		const num_t ukr_pref_dt = ( num_t )va_arg( args, num_t );
-		const bool  ukr_pref    = ( bool  )va_arg( args, int );
+		num_t ukr_pref_dt = ( num_t )va_arg( args, num_t );
+		bool  ukr_pref    = ( bool  )va_arg( args, int );
 
 		// Store the ukernel preference value into the context.
 		bli_cntx_set_ukr_pref_dt( ukr_pref, ukr_pref_dt, ukr_pref_id, cntx );
@@ -337,7 +337,7 @@ void bli_cntx_set_l3_sup_handlers( cntx_t* cntx, ... )
 	// Process sup handlers until BLIS_VA_END is reached.
 	while ( true )
 	{
-		const opid_t op_id = va_arg( args, siz_t );
+		kerid_t op_id = ( kerid_t )va_arg( args, kerid_t );
 
 		// If we find an operation id of BLIS_VA_END, then we are done.
 		if ( op_id == BLIS_VA_END ) break;
@@ -363,7 +363,7 @@ void bli_cntx_set_l3_sup_handlers( cntx_t* cntx, ... )
 
 // -----------------------------------------------------------------------------
 
-err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, siz_t bmult_id, cntx_t* cntx )
+err_t bli_cntx_register_blksz( kerid_t* bs_id, const blksz_t* blksz, kerid_t bmult_id, cntx_t* cntx )
 {
 	siz_t id_blksz;
 	err_t error = bli_stack_push( &id_blksz, &cntx->blkszs );
@@ -390,11 +390,14 @@ err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, siz_t bmult_i
 	}
 }
 
-err_t bli_cntx_register_ukr( siz_t* ukr_id, const func_t* ukr, cntx_t* cntx )
+err_t bli_cntx_register_ukr( kerid_t* ukr_id, const func_t* ukr, cntx_t* cntx )
 {
-	err_t error = bli_stack_push( ukr_id, &cntx->ukrs );
+	siz_t new_ukr_id;
+	err_t error = bli_stack_push( &new_ukr_id, &cntx->ukrs );
 	if ( error != BLIS_SUCCESS )
 		return error;
+
+	*ukr_id = new_ukr_id;
 
 	if ( ukr )
 	{
@@ -406,11 +409,14 @@ err_t bli_cntx_register_ukr( siz_t* ukr_id, const func_t* ukr, cntx_t* cntx )
 	}
 }
 
-err_t bli_cntx_register_ukr2( siz_t* ukr_id, const func2_t* ukr, cntx_t* cntx )
+err_t bli_cntx_register_ukr2( kerid_t* ukr_id, const func2_t* ukr, cntx_t* cntx )
 {
-	err_t error = bli_stack_push( ukr_id, &cntx->ukr2s );
+	siz_t new_ukr_id;
+	err_t error = bli_stack_push( &new_ukr_id, &cntx->ukr2s );
 	if ( error != BLIS_SUCCESS )
 		return error;
+
+	*ukr_id = new_ukr_id;
 
 	if ( ukr )
 	{
@@ -422,11 +428,14 @@ err_t bli_cntx_register_ukr2( siz_t* ukr_id, const func2_t* ukr, cntx_t* cntx )
 	}
 }
 
-err_t bli_cntx_register_ukr_pref( siz_t* ukr_pref_id, const mbool_t* ukr_pref, cntx_t* cntx )
+err_t bli_cntx_register_ukr_pref( kerid_t* ukr_pref_id, const mbool_t* ukr_pref, cntx_t* cntx )
 {
-	err_t error = bli_stack_push( ukr_pref_id, &cntx->ukr_prefs );
+	siz_t new_ukr_pref_id;
+	err_t error = bli_stack_push( &new_ukr_pref_id, &cntx->ukr_prefs );
 	if ( error != BLIS_SUCCESS )
 		return error;
+
+	*ukr_pref_id = new_ukr_pref_id;
 
 	if ( ukr_pref )
 	{

--- a/frame/base/bli_cntx.h
+++ b/frame/base/bli_cntx.h
@@ -44,7 +44,7 @@
 typedef struct cntx_s
 {
 	stck_t blkszs; // blksz_t
-	stck_t bmults; // siz_t
+	stck_t bmults; // kerid_t
 
 	stck_t ukrs; // func_t
 	stck_t ukr2s; // func2_t
@@ -60,7 +60,7 @@ typedef struct cntx_s
 // -- cntx_t query (complex) ---------------------------------------------------
 //
 
-BLIS_INLINE const blksz_t* bli_cntx_get_blksz( siz_t bs_id, const cntx_t* cntx )
+BLIS_INLINE const blksz_t* bli_cntx_get_blksz( kerid_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* blksz;
 	err_t error = bli_stack_get( bs_id, ( void** )&blksz, &cntx->blkszs );
@@ -69,7 +69,7 @@ BLIS_INLINE const blksz_t* bli_cntx_get_blksz( siz_t bs_id, const cntx_t* cntx )
 	return blksz;
 }
 
-BLIS_INLINE dim_t bli_cntx_get_blksz_def_dt( num_t dt, siz_t bs_id, const cntx_t* cntx )
+BLIS_INLINE dim_t bli_cntx_get_blksz_def_dt( num_t dt, kerid_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* blksz  = bli_cntx_get_blksz( bs_id, cntx );
 	dim_t          bs_dt  = bli_blksz_get_def( dt, blksz );
@@ -78,7 +78,7 @@ BLIS_INLINE dim_t bli_cntx_get_blksz_def_dt( num_t dt, siz_t bs_id, const cntx_t
 	return bs_dt;
 }
 
-BLIS_INLINE dim_t bli_cntx_get_blksz_max_dt( num_t dt, siz_t bs_id, const cntx_t* cntx )
+BLIS_INLINE dim_t bli_cntx_get_blksz_max_dt( num_t dt, kerid_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* blksz  = bli_cntx_get_blksz( bs_id, cntx );
 	dim_t          bs_dt  = bli_blksz_get_max( dt, blksz );
@@ -87,24 +87,24 @@ BLIS_INLINE dim_t bli_cntx_get_blksz_max_dt( num_t dt, siz_t bs_id, const cntx_t
 	return bs_dt;
 }
 
-BLIS_INLINE siz_t bli_cntx_get_bmult_id( siz_t bs_id, const cntx_t* cntx )
+BLIS_INLINE kerid_t bli_cntx_get_bmult_id( kerid_t bs_id, const cntx_t* cntx )
 {
-	const siz_t* bsz;
+	const kerid_t* bsz;
 	err_t error = bli_stack_get( bs_id, ( void** )&bsz, &cntx->bmults );
 	if ( error != BLIS_SUCCESS )
 		bli_check_error_code( error );
 	return *bsz;
 }
 
-BLIS_INLINE const blksz_t* bli_cntx_get_bmult( siz_t bs_id, const cntx_t* cntx )
+BLIS_INLINE const blksz_t* bli_cntx_get_bmult( kerid_t bs_id, const cntx_t* cntx )
 {
-	siz_t          bm_id  = bli_cntx_get_bmult_id( bs_id, cntx );
+	kerid_t        bm_id  = bli_cntx_get_bmult_id( bs_id, cntx );
 	const blksz_t* bmult  = bli_cntx_get_blksz( bm_id, cntx );
 
 	return bmult;
 }
 
-BLIS_INLINE dim_t bli_cntx_get_bmult_dt( num_t dt, siz_t bs_id, const cntx_t* cntx )
+BLIS_INLINE dim_t bli_cntx_get_bmult_dt( num_t dt, kerid_t bs_id, const cntx_t* cntx )
 {
 	const blksz_t* bmult  = bli_cntx_get_bmult( bs_id, cntx );
 	dim_t          bm_dt  = bli_blksz_get_def( dt, bmult );
@@ -114,7 +114,7 @@ BLIS_INLINE dim_t bli_cntx_get_bmult_dt( num_t dt, siz_t bs_id, const cntx_t* cn
 
 // -----------------------------------------------------------------------------
 
-BLIS_INLINE const func2_t* bli_cntx_get_ukr2s( siz_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE const func2_t* bli_cntx_get_ukr2s( kerid_t ukr_id, const cntx_t* cntx )
 {
 	const func2_t* ukr;
 	err_t error = bli_stack_get( bli_ker_idx( ukr_id ), ( void** )&ukr, &cntx->ukr2s );
@@ -123,7 +123,7 @@ BLIS_INLINE const func2_t* bli_cntx_get_ukr2s( siz_t ukr_id, const cntx_t* cntx 
 	return ukr;
 }
 
-BLIS_INLINE void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, siz_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, kerid_t ukr_id, const cntx_t* cntx )
 {
 	const func2_t* func = bli_cntx_get_ukr2s( ukr_id, cntx );
 
@@ -132,7 +132,7 @@ BLIS_INLINE void_fp bli_cntx_get_ukr2_dt( num_t dt1, num_t dt2, siz_t ukr_id, co
 
 // -----------------------------------------------------------------------------
 
-BLIS_INLINE const func_t* bli_cntx_get_ukrs( siz_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE const func_t* bli_cntx_get_ukrs( kerid_t ukr_id, const cntx_t* cntx )
 {
 	if ( bli_ker_ntype( ukr_id ) == 2 )
 	{
@@ -148,7 +148,7 @@ BLIS_INLINE const func_t* bli_cntx_get_ukrs( siz_t ukr_id, const cntx_t* cntx )
 	}
 }
 
-BLIS_INLINE void_fp bli_cntx_get_ukr_dt( num_t dt, siz_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE void_fp bli_cntx_get_ukr_dt( num_t dt, kerid_t ukr_id, const cntx_t* cntx )
 {
 	if ( bli_ker_ntype( ukr_id ) == 2 )
 	{
@@ -164,7 +164,7 @@ BLIS_INLINE void_fp bli_cntx_get_ukr_dt( num_t dt, siz_t ukr_id, const cntx_t* c
 
 // -----------------------------------------------------------------------------
 
-BLIS_INLINE const mbool_t* bli_cntx_get_ukr_prefs( siz_t pref_id, const cntx_t* cntx )
+BLIS_INLINE const mbool_t* bli_cntx_get_ukr_prefs( kerid_t pref_id, const cntx_t* cntx )
 {
 	const mbool_t* ukr_prefs;
 	err_t error = bli_stack_get( pref_id, ( void** )&ukr_prefs, &cntx->ukr_prefs );
@@ -173,7 +173,7 @@ BLIS_INLINE const mbool_t* bli_cntx_get_ukr_prefs( siz_t pref_id, const cntx_t* 
 	return ukr_prefs;
 }
 
-BLIS_INLINE bool bli_cntx_get_ukr_prefs_dt( num_t dt, siz_t ukr_id, const cntx_t* cntx )
+BLIS_INLINE bool bli_cntx_get_ukr_prefs_dt( num_t dt, kerid_t ukr_id, const cntx_t* cntx )
 {
 	const mbool_t* mbool = bli_cntx_get_ukr_prefs( ukr_id, cntx );
 
@@ -262,14 +262,14 @@ BLIS_INLINE bool bli_cntx_dislikes_storage_of( const obj_t* obj, ukr_t ukr_id, c
 // NOTE: The framework does not use any of the following functions. We provide
 // them in order to facilitate creating/modifying custom contexts.
 
-BLIS_INLINE err_t bli_cntx_set_blksz( siz_t bs_id, const blksz_t* blksz, siz_t mult_id, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_blksz( kerid_t bs_id, const blksz_t* blksz, kerid_t mult_id, cntx_t* cntx )
 {
 	blksz_t* cntx_blksz;
 	err_t error = bli_stack_get( bs_id, ( void** )&cntx_blksz, &cntx->blkszs );
 	if ( error != BLIS_SUCCESS )
 		return error;
 
-	siz_t* cntx_mult_id;
+	kerid_t* cntx_mult_id;
 	error = bli_stack_get( bs_id, ( void** )&cntx_mult_id, &cntx->bmults );
 	if ( error != BLIS_SUCCESS )
 		return error;
@@ -280,34 +280,34 @@ BLIS_INLINE err_t bli_cntx_set_blksz( siz_t bs_id, const blksz_t* blksz, siz_t m
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE void bli_cntx_set_blksz_def_dt( num_t dt, siz_t bs_id, dim_t bs, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_blksz_def_dt( num_t dt, kerid_t bs_id, dim_t bs, cntx_t* cntx )
 {
 	bli_blksz_set_def( bs, dt, ( blksz_t* )bli_cntx_get_blksz( bs_id, cntx ) );
 }
 
-BLIS_INLINE void bli_cntx_set_blksz_max_dt( num_t dt, siz_t bs_id, dim_t bs, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_blksz_max_dt( num_t dt, kerid_t bs_id, dim_t bs, cntx_t* cntx )
 {
 	bli_blksz_set_max( bs, dt, ( blksz_t* )bli_cntx_get_blksz( bs_id, cntx ) );
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr2( siz_t ukr_id, const func2_t* func, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr2( kerid_t ukr_id, const func2_t* func, cntx_t* cntx )
 {
 	*( func2_t* )bli_cntx_get_ukr2s( ukr_id, cntx ) = *func;
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE void bli_cntx_set_ukr2_dt( void_fp fp, num_t dt1, num_t dt2, siz_t ker_id, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_ukr2_dt( void_fp fp, num_t dt1, num_t dt2, kerid_t ker_id, cntx_t* cntx )
 {
 	bli_func2_set_dt( fp, dt1, dt2, ( func2_t* )bli_cntx_get_ukr2s( ker_id, cntx ) );
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr( siz_t ukr_id, const func_t* func, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr( kerid_t ukr_id, const func_t* func, cntx_t* cntx )
 {
 	*( func_t* )bli_cntx_get_ukrs( ukr_id, cntx ) = *func;
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, siz_t ker_id, cntx_t* cntx )
+BLIS_INLINE void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, kerid_t ker_id, cntx_t* cntx )
 {
 	if ( bli_ker_ntype( ker_id ) == 2 )
 	{
@@ -319,13 +319,13 @@ BLIS_INLINE void bli_cntx_set_ukr_dt( void_fp fp, num_t dt, siz_t ker_id, cntx_t
 	}
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr_pref( siz_t ukr_id, const mbool_t* prefs, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr_pref( kerid_t ukr_id, const mbool_t* prefs, cntx_t* cntx )
 {
 	*( mbool_t* )bli_cntx_get_ukr_prefs( ukr_id, cntx ) = *prefs;
 	return BLIS_SUCCESS;
 }
 
-BLIS_INLINE err_t bli_cntx_set_ukr_pref_dt( bool pref, num_t dt, siz_t ukr_id, cntx_t* cntx )
+BLIS_INLINE err_t bli_cntx_set_ukr_pref_dt( bool pref, num_t dt, kerid_t ukr_id, cntx_t* cntx )
 {
 	bli_mbool_set_dt( pref, dt, ( mbool_t* )bli_cntx_get_ukr_prefs( ukr_id, cntx ));
 	return BLIS_SUCCESS;
@@ -400,13 +400,13 @@ BLIS_EXPORT_BLIS void bli_cntx_print( const cntx_t* cntx );
 
 BLIS_EXPORT_BLIS void bli_cntx_set_l3_sup_handlers( cntx_t* cntx, ... );
 
-BLIS_EXPORT_BLIS err_t bli_cntx_register_blksz( siz_t* bs_id, const blksz_t* blksz, siz_t bmult_id, cntx_t* cntx );
+BLIS_EXPORT_BLIS err_t bli_cntx_register_blksz( kerid_t* bs_id, const blksz_t* blksz, kerid_t bmult_id, cntx_t* cntx );
 
-BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr( siz_t* ukr_id, const func_t* ukr, cntx_t* cntx );
+BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr( kerid_t* ukr_id, const func_t* ukr, cntx_t* cntx );
 
-BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr2( siz_t* ukr_id, const func2_t* ukr, cntx_t* cntx );
+BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr2( kerid_t* ukr_id, const func2_t* ukr, cntx_t* cntx );
 
-BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr_pref( siz_t* ukr_pref_id, const mbool_t* ukr_pref, cntx_t* cntx );
+BLIS_EXPORT_BLIS err_t bli_cntx_register_ukr_pref( kerid_t* ukr_pref_id, const mbool_t* ukr_pref, cntx_t* cntx );
 
 
 #endif

--- a/frame/base/bli_gks.c
+++ b/frame/base/bli_gks.c
@@ -482,10 +482,10 @@ kimpl_t bli_gks_l3_ukr_impl_type( ukr_t ukr, ind_t method, num_t dt )
 // -- microkernel and block size registration ----------------------------------
 //
 
-err_t bli_gks_register_blksz( siz_t* bs_id )
+err_t bli_gks_register_blksz( kerid_t* bs_id )
 {
-	siz_t id = 0;
-	siz_t next_id;
+	kerid_t id = 0;
+	kerid_t next_id;
 	cntx_t* cntx;
 	err_t err;
 
@@ -513,10 +513,10 @@ err_t bli_gks_register_blksz( siz_t* bs_id )
 	return BLIS_SUCCESS;
 }
 
-err_t bli_gks_register_ukr( siz_t* ukr_id )
+err_t bli_gks_register_ukr( kerid_t* ukr_id )
 {
-	siz_t id = 0;
-	siz_t next_id;
+	kerid_t id = 0;
+	kerid_t next_id;
 	cntx_t* cntx;
 	err_t err;
 
@@ -544,10 +544,10 @@ err_t bli_gks_register_ukr( siz_t* ukr_id )
 	return BLIS_SUCCESS;
 }
 
-err_t bli_gks_register_ukr2( siz_t* ukr_id )
+err_t bli_gks_register_ukr2( kerid_t* ukr_id )
 {
-	siz_t id = 0;
-	siz_t next_id;
+	kerid_t id = 0;
+	kerid_t next_id;
 	cntx_t* cntx;
 	err_t err;
 
@@ -575,10 +575,10 @@ err_t bli_gks_register_ukr2( siz_t* ukr_id )
 	return BLIS_SUCCESS;
 }
 
-err_t bli_gks_register_ukr_pref( siz_t* ukr_pref_id )
+err_t bli_gks_register_ukr_pref( kerid_t* ukr_pref_id )
 {
-	siz_t id = 0;
-	siz_t next_id;
+	kerid_t id = 0;
+	kerid_t next_id;
 	cntx_t* cntx;
 	err_t err;
 

--- a/frame/base/bli_gks.h
+++ b/frame/base/bli_gks.h
@@ -57,13 +57,13 @@ BLIS_EXPORT_BLIS kimpl_t       bli_gks_l3_ukr_impl_type( ukr_t ukr, ind_t method
 
 //char*                          bli_gks_l3_ukr_avail_impl_string( ukr_t ukr, num_t dt );
 
-BLIS_EXPORT_BLIS err_t bli_gks_register_blksz( siz_t* bs_id );
+BLIS_EXPORT_BLIS err_t bli_gks_register_blksz( kerid_t* bs_id );
 
-BLIS_EXPORT_BLIS err_t bli_gks_register_ukr( siz_t* ukr_id );
+BLIS_EXPORT_BLIS err_t bli_gks_register_ukr( kerid_t* ukr_id );
 
-BLIS_EXPORT_BLIS err_t bli_gks_register_ukr2( siz_t* ukr_id );
+BLIS_EXPORT_BLIS err_t bli_gks_register_ukr2( kerid_t* ukr_id );
 
-BLIS_EXPORT_BLIS err_t bli_gks_register_ukr_pref( siz_t* ukr_pref_id );
+BLIS_EXPORT_BLIS err_t bli_gks_register_ukr_pref( kerid_t* ukr_pref_id );
 
 #endif
 

--- a/frame/include/bli_type_defs.h
+++ b/frame/include/bli_type_defs.h
@@ -623,13 +623,17 @@ typedef enum
 #define BLIS_2TYPE_KER       (  1u << BLIS_NTYPE_KER_SHIFT)
 #define BLIS_3TYPE_KER       (  2u << BLIS_NTYPE_KER_SHIFT)
 
-#define bli_ker_idx( ker )	 ((ker) & ~BLIS_NTYPE_KER_BITS)
+#define bli_ker_idx( ker )   ( kerid_t )((ker) & ~BLIS_NTYPE_KER_BITS)
 #define bli_ker_ntype( ker ) ((((ker) & BLIS_NTYPE_KER_BITS) >> BLIS_NTYPE_KER_SHIFT) + 1)
+
+// We have to use a 32-bit type here to avoid problems with passing small enum
+// constants to variadic functions. See https://github.com/flame/blis/issues/839.
+typedef uint32_t kerid_t;
 
 // Sentinel constant used to indicate the end of a variable argument function
 // (See bli_cntx.c)
 
-#define BLIS_VA_END  ((siz_t)-1)
+#define BLIS_VA_END  ((kerid_t)-1)
 
 typedef enum
 {
@@ -710,7 +714,7 @@ typedef enum
 	// BLIS_NUM_UKR2S must come after all kernels!
 	BLIS_NUM_UKR2S_, BLIS_NUM_UKR2S = bli_ker_idx( BLIS_NUM_UKR2S_ ),
 
-	// Force the size of ukr_t values to be as large as siz_t
+	// Force the size of ukr_t values to be as large as kerid_t
 	BLIS_UKRS_END_ = BLIS_VA_END
 } ukr_t;
 
@@ -738,7 +742,7 @@ typedef enum
     // BLIS_NUM_UKR_PREFS must be last!
     BLIS_NUM_UKR_PREFS,
 
-	// Force the size of ukr_pref_t values to be as large as siz_t
+	// Force the size of ukr_pref_t values to be as large as kerid_t
 	BLIS_UKR_PREFS_END_ = BLIS_VA_END
 } ukr_pref_t;
 
@@ -876,7 +880,7 @@ typedef enum
 	BLIS_NOID,
 	BLIS_NUM_LEVEL3_OPS = BLIS_NOID,
 
-	// Force the size of opid_t values to be as large as siz_t
+	// Force the size of opid_t values to be as large as kerid_t
 	BLIS_LEVEL3_OPS_END_ = BLIS_VA_END
 } opid_t;
 
@@ -926,7 +930,7 @@ typedef enum
 	              // such as when characterizing a packm operation.
 	BLIS_NUM_BLKSZS = BLIS_NO_PART,
 
-	// Force the size of bszid_t values to be as large as siz_t
+	// Force the size of bszid_t values to be as large as kerid_t
 	BLIS_BLKSZS_END_ = BLIS_VA_END
 } bszid_t;
 


### PR DESCRIPTION
Details:
- Currently, all enums used to represent built-in kernel IDs, blocksizes, preferences, and operation IDs have a special member equal to `BLIS_VA_END`, which in turn is `(siz_t)-1`. In principle, this would force the underlying type used to represent the enum values to be as wide as `siz_t`, particularly when passed to the variadic function `bli_cntx_set_ukrs` and friends. User-registered kernels IDs and such are of type `siz_t` explicitly. However, gcc (12 and older), clang, and icx pass literal enum constants (e.g. `BLIS_MR`) that are small enough as `int` when 32-bit mode is used (`-m32`). This causes a misalignment of the parameters on the stack and ultimately a segfault. The problem also exists in 64-bit mode with clang and icx and on aarch64 with clang, as parameters far enough down the list to go on the stack do not get the upper 4 bytes initialized.
- This commit introduces a new type `kerid_t` which is always `uint32_t`. This type is used for all kernel, blocksize, preference, and operation IDs (including user-registered ones). It is also used for `BLIS_VA_END`.
- Now all enum values are always passed as 32-bit ints on all architectures.
- Fixes #839.