### PR TITLE
Fix errors and typos in some docs

### DIFF
--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -74,15 +74,15 @@ The following tables list various types used throughout the BLIS object API.
 
 ### Integer-based types
 
-| BLIS integer type | Type definition          | Used to represent...                                                 |
-|:------------------|:-------------------------|:---------------------------------------------------------------------|
-| `gint_t`          | `int32_t` or `int64_t`   | general-purpose signed integer; used to define signed integer types. |
-| `guint_t`         | `uint32_t` or `uint64_t` | general-purpose signed integer; used to define signed integer types. |
-| `dim_t`           | `gint_t`                 | matrix and vector dimensions.                                        |
-| `inc_t`           | `gint_t`                 | matrix row/column strides and vector increments.                     |
+| BLIS integer type | Type definition          | Used to represent...                                                     |
+|:------------------|:-------------------------|:-------------------------------------------------------------------------|
+| `gint_t`          | `int32_t` or `int64_t`   | general-purpose signed integer; used to define signed integer types.     |
+| `guint_t`         | `uint32_t` or `uint64_t` | general-purpose unsigned integer; used to define unsigned integer types. |
+| `dim_t`           | `gint_t`                 | matrix and vector dimensions.                                            |
+| `inc_t`           | `gint_t`                 | matrix row/column strides and vector increments.                         |
 | `doff_t`          | `gint_t`                 | matrix diagonal offset: if _k_ < 0, diagonal begins at element (-_k_,0); otherwise diagonal begins at element (0,_k_). |
-| `siz_t`           | `guint_t`                | a byte size or byte offset.                                          |
-| `kerid_t`         | `uint32_t`               | a kernel, block size, operation, or kernel preference ID.        |
+| `siz_t`           | `guint_t`                | a byte size or byte offset, unsigned integer.                            |
+| `kerid_t`         | `uint32_t`               | a kernel, block size, operation, or kernel preference ID.                |
 
 ### Floating-point types
 
@@ -1418,6 +1418,7 @@ Observed object properties: `conj?(alphax)`, `conj?(x)`, `conj?(alphay)`, `conj?
 void bli_dotaxpyv
      (
        obj_t*  alpha,
+       obj_t*  xt,
        obj_t*  x,
        obj_t*  y,
        obj_t*  rho,
@@ -1481,6 +1482,7 @@ Observed object properties: `conj?(alpha)`, `conj?(beta)`, `conj?(A)`, `conj?(x)
 void bli_dotxaxpyf
      (
        obj_t*  alpha,
+       obj_t*  at,
        obj_t*  a,
        obj_t*  w,
        obj_t*  x,

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -2368,10 +2368,33 @@ gint_t bli_info_get_stack_buf_max_size( void );
 gint_t bli_info_get_stack_buf_align_size( void );
 gint_t bli_info_get_heap_addr_align_size( void );
 gint_t bli_info_get_heap_stride_align_size( void );
-gint_t bli_info_get_pool_addr_align_size( void );
+gint_t bli_info_get_pool_addr_align_size_a( void );
+gint_t bli_info_get_pool_addr_align_size_b( void );
+gint_t bli_info_get_pool_addr_align_size_c( void );
+gint_t bli_info_get_pool_addr_align_size_gen( void );
+gint_t bli_info_get_pool_addr_offset_size_a( void );
+gint_t bli_info_get_pool_addr_offset_size_b( void );
+gint_t bli_info_get_pool_addr_offset_size_c( void );
+gint_t bli_info_get_pool_addr_offset_size_gen( void );
 gint_t bli_info_get_enable_stay_auto_init( void );
 gint_t bli_info_get_enable_blas( void );
+gint_t bli_info_get_enable_cblas( void );
 gint_t bli_info_get_blas_int_type_size( void );
+gint_t bli_info_get_enable_pba_pools( void );
+gint_t bli_info_get_enable_sba_pools( void );
+gint_t bli_info_get_enable_threading( void );
+gint_t bli_info_get_enable_openmp( void );
+gint_t bli_info_get_enable_pthreads( void );
+gint_t bli_info_get_enable_hpx( void );
+gint_t bli_info_get_enable_openmp_as_default( void );
+gint_t bli_info_get_enable_pthreads_as_default( void );
+gint_t bli_info_get_enable_hpx_as_default( void );
+gint_t bli_info_get_thread_jrir_slab( void );
+gint_t bli_info_get_thread_jrir_rr( void );
+gint_t bli_info_get_thread_jrir_tlb( void );
+gint_t bli_info_get_enable_tls( void );
+gint_t bli_info_get_enable_memkind( void );
+gint_t bli_info_get_enable_sandbox( void );
 ```
 
 ## Kernel information

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -2200,12 +2200,12 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 #### getijv
 ```c
 err_t bli_getijv
-      (
-        dim_t    i,
-        obj_t*   x,
-        double*  ar,
-        double*  ai
-      );
+     (
+       dim_t    i,
+       obj_t*   x,
+       double*  ar,
+       double*  ai
+     );
 ```
 Copy the real and imaginary values at the `i`th element of vector object `x` to `ar` and `ai`. If elements of `x` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 If either the element offset `i` is beyond the vector dimension of `x` or less than zero, the function returns `BLIS_FAILURE` without taking any action. Similarly, if `x` is a global scalar constant such as `BLIS_ONE`, the function returns `BLIS_FAILURE`.
@@ -2215,13 +2215,13 @@ If either the element offset `i` is beyond the vector dimension of `x` or less t
 #### getijm
 ```c
 err_t bli_getijm
-      (
-        dim_t    i,
-        dim_t    j,
-        obj_t*   b,
-        double*  ar,
-        double*  ai
-      );
+     (
+       dim_t    i,
+       dim_t    j,
+       obj_t*   b,
+       double*  ar,
+       double*  ai
+     );
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. If elements of `b` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 If either the row offset `i` is beyond the _m_ dimension of `b` or less than zero, or column offset `j` is beyond the _n_ dimension of `b` or less than zero, the function returns `BLIS_FAILURE` without taking any action. Similarly, if `b` is a global scalar constant such as `BLIS_ONE`, the function returns `BLIS_FAILURE`.

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -659,7 +659,7 @@ Modify the properties of `obj` to induce a logical transposition. This function 
 void bli_obj_alias_to( obj_t* a, obj_t* b );
 ```
 Initialize `b` to be a shallow copy, or alias, of `a`. For most people's purposes, this is equivalent to
-```
+```c
   b = a;
 ```
 However, there is at least one field (one that only developers should be concerned with) that is not copied.
@@ -758,7 +758,7 @@ Observed object properties: `conj?(alpha)`, `conj?(x)`.
 ---
 
 #### axpbyv
-```
+```c
 void bli_axpbyv
      (
        obj_t*  alpha,
@@ -986,7 +986,7 @@ Swap corresponding elements of two _n_-length vectors `x` and `y`.
 ---
 
 #### xpbyv
-```
+```c
 void bli_xpbyv
      (
        obj_t*  x,

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -86,12 +86,12 @@ The following tables list various types used throughout the BLIS object API.
 
 ### Floating-point types
 
-| BLIS fp type      | Type definition                        | Used to represent...              |
-|:------------------|:---------------------------------------|:----------------------------------|
-| `float`           | _N/A_                                  | single-precision real numbers.    |
-| `double`          | _N/A_                                  | double-precision real numbers.    |
-| `scomplex`        | `struct { float real; float imag; }`   | single-precision complex numbers. |
-| `dcomplex`        | `struct { double real; double imag; }` | double-precision complex numbers. |
+| BLIS fp type | Type definition                        | Used to represent...              |
+|:-------------|:---------------------------------------|:----------------------------------|
+| `float`      | _N/A_                                  | single-precision real numbers.    |
+| `double`     | _N/A_                                  | double-precision real numbers.    |
+| `scomplex`   | `struct { float real; float imag; }`   | single-precision complex numbers. |
+| `dcomplex`   | `struct { double real; double imag; }` | double-precision complex numbers. |
 
 ### Enumerated parameter types
 
@@ -114,7 +114,7 @@ The following tables list various types used throughout the BLIS object API.
 | `BLIS_SINGLE_PREC` | contains single-precision elements.        |
 | `BLIS_DOUBLE_PREC` | contains double-precision elements.        |
 
-| `trans_t`                | Semantic meaning: Matrix operand ...            |
+| `trans_t`                | Semantic meaning: Matrix operand...             |
 |:-------------------------|:------------------------------------------------|
 | `BLIS_NO_TRANSPOSE`      | will be used as given.                          |
 | `BLIS_TRANSPOSE`         | will be implicitly transposed.                  |
@@ -144,7 +144,7 @@ The following tables list various types used throughout the BLIS object API.
 | `BLIS_UPPER` | is stored in (and will be accessed only from) the upper triangle. |
 | `BLIS_DENSE` | is stored as a full matrix (ie: in both triangles).               |
 
-| `diag_t`            | Semantic meaning: Matrix operand ...                                       |
+| `diag_t`            | Semantic meaning: Matrix operand...                                        |
 |:--------------------|:---------------------------------------------------------------------------|
 | `BLIS_NONUNIT_DIAG` | has a non-unit diagonal that should be explicitly read from.               |
 | `BLIS_UNIT_DIAG`    | has a unit diagonal that should be implicitly assumed (and not read from). |
@@ -2420,6 +2420,24 @@ Possible microkernel types (ie: the return values for `bli_info_get_*_ukr_impl_s
  * `BLIS_VIRTUAL_UKERNEL` (`"virtual"`): This value is returned when the queried microkernel is driven by a the "virtual" microkernel provided by an induced method. This happens for any `method` value that is not `BLIS_NAT` (ie: native), but only applies to the complex domain.
  * `BLIS_OPTIMIZED_UKERNEL` (`"optimzd"`): This value is returned when the queried microkernel is provided by an implementation that is neither reference nor virtual, and thus we assume the kernel author would deem it to be "optimized". Such a microkernel may not be optimal in the literal sense of the word, but nonetheless is _intended_ to be optimized, at least relative to the reference microkernels.
  * `BLIS_NOTAPPLIC_UKERNEL` (`"notappl"`): This value is returned usually when performing a `gemmtrsm` or `trsm` microkernel type query for any `method` value that is not `BLIS_NAT` (ie: native). That is, induced methods cannot be (purely) used on `trsm`-based microkernels because these microkernels perform more a triangular inversion, which is not matrix multiplication.
+
+
+### Operation implementation type query
+
+The following routines allow the caller to obtain a string that identifies the implementation (`ind_t`) that is currently active (ie: implemented and enabled) for each level-3 operation. Possible implementation types are listed in the section above covering [microkernel implemenation query](BLISTypedAPI.md#microkernel-implementation-type-query).
+```c
+char* bli_info_get_gemm_impl_string( num_t dt );
+char* bli_info_get_gemmt_impl_string( num_t dt );
+char* bli_info_get_hemm_impl_string( num_t dt );
+char* bli_info_get_herk_impl_string( num_t dt );
+char* bli_info_get_her2k_impl_string( num_t dt );
+char* bli_info_get_symm_impl_string( num_t dt );
+char* bli_info_get_syrk_impl_string( num_t dt );
+char* bli_info_get_syr2k_impl_string( num_t dt );
+char* bli_info_get_trmm_impl_string( num_t dt );
+char* bli_info_get_trmm3_impl_string( num_t dt );
+char* bli_info_get_trsm_impl_string( num_t dt );
+```
 
 
 ## Clock functions

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -161,6 +161,9 @@ BLIS defines a handful of scalar objects that conveniently represent various con
 |  `BLIS_ZERO`               | ` 0.0`           |
 |  `BLIS_ONE`                | ` 1.0`           |
 |  `BLIS_TWO`                | ` 2.0`           |
+|  `BLIS_MINUS_ONE_I`        | ` 0.0-1.0*i`     |
+|  `BLIS_ONE_I`              | ` 0.0+1.0*i`     |
+|  `BLIS_NAN`                | ` NaN`           |
 
 These objects are polymorphic; each one contains a `float`, `double`, `scomplex`, `dcomplex`, and `gint_t` representation of the constant value in question. They can be used in place of any `obj_t*` operand in any object API function provided that the following criteria are met:
  * The object parameter requires unit dimensions (1x1). (In other words, the function expects a scalar for the operand in question.)

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -181,24 +181,24 @@ The functions listed in this document belong to the "basic" interface subset of 
 ```c
 void bli_gemm
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 while the expert interface is:
 ```c
 void bli_gemm_ex
      (
-       obj_t*   alpha,
-       obj_t*   a,
-       obj_t*   b,
-       obj_t*   beta,
-       obj_t*   c,
-       cntx_t*  cntx,
-       rntm_t*  rntm
+       const obj_t*   alpha,
+       const obj_t*   a,
+       const obj_t*   b,
+       const obj_t*   beta,
+       const obj_t*   c,
+       const cntx_t*  cntx,
+       const rntm_t*  rntm
      );
 ```
 The expert interface contains two additional parameters: a `cntx_t*` and `rntm_t*`. Note that calling a function from the expert interface with the `cntx_t*` and `rntm_t*` arguments each set to `NULL` is equivalent to calling the corresponding basic interface. Specifically, a `NULL` value passed in for the `cntx_t*` results in a valid context being queried from BLIS, and a `NULL` value passed in for the `rntm_t*` results in the current global settings for multithreading to be used.
@@ -207,7 +207,7 @@ The expert interface contains two additional parameters: a `cntx_t*` and `rntm_t
 
 In general, it is permissible to pass in `NULL` for a `cntx_t*` parameter when calling an expert interface such as `bli_gemm_ex()`. However, there are cases where `NULL` values are not accepted and may result in a segmentation fault. Specifically, the `cntx_t*` argument appears in the interfaces to the `gemm`, `trsm`, and `gemmtrsm` [level-3 microkernels](KernelsHowTo.md#level-3) along with all [level-1v](KernelsHowTo.md#level-1v) and [level-1f](KernelsHowTo.md#level-1f) kernels. There, as a general rule, a valid pointer must be passed in. Whenever a valid context is needed, the developer may query a default context from the global kernel structure (if a context is not already available in the current scope):
 ```c
-cntx_t* bli_gks_query_cntx( void );
+const cntx_t* bli_gks_query_cntx( void );
 ```
 When BLIS is configured to target a configuration family (e.g. `intel64`, `x86_64`), `bli_gks_query_cntx()` will use `cpuid` or an equivalent heuristic to select and and return the appropriate context. When BLIS is configured to target a singleton sub-configuration (e.g. `haswell`, `skx`), `bli_gks_query_cntx()` will unconditionally return a pointer to the context appropriate for the targeted configuration.
 
@@ -389,8 +389,8 @@ Objects initialized via this function should generally not be passed to `bli_obj
 ```c
 void bli_obj_create_conf_to
      (
-       obj_t*  s,
-       obj_t*  d
+       const obj_t*  s,
+             obj_t*  d
      );
 ```
 Initialize an object `d` with dimensions conformal to those of an existing object `s`. Object `d` is initialized with the same row and column strides as those of `s`. However, the structure, uplo, conjugation, and transposition properties of `s` are **not** inherited by `d`.
@@ -430,35 +430,35 @@ Notes for interpreting function descriptions:
 ---
 
 ```c
-num_t bli_obj_dt( obj_t* obj );
+num_t bli_obj_dt( const obj_t* obj );
 ```
 Return the storage datatype property of `obj`.
 
 ---
 
 ```c
-dom_t bli_obj_domain( obj_t* obj );
+dom_t bli_obj_domain( const obj_t* obj );
 ```
 Return the domain component of the storage datatype property of `obj`.
 
 ---
 
 ```c
-prec_t bli_obj_prec( obj_t* obj );
+prec_t bli_obj_prec( const obj_t* obj );
 ```
 Return the precision component of the storage datatype property of `obj`.
 
 ---
 
 ```c
-trans_t bli_obj_conjtrans_status( obj_t* obj );
+trans_t bli_obj_conjtrans_status( const obj_t* obj );
 ```
 Return the `trans_t` property of `obj`, which may indicate transposition, conjugation, both, or neither. Thus, possible return values are `BLIS_NO_TRANSPOSE`, `BLIS_CONJ_NO_TRANSPOSE`, `BLIS_TRANSPOSE`, or `BLIS_CONJ_TRANSPOSE`.
 
 ---
 
 ```c
-trans_t bli_obj_onlytrans_status( obj_t* obj );
+trans_t bli_obj_onlytrans_status( const obj_t* obj );
 ```
 Return the transposition component of the `trans_t` property of `obj`, which may indicate transposition or no transposition.
 Thus, possible return values are `BLIS_NO_TRANSPOSE` or `BLIS_TRANSPOSE`.
@@ -466,7 +466,7 @@ Thus, possible return values are `BLIS_NO_TRANSPOSE` or `BLIS_TRANSPOSE`.
 ---
 
 ```c
-conj_t bli_obj_conj_status( obj_t* obj );
+conj_t bli_obj_conj_status( const obj_t* obj );
 ```
 Return the conjugation component of the `trans_t` property of `obj`, which may indicate conjugation or no conjugation.
 Thus, possible return values are `BLIS_NO_CONJUGATE` or `BLIS_CONJUGATE`.
@@ -474,77 +474,77 @@ Thus, possible return values are `BLIS_NO_CONJUGATE` or `BLIS_CONJUGATE`.
 ---
 
 ```c
-struc_t bli_obj_struc( obj_t* obj );
+struc_t bli_obj_struc( const obj_t* obj );
 ```
 Return the structure property of `obj`.
 
 ---
 
 ```c
-uplo_t bli_obj_uplo( obj_t* obj );
+uplo_t bli_obj_uplo( const obj_t* obj );
 ```
 Return the uplo (i.e., storage) property of `obj`.
 
 ---
 
 ```c
-diag_t bli_obj_diag( obj_t* obj );
+diag_t bli_obj_diag( const obj_t* obj );
 ```
 Return the diagonal property of `obj`.
 
 ---
 
 ```c
-doff_t bli_obj_diag_offset( obj_t* obj );
+doff_t bli_obj_diag_offset( const obj_t* obj );
 ```
 Return the diagonal offset of `obj`. Note that the diagonal offset will be negative, `-i`, if the diagonal begins at element `(-i,0)` and positive `j` if the diagonal begins at element `(0,j)`.
 
 ---
 
 ```c
-dim_t bli_obj_length( obj_t* obj );
+dim_t bli_obj_length( const obj_t* obj );
 ```
 Return the number of rows (or _m_ dimension) of `obj`. This value is the _m_ dimension **before** taking into account the transposition property as indicated by `bli_obj_onlytrans_status()` or `bli_obj_conjtrans_status()`.
 
 ---
 
 ```c
-dim_t bli_obj_width( obj_t* obj );
+dim_t bli_obj_width( const obj_t* obj );
 ```
 Return the number of columns (or _n_ dimension) of `obj`. This value is the _n_ dimension **before** taking into account the transposition property as indicated by `bli_obj_onlytrans_status()` or `bli_obj_conjtrans_status()`.
 
 ---
 
 ```c
-dim_t bli_obj_length_after_trans( obj_t* obj );
+dim_t bli_obj_length_after_trans( const obj_t* obj );
 ```
 Return the number of rows (or _m_ dimension) of `obj` after taking into account the transposition property as indicated by `bli_obj_onlytrans_status()` or `bli_obj_conjtrans_status()`.
 
 ---
 
 ```c
-dim_t bli_obj_width_after_trans( obj_t* obj );
+dim_t bli_obj_width_after_trans( const obj_t* obj );
 ```
 Return the number of columns (or _n_ dimension) of `obj` after taking into account the transposition property as indicated by `bli_obj_onlytrans_status()` or `bli_obj_conjtrans_status()`.
 
 ---
 
 ```c
-inc_t bli_obj_row_stride( obj_t* obj );
+inc_t bli_obj_row_stride( const obj_t* obj );
 ```
 Return the row stride property of `obj`. When storing by columns, the row stride is 1. When storing by rows, the row stride is also sometimes called the _leading dimension_.
 
 ---
 
 ```c
-inc_t bli_obj_col_stride( obj_t* obj );
+inc_t bli_obj_col_stride( const obj_t* obj );
 ```
 Return the column stride property of `obj`. When storing by rows, the column stride is 1. When storing by columns, the column stride is also sometimes called the _leading dimension_.
 
 ---
 
 ```c
-dim_t bli_obj_vector_dim( obj_t* obj );
+dim_t bli_obj_vector_dim( const obj_t* obj );
 ```
 Return the number of elements in a vector object `obj`.
 This function assumes that at least one dimension of `obj` is unit, and that it therefore represents a vector.
@@ -552,7 +552,7 @@ This function assumes that at least one dimension of `obj` is unit, and that it 
 ---
 
 ```c
-inc_t bli_obj_vector_inc( obj_t* obj );
+inc_t bli_obj_vector_inc( const obj_t* obj );
 ```
 Return the storage increment of a vector object `obj`.
 This function assumes that at least one dimension of `obj` is unit, and that it therefore represents a vector.
@@ -560,7 +560,7 @@ This function assumes that at least one dimension of `obj` is unit, and that it 
 ---
 
 ```c
-void* bli_obj_buffer( obj_t* obj );
+void* bli_obj_buffer( const obj_t* obj );
 ```
 Return the address to the data buffer associated with object `obj`.
 **Note**: The address returned by this buffer will not take into account any subpartitioning. However, this will not be a problem for most casual users.
@@ -568,7 +568,7 @@ Return the address to the data buffer associated with object `obj`.
 ---
 
 ```c
-siz_t bli_obj_elem_size( obj_t* obj );
+siz_t bli_obj_elem_size( const obj_t* obj );
 ```
 Return the size, in bytes, of the storage datatype as indicated by `bli_obj_dt()`.
 
@@ -659,7 +659,7 @@ Modify the properties of `obj` to induce a logical transposition. This function 
 ---
 
 ```c
-void bli_obj_alias_to( obj_t* a, obj_t* b );
+void bli_obj_alias_to( const obj_t* a, obj_t* b );
 ```
 Initialize `b` to be a shallow copy, or alias, of `a`. For most people's purposes, this is equivalent to
 ```c
@@ -670,14 +670,14 @@ However, there is at least one field (one that only developers should be concern
 ---
 
 ```c
-void bli_obj_real_part( obj_t* c, obj_t* r );
+void bli_obj_real_part( const obj_t* c, obj_t* r );
 ```
 Initialize `r` to be a modified shallow copy of `c` that refers only to the real part of `c`.
 
 ---
 
 ```c
-void bli_obj_imag_part( obj_t* c, obj_t* i );
+void bli_obj_imag_part( const obj_t* c, obj_t* i );
 ```
 Initialize `i` to be a modified shallow copy of `c` that refers only to the imaginary part of `c`.
 
@@ -709,8 +709,8 @@ Level-1v operations perform various level-1 BLAS-like operations on vectors (hen
 ```c
 void bli_addv
      (
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Perform
@@ -727,8 +727,8 @@ Observed object properties: `conj?(x)`.
 ```c
 void bli_amaxv
      (
-       obj_t*  x,
-       obj_t*  index
+       const obj_t*  x,
+       const obj_t*  index
      );
 ```
 Given a vector of length _n_, return the zero-based index of the element of vector `x` that contains the largest absolute value (or, in the complex domain, the largest complex modulus). The object `index` must be created of type `BLIS_INT`.
@@ -745,9 +745,9 @@ Observed object properties: none.
 ```c
 void bli_axpyv
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Perform
@@ -764,10 +764,10 @@ Observed object properties: `conj?(alpha)`, `conj?(x)`.
 ```c
 void bli_axpbyv
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y
      );
 ```
 Perform
@@ -784,8 +784,8 @@ Observed object properties: `conj?(alpha)`, `conj?(x)`.
 ```c
 void bli_copyv
      (
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Perform
@@ -802,9 +802,9 @@ Observed object properties: `conj?(x)`.
 ```c
 void bli_dotv
      (
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  rho
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  rho
      );
 ```
 Perform
@@ -821,11 +821,11 @@ Observed object properties: `conj?(x)`, `conj?(y)`.
 ```c
 void bli_dotxv
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  beta,
-       obj_t*  rho
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  beta,
+       const obj_t*  rho
      );
 ```
 Perform
@@ -842,7 +842,7 @@ Observed object properties: `conj?(alpha)`, `conj?(beta)`, `conj?(x)`, `conj?(y)
 ```c
 void bli_invertv
      (
-       obj_t*  x
+       const obj_t*  x
      );
 ```
 Invert all elements of an _n_-length vector `x`.
@@ -853,8 +853,8 @@ Invert all elements of an _n_-length vector `x`.
 ```c
 void bli_invscalv
      (
-       obj_t*  alpha,
-       obj_t*  x
+       const obj_t*  alpha,
+       const obj_t*  x
      );
 ```
 Perform
@@ -871,8 +871,8 @@ Observed object properties: `conj?(alpha)`.
 ```c
 void bli_scalv
      (
-       obj_t*  alpha,
-       obj_t*  x
+       const obj_t*  alpha,
+       const obj_t*  x
      );
 ```
 Perform
@@ -889,9 +889,9 @@ Observed object properties: `conj?(alpha)`.
 ```c
 void bli_scal2v
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Perform
@@ -908,8 +908,8 @@ Observed object properties: `conj?(alpha)`, `conj?(x)`.
 ```c
 void bli_setv
      (
-       obj_t*  alpha,
-       obj_t*  x
+       const obj_t*  alpha,
+       const obj_t*  x
      );
 ```
 Perform
@@ -926,8 +926,8 @@ Observed object properties: `conj?(alpha)`.
 ```c
 void bli_setrv
      (
-       obj_t*  alpha,
-       obj_t*  x
+       const obj_t*  alpha,
+       const obj_t*  x
      );
 ```
 Perform
@@ -944,8 +944,8 @@ If `x` is real, this operation is equivalent to performing `setv` on `x` with th
 ```c
 void bli_setiv
      (
-       obj_t*  alpha,
-       obj_t*  x
+       const obj_t*  alpha,
+       const obj_t*  x
      );
 ```
 Perform
@@ -962,8 +962,8 @@ If `x` is real, this operation is equivalent to a no-op.
 ```c
 void bli_subv
      (
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Perform
@@ -980,8 +980,8 @@ Observed object properties: `conj?(x)`.
 ```c
 void bli_swapv
      (
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Swap corresponding elements of two _n_-length vectors `x` and `y`.
@@ -992,9 +992,9 @@ Swap corresponding elements of two _n_-length vectors `x` and `y`.
 ```c
 void bli_xpbyv
      (
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y
      );
 ```
 Perform
@@ -1023,8 +1023,8 @@ These operations are similar to their level-1m counterparts, except they only re
 ```c
 void bli_addd
      (
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 
@@ -1036,9 +1036,9 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `trans?(A)`.
 ```c
 void bli_axpyd
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 
@@ -1050,8 +1050,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `diag(A)`, `trans?(A)`
 ```c
 void bli_copyd
      (
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 
@@ -1063,7 +1063,7 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `trans?(A)`.
 ```c
 void bli_invertd
      (
-       obj_t*  a
+       const obj_t*  a
      );
 ```
 
@@ -1075,8 +1075,8 @@ Observed object properties: `diagoff(A)`.
 ```c
 void bli_invscald
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 
@@ -1088,8 +1088,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`.
 ```c
 void bli_scald
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 
@@ -1101,9 +1101,9 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`.
 ```c
 void bli_scal2d
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 
@@ -1115,8 +1115,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `diag(A)`, `trans?(A)`
 ```c
 void bli_setd
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 
@@ -1128,8 +1128,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`.
 ```c
 void bli_setid
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Set the imaginary components of every element along the diagonal of `a`
@@ -1145,8 +1145,8 @@ Observed object properties: `diagoff(A)`.
 ```c
 void bli_shiftd
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Add a constant value `alpha` to every element along the diagonal of `a`.
@@ -1159,8 +1159,8 @@ Observed object properties: `diagoff(A)`.
 ```c
 void bli_subd
      (
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 
@@ -1172,9 +1172,9 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `trans?(A)`.
 ```c
 void bli_xpbyd
      (
-       obj_t*  a,
-       obj_t*  beta,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  beta,
+       const obj_t*  b
      );
 ```
 
@@ -1194,8 +1194,8 @@ Level-1m operations perform various level-1 BLAS-like operations on matrices (he
 ```c
 void bli_addm
      (
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Perform
@@ -1213,9 +1213,9 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`, `trans?(A)`.
 ```c
 void bli_axpym
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Perform
@@ -1233,8 +1233,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `diag(A)`, `uplo(A)`, 
 ```c
 void bli_copym
      (
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Perform
@@ -1252,8 +1252,8 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`, `trans?(A)`.
 ```c
 void bli_invscalm
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1270,8 +1270,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `uplo(A)`.
 ```c
 void bli_scalm
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1288,9 +1288,9 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `uplo(A)`.
 ```c
 void bli_scal2m
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Perform
@@ -1308,8 +1308,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `diag(A)`, `uplo(A)`, 
 ```c
 void bli_setm
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1326,8 +1326,8 @@ Observed object properties: `conj?(alpha)`, `diagoff(A)`, `diag(A)`, `uplo(A)`.
 ```c
 void bli_setrm
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1346,8 +1346,8 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`.
 ```c
 void bli_setim
      (
-       obj_t*  alpha,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1366,8 +1366,8 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`.
 ```c
 void bli_subm
      (
-       obj_t*  a,
-       obj_t*  b
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Perform
@@ -1399,11 +1399,11 @@ Level-1f kernels are employed when optimizing level-2 operations.
 ```c
 void bli_axpy2v
      (
-       obj_t*  alphax,
-       obj_t*  alphay,
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  z
+       const obj_t*  alphax,
+       const obj_t*  alphay,
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  z
      );
 ```
 Perform
@@ -1420,12 +1420,12 @@ Observed object properties: `conj?(alphax)`, `conj?(x)`, `conj?(alphay)`, `conj?
 ```c
 void bli_dotaxpyv
      (
-       obj_t*  alpha,
-       obj_t*  xt,
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  rho,
-       obj_t*  z
+       const obj_t*  alpha,
+       const obj_t*  xt,
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  rho,
+       const obj_t*  z
      );
 ```
 Perform
@@ -1443,10 +1443,10 @@ Observed object properties: `conj?(x)`, `conj?(y)`, `conj?(alpha)`.
 ```c
 void bli_axpyf
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  x,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  x,
+       const obj_t*  y
      );
 ```
 Perform
@@ -1463,11 +1463,11 @@ Observed object properties: `conj?(alpha)`, `conj?(A)`, `conj?(x)`.
 ```c
 void bli_dotxf
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y
      );
 ```
 Perform
@@ -1484,14 +1484,14 @@ Observed object properties: `conj?(alpha)`, `conj?(beta)`, `conj?(A)`, `conj?(x)
 ```c
 void bli_dotxaxpyf
      (
-       obj_t*  alpha,
-       obj_t*  at,
-       obj_t*  a,
-       obj_t*  w,
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y,
-       obj_t*  z
+       const obj_t*  alpha,
+       const obj_t*  at,
+       const obj_t*  a,
+       const obj_t*  w,
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y,
+       const obj_t*  z
      );
 ```
 Perform
@@ -1516,11 +1516,11 @@ Level-2 operations perform various level-2 BLAS-like operations.
 ```c
 void bli_gemv
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y
      );
 ```
 Perform
@@ -1537,10 +1537,10 @@ Observed object properties: `conj?(alpha)`, `conj?(beta)`, `trans?(A)`, `conj?(x
 ```c
 void bli_ger
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1557,11 +1557,11 @@ Observed object properties: `conj?(alpha)`, `conj?(x)`, `conj?(y)`.
 ```c
 void bli_hemv
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y
      );
 ```
 Perform
@@ -1578,9 +1578,9 @@ Observed object properties: `conj?(alpha)`, `conj?(beta)`, `conj?(A)`, `uplo(A)`
 ```c
 void bli_her
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1599,10 +1599,10 @@ Observed object properties: `conj?(alpha)`, `uplo(A)`, `conj?(x)`.
 ```c
 void bli_her2
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1619,11 +1619,11 @@ Observed object properties: `uplo(A)`, `conj?(x)`, `conj?(y)`.
 ```c
 void bli_symv
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  x,
-       obj_t*  beta,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  x,
+       const obj_t*  beta,
+       const obj_t*  y
      );
 ```
 Perform
@@ -1640,9 +1640,9 @@ Observed object properties: `conj?(alpha)`, `conj?(beta)`, `conj?(A)`, `uplo(A)`
 ```c
 void bli_syr
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1659,10 +1659,10 @@ Observed object properties: `conj?(alpha)`, `conj?(x)`.
 ```c
 void bli_syr2
      (
-       obj_t*  alpha,
-       obj_t*  x,
-       obj_t*  y,
-       obj_t*  a
+       const obj_t*  alpha,
+       const obj_t*  x,
+       const obj_t*  y,
+       const obj_t*  a
      );
 ```
 Perform
@@ -1679,9 +1679,9 @@ Observed object properties: `uplo(A)`, `conj?(x)`, `conj?(y)`.
 ```c
 void bli_trmv
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  x
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  x
      );
 ```
 Perform
@@ -1698,9 +1698,9 @@ Observed object properties: `conj?(alpha)`, `uplo(A)`, `trans?(A)`, `diag(A)`.
 ```c
 void bli_trsv
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  y
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  y
      );
 ```
 Solve the linear system
@@ -1727,11 +1727,11 @@ Level-3 operations perform various level-3 BLAS-like operations.
 ```c
 void bli_gemm
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1748,11 +1748,11 @@ Observed object properties: `trans?(A)`, `trans?(B)`.
 ```c
 void bli_gemmt
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1769,12 +1769,12 @@ Observed object properties: `trans?(A)`, `trans?(B)`, `uplo(C)`.
 ```c
 void bli_hemm
      (
-       side_t  sidea,
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+             side_t  sidea,
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1795,10 +1795,10 @@ Observed object properties: `uplo(A)`, `conj?(A)`, `trans?(B)`.
 ```c
 void bli_herk
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1817,11 +1817,11 @@ Observed object properties: `trans?(A)`, `uplo(C)`.
 ```c
 void bli_her2k
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1840,12 +1840,12 @@ Observed object properties: `trans?(A)`, `trans?(B)`, `uplo(C)`.
 ```c
 void bli_symm
      (
-       side_t  sidea,
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+             side_t  sidea,
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1866,10 +1866,10 @@ Observed object properties: `uplo(A)`, `conj?(A)`, `trans?(B)`.
 ```c
 void bli_syrk
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1886,11 +1886,11 @@ Observed object properties: `trans?(A)`, `uplo(C)`.
 ```c
 void bli_syr2k
      (
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1907,10 +1907,10 @@ Observed object properties: `trans?(A)`, `trans?(B)`, `uplo(C)`.
 ```c
 void bli_trmm
      (
-       side_t  sidea,
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b
+             side_t  sidea,
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Perform
@@ -1931,12 +1931,12 @@ Observed object properties: `uplo(A)`, `trans?(A)`, `diag(A)`.
 ```c
 void bli_trmm3
      (
-       side_t  sidea,
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b,
-       obj_t*  beta,
-       obj_t*  c
+             side_t  sidea,
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b,
+       const obj_t*  beta,
+       const obj_t*  c
      );
 ```
 Perform
@@ -1957,10 +1957,10 @@ Observed object properties: `uplo(A)`, `trans?(A)`, `diag(A)`, `trans?(B)`.
 ```c
 void bli_trsm
      (
-       side_t  sidea,
-       obj_t*  alpha,
-       obj_t*  a,
-       obj_t*  b
+             side_t  sidea,
+       const obj_t*  alpha,
+       const obj_t*  a,
+       const obj_t*  b
      );
 ```
 Solve the linear system with multiple right-hand sides
@@ -1986,8 +1986,8 @@ Observed object properties: `uplo(A)`, `trans?(A)`, `diag(A)`.
 ```c
 void bli_asumv
      (
-       obj_t*  x,
-       obj_t*  asum
+       const obj_t*  x,
+       const obj_t*  asum
      );
 ```
 Compute the sum of the absolute values of the fundamental elements of vector `x`. The resulting sum is stored to `asum`.
@@ -2005,8 +2005,8 @@ Observed object properties: none.
 ```c
 void bli_norm[1fi]m
      (
-       obj_t*  a,
-       obj_t*  norm
+       const obj_t*  a,
+       const obj_t*  norm
      );
 ```
 Compute the one-norm (`bli_norm1m()`), Frobenius norm (`bli_normfm()`), or infinity norm (`bli_normim()`) of the elements in an _m x n_ matrix `A`. If `uplo(A)` is `BLIS_LOWER` or `BLIS_UPPER` then `A` is assumed to be lower or upper triangular, respectively, with the main diagonal located at offset `diagoff(A)`. The resulting norm is stored to `norm`.
@@ -2023,8 +2023,8 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`.
 ```c
 void bli_norm[1fi]v
      (
-       obj_t*  x,
-       obj_t*  norm
+       const obj_t*  x,
+       const obj_t*  norm
      );
 ```
 Compute the one-norm (`bli_norm1v()`), Frobenius norm (`bli_normfv()`), or infinity norm (`bli_normiv()`) of the elements in a vector `x` of length _n_. The resulting norm is stored to `norm`.
@@ -2039,7 +2039,7 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`.
 ```c
 void bli_mkherm
      (
-       obj_t*  a
+       const obj_t*  a
      );
 ```
 Make an _m x m_ matrix `A` explicitly Hermitian by copying the conjugate of the triangle specified by `uplo(A)` to the opposite triangle. Imaginary components of diagonal elements are explicitly set to zero. It is assumed that the diagonal offset of `A` is zero.
@@ -2052,7 +2052,7 @@ Observed object properties: `uplo(A)`.
 ```c
 void bli_mksymm
      (
-       obj_t*  a
+       const obj_t*  a
      );
 ```
 Make an _m x m_ matrix `A` explicitly symmetric by copying the triangle specified by `uplo(A)` to the opposite triangle. It is assumed that the diagonal offset of `A` is zero.
@@ -2065,7 +2065,7 @@ Observed object properties: `uplo(A)`.
 ```c
 void bli_mktrim
      (
-       obj_t*  a
+       const obj_t*  a
      );
 ```
 Make an _m x m_ matrix `A` explicitly triangular by preserving the triangle specified by `uplo(A)` and zeroing the elements in the opposite triangle. It is assumed that the diagonal offset of `A` is zero.
@@ -2078,11 +2078,11 @@ Observed object properties: `uplo(A)`.
 ```c
 void bli_fprintv
      (
-       FILE*   file,
-       char*   s1,
-       obj_t*  x,
-       char*   format,
-       char*   s2
+             FILE*   file,
+       const char*   s1,
+       const obj_t*  x,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print a vector `x` of length _m_ to file stream `file`, where `file` is a file pointer returned by the standard C library function `fopen()`. The caller may also pass in a global file pointer such as `stdout` or `stderr`. The strings `s1` and `s2` are printed immediately before and after the output (respectively), and the format specifier `format` is used to format the individual elements. For valid format specifiers, please see documentation for the standard C library function `printf()`.
@@ -2095,11 +2095,11 @@ Print a vector `x` of length _m_ to file stream `file`, where `file` is a file p
 ```c
 void bli_fprintm
      (
-       FILE*   file,
-       char*   s1,
-       obj_t*  a,
-       char*   format,
-       char*   s2
+             FILE*   file,
+       const char*   s1,
+       const obj_t*  a,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print an _m x n_ matrix `A` to file stream `file`, where `file` is a file pointer returned by the standard C library function `fopen()`. The caller may also pass in a global file pointer such as `stdout` or `stderr`. The strings `s1` and `s2` are printed immediately before and after the output (respectively), and the format specifier `format` is used to format the individual elements. For valid format specifiers, please see documentation for the standard C library function `printf()`.
@@ -2112,10 +2112,10 @@ Print an _m x n_ matrix `A` to file stream `file`, where `file` is a file pointe
 ```c
 void bli_printv
      (
-       char*   s1,
-       obj_t*  x,
-       char*   format,
-       char*   s2
+       const char*   s1,
+       const obj_t*  x,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print a vector `x` of length _m_ to standard output. This function call is equivalent to calling `bli_fprintv()` with `stdout` as the file pointer.
@@ -2126,10 +2126,10 @@ Print a vector `x` of length _m_ to standard output. This function call is equiv
 ```c
 void bli_printm
      (
-       char*   s1,
-       obj_t*  a,
-       char*   format,
-       char*   s2
+       const char*   s1,
+       const obj_t*  a,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print an _m x n_ matrix `a` to standard output. This function call is equivalent to calling `bli_fprintm()` with `stdout` as the file pointer.
@@ -2140,7 +2140,7 @@ Print an _m x n_ matrix `a` to standard output. This function call is equivalent
 ```c
 void bli_randv
      (
-       obj_t*  x
+       const obj_t*  x
      );
 ```
 Set the elements of a vector `x` of length _n_ to random values on the interval `[-1,1)`.
@@ -2153,7 +2153,7 @@ Set the elements of a vector `x` of length _n_ to random values on the interval 
 ```c
 void bli_randm
      (
-       obj_t*  a
+       const obj_t*  a
      );
 ```
 Set the elements of an _m x n_ matrix `A` to random values on the interval `[-1,1)`. Off-diagonal elements (in the triangle specified by `uplo(A)`) are scaled by `1.0/max(m,n)`.
@@ -2169,9 +2169,9 @@ Observed object properties: `diagoff(A)`, `uplo(A)`.
 ```c
 void bli_sumsqv
      (
-       obj_t*  x,
-       obj_t*  scale,
-       obj_t*  sumsq
+       const obj_t*  x,
+       const obj_t*  scale,
+       const obj_t*  sumsq
      );
 ```
 Compute the sum of the squares of the elements in a vector `x` of length _n_. The result is computed in scaled form, and in such a way that it may be used repeatedly to accumulate the sum of the squares of several vectors.
@@ -2191,9 +2191,9 @@ where, on entry, `scale` and `sumsq` contain `scale_old` and `sumsq_old`, respec
 ```c
 void bli_getsc
      (
-       obj_t*   chi,
-       double*  zeta_r,
-       double*  zeta_i
+       const obj_t*   chi,
+             double*  zeta_r,
+             double*  zeta_i
      );
 ```
 Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and `zeta_i`. If `chi` is stored as a real type, then `zeta_i` is set to zero. (If `chi` is stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -2204,10 +2204,10 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 ```c
 err_t bli_getijv
      (
-       dim_t    i,
-       obj_t*   x,
-       double*  ar,
-       double*  ai
+             dim_t    i,
+       const obj_t*   x,
+             double*  ar,
+             double*  ai
      );
 ```
 Copy the real and imaginary values at the `i`th element of vector object `x` to `ar` and `ai`. If elements of `x` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -2219,11 +2219,11 @@ If either the element offset `i` is beyond the vector dimension of `x` or less t
 ```c
 err_t bli_getijm
      (
-       dim_t    i,
-       dim_t    j,
-       obj_t*   b,
-       double*  ar,
-       double*  ai
+             dim_t    i,
+             dim_t    j,
+       const obj_t*   b,
+             double*  ar,
+             double*  ai
      );
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. If elements of `b` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -2235,9 +2235,9 @@ If either the row offset `i` is beyond the _m_ dimension of `b` or less than zer
 ```c
 void bli_setsc
      (
-       double  zeta_r,
-       double  zeta_i,
-       obj_t*  chi
+             double  zeta_r,
+             double  zeta_i,
+       const obj_t*  chi
      );
 ```
 Copy real and imaginary values `zeta_r` and `zeta_i` to the scalar object `chi`. If `chi` is stored as a real type, then `zeta_i` is ignored. (If `chi` is stored in single precision, the contents are typecast/demoted during the copy.)
@@ -2248,10 +2248,10 @@ Copy real and imaginary values `zeta_r` and `zeta_i` to the scalar object `chi`.
 ```c
 err_t bli_setijv
      (
-       double  ar,
-       double  ai,
-       dim_t   i,
-       obj_t*  x
+             double  ar,
+             double  ai,
+             dim_t   i,
+       const obj_t*  x
      );
 ```
 Copy real and imaginary values `ar` and `ai` to the `i`th element of vector object `x`. If elements of `x` are stored as real types, then only `ar` is copied and `ai` is ignored. (If `x` contains elements stored in single precision, the corresponding elements are typecast/demoted during the copy.)
@@ -2263,11 +2263,11 @@ If the element offset `i` is beyond the vector dimension of `x` or less than zer
 ```c
 err_t bli_setijm
      (
-       double  ar,
-       double  ai,
-       dim_t   i,
-       dim_t   j,
-       obj_t*  b
+             double  ar,
+             double  ai,
+             dim_t   i,
+             dim_t   j,
+       const obj_t*  b
      );
 ```
 Copy real and imaginary values `ar` and `ai` to the (`i`,`j`) element of object `b`. If elements of `b` are stored as real types, then only `ar` is copied and `ai` is ignored. (If `b` contains elements stored in single precision, the corresponding elements are typecast/demoted during the copy.)
@@ -2279,9 +2279,9 @@ If either the row offset `i` is beyond the _m_ dimension of `b` or less than zer
 ```c
 void bli_eqsc
      (
-       obj_t*  chi,
-       obj_t*  psi,
-       bool*   is_eq
+       const obj_t*  chi,
+       const obj_t*  psi,
+             bool*   is_eq
      );
 ```
 Perform an element-wise comparison between scalars `chi` and `psi` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -2295,9 +2295,9 @@ Observed object properties: `conj?(chi)`, `conj?(psi)`.
 ```c
 void bli_eqv
      (
-       obj_t*  x,
-       obj_t*  y,
-       bool*   is_eq
+       const obj_t*  x,
+       const obj_t*  y,
+             bool*   is_eq
      );
 ```
 Perform an element-wise comparison between vectors `x` and `y` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -2311,9 +2311,9 @@ Observed object properties: `conj?(x)`, `conj?(y)`.
 ```c
 void bli_eqm
      (
-       obj_t*  a,
-       obj_t*  b,
-       bool*   is_eq
+       const obj_t*  a,
+       const obj_t*  b,
+             bool*   is_eq
      );
 ```
 Perform an element-wise comparison between matrices `A` and `B` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -2331,7 +2331,7 @@ Observed object properties: `diagoff(A)`, `diag(A)`, `uplo(A)`, `trans?(A)`, `tr
 
 BLIS allows applications to query information about how BLIS was configured. The `bli_info_` API provides several categories of query routines. Most values are returned as a `gint_t`, which is a signed integer. The size of this integer can be queried through a special routine that returns the size in a character string:
 ```c
-char* bli_info_get_int_type_size_str( void );
+const char* bli_info_get_int_type_size_str( void );
 ```
 **Note:** All of the `bli_info_` functions are **always** thread-safe, no matter how BLIS was configured.
 
@@ -2339,7 +2339,7 @@ char* bli_info_get_int_type_size_str( void );
 
 The following routine returns the address the full BLIS version string:
 ```c
-char* bli_info_get_version_str( void );
+const char* bli_info_get_version_str( void );
 ```
 
 ## Specific configuration
@@ -2352,7 +2352,7 @@ This is most useful when BLIS is configured with multiple configurations. (When 
 
 Once the configuration's ID is known, it can be used to query a string that contains the name of the configuration:
 ```c
-char* bli_arch_string( arch_t id );
+const char* bli_arch_string( arch_t id );
 ```
 
 ## General configuration
@@ -2407,11 +2407,11 @@ gint_t bli_info_get_enable_sandbox( void );
 The following routines allow the caller to obtain a string that identifies the implementation type of each microkernel that is currently active (ie: part of the current active configuration, as identified bi `bli_arch_query_id()`).
 
 ```c
-char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt );
 ```
 
 Possible implementation (ie: the `ind_t method` argument) types are:
@@ -2429,17 +2429,17 @@ Possible microkernel types (ie: the return values for `bli_info_get_*_ukr_impl_s
 
 The following routines allow the caller to obtain a string that identifies the implementation (`ind_t`) that is currently active (ie: implemented and enabled) for each level-3 operation. Possible implementation types are listed in the section above covering [microkernel implemenation query](BLISTypedAPI.md#microkernel-implementation-type-query).
 ```c
-char* bli_info_get_gemm_impl_string( num_t dt );
-char* bli_info_get_gemmt_impl_string( num_t dt );
-char* bli_info_get_hemm_impl_string( num_t dt );
-char* bli_info_get_herk_impl_string( num_t dt );
-char* bli_info_get_her2k_impl_string( num_t dt );
-char* bli_info_get_symm_impl_string( num_t dt );
-char* bli_info_get_syrk_impl_string( num_t dt );
-char* bli_info_get_syr2k_impl_string( num_t dt );
-char* bli_info_get_trmm_impl_string( num_t dt );
-char* bli_info_get_trmm3_impl_string( num_t dt );
-char* bli_info_get_trsm_impl_string( num_t dt );
+const char* bli_info_get_gemm_impl_string( num_t dt );
+const char* bli_info_get_gemmt_impl_string( num_t dt );
+const char* bli_info_get_hemm_impl_string( num_t dt );
+const char* bli_info_get_herk_impl_string( num_t dt );
+const char* bli_info_get_her2k_impl_string( num_t dt );
+const char* bli_info_get_symm_impl_string( num_t dt );
+const char* bli_info_get_syrk_impl_string( num_t dt );
+const char* bli_info_get_syr2k_impl_string( num_t dt );
+const char* bli_info_get_trmm_impl_string( num_t dt );
+const char* bli_info_get_trmm3_impl_string( num_t dt );
+const char* bli_info_get_trsm_impl_string( num_t dt );
 ```
 
 

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -2205,7 +2205,7 @@ err_t bli_getijv
         obj_t*   x,
         double*  ar,
         double*  ai
-      )
+      );
 ```
 Copy the real and imaginary values at the `i`th element of vector object `x` to `ar` and `ai`. If elements of `x` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 If either the element offset `i` is beyond the vector dimension of `x` or less than zero, the function returns `BLIS_FAILURE` without taking any action. Similarly, if `x` is a global scalar constant such as `BLIS_ONE`, the function returns `BLIS_FAILURE`.
@@ -2221,7 +2221,7 @@ err_t bli_getijm
         obj_t*   b,
         double*  ar,
         double*  ai
-      )
+      );
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. If elements of `b` are stored as real types, then only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
 If either the row offset `i` is beyond the _m_ dimension of `b` or less than zero, or column offset `j` is beyond the _n_ dimension of `b` or less than zero, the function returns `BLIS_FAILURE` without taking any action. Similarly, if `b` is a global scalar constant such as `BLIS_ONE`, the function returns `BLIS_FAILURE`.
@@ -2381,11 +2381,11 @@ gint_t bli_info_get_blas_int_type_size( void );
 The following routines allow the caller to obtain a string that identifies the implementation type of each microkernel that is currently active (ie: part of the current active configuration, as identified bi `bli_arch_query_id()`).
 
 ```c
-char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt )
+char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt );
 ```
 
 Possible implementation (ie: the `ind_t method` argument) types are:
@@ -2405,10 +2405,7 @@ Possible microkernel types (ie: the return values for `bli_info_get_*_ukr_impl_s
 
 #### clock
 ```c
-double bli_clock
-     (
-       void
-     );
+double bli_clock( void );
 ```
 Return the amount of time that has elapsed since some fixed time in the past. The return values of `bli_clock()` typically feature nanosecond precision, though this is not guaranteed.
 

--- a/docs/BLISObjectAPI.md
+++ b/docs/BLISObjectAPI.md
@@ -182,7 +182,7 @@ void bli_gemm
        obj_t*  a,
        obj_t*  b,
        obj_t*  beta,
-       obj_t*  c,
+       obj_t*  c
      );
 ```
 while the expert interface is:
@@ -707,7 +707,7 @@ Level-1v operations perform various level-1 BLAS-like operations on vectors (hen
 void bli_addv
      (
        obj_t*  x,
-       obj_t*  y,
+       obj_t*  y
      );
 ```
 Perform

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -2067,11 +2067,11 @@ gint_t bli_info_get_blas_int_type_size( void );
 The following routines allow the caller to obtain a string that identifies the implementation type of each microkernel that is currently active (ie: part of the current active configuration, as identified bi `bli_arch_query_id()`).
 
 ```c
-char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt )
-char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt )
+char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt );
+char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt );
 ```
 
 Possible implementation (ie: the `ind_t method` argument) types are:
@@ -2108,10 +2108,7 @@ char* bli_info_get_trsm_impl_string( num_t dt );
 
 #### clock
 ```c
-double bli_clock
-     (
-       void
-     );
+double bli_clock( void );
 ```
 Return the amount of time that has elapsed since some fixed time in the past. The return values of `bli_clock()` typically feature nanosecond precision, though this is not guaranteed.
 

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -2054,10 +2054,33 @@ gint_t bli_info_get_stack_buf_max_size( void );
 gint_t bli_info_get_stack_buf_align_size( void );
 gint_t bli_info_get_heap_addr_align_size( void );
 gint_t bli_info_get_heap_stride_align_size( void );
-gint_t bli_info_get_pool_addr_align_size( void );
+gint_t bli_info_get_pool_addr_align_size_a( void );
+gint_t bli_info_get_pool_addr_align_size_b( void );
+gint_t bli_info_get_pool_addr_align_size_c( void );
+gint_t bli_info_get_pool_addr_align_size_gen( void );
+gint_t bli_info_get_pool_addr_offset_size_a( void );
+gint_t bli_info_get_pool_addr_offset_size_b( void );
+gint_t bli_info_get_pool_addr_offset_size_c( void );
+gint_t bli_info_get_pool_addr_offset_size_gen( void );
 gint_t bli_info_get_enable_stay_auto_init( void );
 gint_t bli_info_get_enable_blas( void );
+gint_t bli_info_get_enable_cblas( void );
 gint_t bli_info_get_blas_int_type_size( void );
+gint_t bli_info_get_enable_pba_pools( void );
+gint_t bli_info_get_enable_sba_pools( void );
+gint_t bli_info_get_enable_threading( void );
+gint_t bli_info_get_enable_openmp( void );
+gint_t bli_info_get_enable_pthreads( void );
+gint_t bli_info_get_enable_hpx( void );
+gint_t bli_info_get_enable_openmp_as_default( void );
+gint_t bli_info_get_enable_pthreads_as_default( void );
+gint_t bli_info_get_enable_hpx_as_default( void );
+gint_t bli_info_get_thread_jrir_slab( void );
+gint_t bli_info_get_thread_jrir_rr( void );
+gint_t bli_info_get_thread_jrir_tlb( void );
+gint_t bli_info_get_enable_tls( void );
+gint_t bli_info_get_enable_memkind( void );
+gint_t bli_info_get_enable_sandbox( void );
 ```
 
 ## Kernel information

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -1668,11 +1668,11 @@ Print an _m x n_ matrix `A` to file stream `file`, where `file` is a file pointe
 ```c
 void bli_?printv
      (
-       const char*   s1,
-             dim_t   m,
-       const ctype*  x, inc_t incx,
-       const char*   format,
-       const char*   s2
+       const char*  s1,
+             dim_t  m,
+       const void*  x, inc_t incx,
+       const char*  format,
+       const char*  s2
      );
 ```
 Print a vector `x` of length _m_ to standard output. This function call is equivalent to calling `bli_?fprintv()` with `stdout` as the file pointer.
@@ -1683,12 +1683,12 @@ Print a vector `x` of length _m_ to standard output. This function call is equiv
 ```c
 void bli_?printm
      (
-       const char*   s1,
-             dim_t   m,
-             dim_t   n,
-       const ctype*  a, inc_t rs_a, inc_t cs_a,
-       const char*   format,
-       const char*   s2
+       const char*  s1,
+             dim_t  m,
+             dim_t  n,
+       const void*  a, inc_t rs_a, inc_t cs_a,
+       const char*  format,
+       const char*  s2
      );
 ```
 Print an _m x n_ matrix `a` to standard output. This function call is equivalent to calling `bli_?fprintm()` with `stdout` as the file pointer.
@@ -1766,7 +1766,7 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 err_t bli_?getijv
      (
              dim_t    i,
-       const ctype*   x, inc_t incx,
+       const void*    x, inc_t incx,
              double*  ar,
              double*  ai
      );
@@ -1782,7 +1782,7 @@ err_t bli_?getijm
      (
              dim_t    i,
              dim_t    j,
-       const ctype*   b, inc_t rs_b, inc_t cs_b,
+       const void*    b, inc_t rs_b, inc_t cs_b,
              double*  ar,
              double*  ai
      );
@@ -1812,7 +1812,7 @@ err_t bli_?setijv
        double  ar,
        double  ai,
        dim_t   i,
-       ctype*  x, inc_t incx
+       void*   x, inc_t incx
      );
 ```
 Copy real and imaginary values `ar` and `ai` to the `i`th element of vector object `x`. For real domain invocations, only `ar` is copied and `ai` is ignored. (If `x` contains elements stored in single precision, the corresponding elements are typecast/demoted during the copy.)
@@ -1828,7 +1828,7 @@ err_t bli_?setijm
        double  ai,
        dim_t   i,
        dim_t   j,
-       ctype*  b, inc_t rs_b, inc_t cs_b
+       void*   b, inc_t rs_b, inc_t cs_b
      );
 ```
 Copy real and imaginary values `ar` and `ai` to the (`i`,`j`) element of object `b`. For real domain invocations, only `ar` is copied and `ai` is ignored. (If `b` contains elements stored in single precision, the corresponding elements are typecast/demoted during the copy.)

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -77,41 +77,41 @@ The following tables list various types used throughout the BLIS typed API.
 
 ### Floating-point types
 
-| BLIS type  | BLIS char | Type definition                        | Used to represent...                 |
-|:-----------|:----------|:---------------------------------------|:-------------------------------------|
-| `float`    | `s`       | _N/A_                                  | single-precision real numbers    |
-| `double`   | `d`       | _N/A_                                  | double-precision real numbers    |
-| `scomplex` | `c`       | `struct { float real; float imag; }`   | single-precision complex numbers |
-| `dcomplex` | `z`       | `struct { double real; double imag; }` | double-precision complex numbers |
+| BLIS fp type | BLIS char | Type definition                        | Used to represent...              |
+|:-------------|:----------|:---------------------------------------|:----------------------------------|
+| `float`      | `s`       | _N/A_                                  | single-precision real numbers.    |
+| `double`     | `d`       | _N/A_                                  | double-precision real numbers.    |
+| `scomplex`   | `c`       | `struct { float real; float imag; }`   | single-precision complex numbers. |
+| `dcomplex`   | `z`       | `struct { double real; double imag; }` | double-precision complex numbers. |
 
 ### Enumerated parameter types
 
-| `trans_t`                | Semantic meaning: Corresponding matrix operand... |
-|:-------------------------|:--------------------------------------------------|
-| `BLIS_NO_TRANSPOSE`      | will be used as given.                         |
-| `BLIS_TRANSPOSE`         | will be implicitly transposed.                 |
-| `BLIS_CONJ_NO_TRANSPOSE` | will be implicitly conjugated.                 |
+| `trans_t`                | Semantic meaning: Matrix operand...             |
+|:-------------------------|:------------------------------------------------|
+| `BLIS_NO_TRANSPOSE`      | will be used as given.                          |
+| `BLIS_TRANSPOSE`         | will be implicitly transposed.                  |
+| `BLIS_CONJ_NO_TRANSPOSE` | will be implicitly conjugated.                  |
 | `BLIS_CONJ_TRANSPOSE`    | will be implicitly transposed _and_ conjugated. |
 
-| `conj_t`             | Semantic meaning: Corresponding matrix/vector operand... |
-|:---------------------|:---------------------------------------------------------|
-| `BLIS_NO_CONJUGATE`  | will be used as given.                                |
-| `BLIS_CONJUGATE`     | will be implicitly conjugated.                        |
+| `conj_t`             | Semantic meaning: Matrix/vector operand... |
+|:---------------------|:-------------------------------------------|
+| `BLIS_NO_CONJUGATE`  | will be used as given.                     |
+| `BLIS_CONJUGATE`     | will be implicitly conjugated.             |
 
-| `side_t`     | Semantic meaning: Corresponding matrix operand...  |
-|:-------------|:---------------------------------------------------|
-| `BLIS_LEFT`  | appears on the left.                            |
-| `BLIS_RIGHT` | appears on the right.                           |
+| `side_t`     | Semantic meaning: Matrix operand... |
+|:-------------|:------------------------------------|
+| `BLIS_LEFT`  | appears on the left.                |
+| `BLIS_RIGHT` | appears on the right.               |
 
-| `uplo_t`     | Semantic meaning: Corresponding matrix operand... |
-|:-------------|:--------------------------------------------------|
+| `uplo_t`     | Semantic meaning: Matrix operand...                               |
+|:-------------|:------------------------------------------------------------------|
 | `BLIS_LOWER` | is stored in (and will be accessed only from) the lower triangle. |
 | `BLIS_UPPER` | is stored in (and will be accessed only from) the upper triangle. |
 | `BLIS_DENSE` | is stored as a full matrix (ie: in both triangles).               |
 
-| `diag_t`            | Semantic meaning: Corresponding matrix operand... |
-|:--------------------|:--------------------------------------------------|
-| `BLIS_NONUNIT_DIAG` | has a non-unit diagonal that should be explicitly read from. |
+| `diag_t`            | Semantic meaning: Matrix operand...                                        |
+|:--------------------|:---------------------------------------------------------------------------|
+| `BLIS_NONUNIT_DIAG` | has a non-unit diagonal that should be explicitly read from.               |
 | `BLIS_UNIT_DIAG`    | has a unit diagonal that should be implicitly assumed (and not read from). |
 
 ### Basic vs expert interfaces
@@ -195,7 +195,6 @@ void bli_finalize( void );
 # Computational function reference
 
 Notes for interpreting the following prototypes:
-
   * Any occurrence of `?` should be replaced with `s`, `d`, `c`, or `z` to form an actual function name.
   * Any occurrence of `ctype` should be replaced with the actual C type corresponding to the datatype instance in question, while `rtype` should be replaced by the real projection of `ctype`. For example:
     * If we consider the prototype for `bli_zaxpyv()` below, `ctype` refers to `dcomplex`.

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -1668,11 +1668,11 @@ Print an _m x n_ matrix `A` to file stream `file`, where `file` is a file pointe
 ```c
 void bli_?printv
      (
-       const char*  s1,
-             dim_t  m,
-       const void*  x, inc_t incx,
-       const char*  format,
-       const char*  s2
+       const char*   s1,
+             dim_t   m,
+       const ctype*  x, inc_t incx,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print a vector `x` of length _m_ to standard output. This function call is equivalent to calling `bli_?fprintv()` with `stdout` as the file pointer.
@@ -1683,12 +1683,12 @@ Print a vector `x` of length _m_ to standard output. This function call is equiv
 ```c
 void bli_?printm
      (
-       const char*  s1,
-             dim_t  m,
-             dim_t  n,
-       const void*  a, inc_t rs_a, inc_t cs_a,
-       const char*  format,
-       const char*  s2
+       const char*   s1,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  a, inc_t rs_a, inc_t cs_a,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print an _m x n_ matrix `a` to standard output. This function call is equivalent to calling `bli_?fprintm()` with `stdout` as the file pointer.

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -1903,6 +1903,8 @@ If `transa` indicates a conjugation and/or transposition, then `A` will be conju
 ```c
 void bli_?gemm_*
      (
+       dim_t                m,
+       dim_t                n,
        dim_t                k,
        ctype*      restrict alpha,
        ctype*      restrict a1,
@@ -1959,6 +1961,8 @@ Please see the [Kernel Guide](KernelsHowTo.md) for more information on the `trsm
 ```c
 void bli_?gemmtrsm_l_*
      (
+       dim_t                m,
+       dim_t                n,
        dim_t                k,
        ctype*      restrict alpha,
        ctype*      restrict a10,
@@ -1972,6 +1976,8 @@ void bli_?gemmtrsm_l_*
 
 void bli_?gemmtrsm_u_*
      (
+       dim_t                m,
+       dim_t                n,
        dim_t                k,
        ctype*      restrict alpha,
        ctype*      restrict a12,

--- a/docs/BLISTypedAPI.md
+++ b/docs/BLISTypedAPI.md
@@ -120,34 +120,34 @@ The functions listed in this document belong to the "basic" interface subset of 
 ```c
 void bli_?gemm
      (
-       trans_t  transa,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    n,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             trans_t  transa,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    n,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 while the expert interface is:
 ```c
 void bli_?gemm_ex
      (
-       trans_t  transa,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    n,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc,
-       cntx_t*  cntx,
-       rntm_t*  rntm
+             trans_t  transa,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    n,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc,
+       const cntx_t*  cntx,
+       const rntm_t*  rntm
      );
 ```
 The expert interface contains two additional parameters: a `cntx_t*` and `rntm_t*`. Note that calling a function from the expert interface with the `cntx_t*` and `rntm_t*` arguments each set to `NULL` is equivalent to calling the corresponding basic interface. Specifically, a `NULL` value passed in for the `cntx_t*` results in a valid context being queried from BLIS, and a `NULL` value passed in for the `rntm_t*` results in the current global settings for multithreading to be used.
@@ -156,7 +156,7 @@ The expert interface contains two additional parameters: a `cntx_t*` and `rntm_t
 
 In general, it is permissible to pass in `NULL` for a `cntx_t*` parameter when calling an expert interface such as `bli_dgemm_ex()`. However, there are cases where `NULL` values are not accepted and may result in a segmentation fault. Specifically, the `cntx_t*` argument appears in the interfaces to the `gemm`, `trsm`, and `gemmtrsm` [level-3 microkernels](KernelsHowTo.md#level-3) along with all [level-1v](KernelsHowTo.md#level-1v) and [level-1f](KernelsHowTo.md#level-1f) kernels. There, as a general rule, a valid pointer must be passed in. Whenever a valid context is needed, the developer may query a default context from the global kernel structure (if a context is not already available in the current scope):
 ```c
-cntx_t* bli_gks_query_cntx( void );
+const cntx_t* bli_gks_query_cntx( void );
 ```
 When BLIS is configured to target a configuration family (e.g. `intel64`, `x86_64`), `bli_gks_query_cntx()` will use `cpuid` or an equivalent heuristic to select and and return the appropriate context. When BLIS is configured to target a singleton sub-configuration (e.g. `haswell`, `skx`), `bli_gks_query_cntx()` will unconditionally return a pointer to the context appropriate for the targeted configuration.
 
@@ -226,10 +226,10 @@ Level-1v operations perform various level-1 BLAS-like operations on vectors (hen
 ```c
 void bli_?addv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -244,9 +244,9 @@ where `x` and `y` are vectors of length _n_.
 ```c
 void bli_?amaxv
      (
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       dim_t*  index
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             dim_t*  index
      );
 ```
 Given a vector of length _n_, return the zero-based index `index` of the element of vector `x` that contains the largest absolute value (or, in the complex domain, the largest complex modulus).
@@ -261,11 +261,11 @@ If `NaN` is encountered, it is treated as if it were a valid value that was smal
 ```c
 void bli_?axpyv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -280,12 +280,12 @@ where `x` and `y` are vectors of length _n_, and `alpha` is a scalar.
 ```c
 void bli_?axpbyv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+       const ctype*  beta,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -300,10 +300,10 @@ where `x` and `y` are vectors of length _n_, and `alpha` and `beta` are scalars.
 ```c
 void bli_?copyv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -318,12 +318,12 @@ where `x` and `y` are vectors of length _n_.
 ```c
 void bli_?dotv
      (
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  rho
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             ctype*  rho
      );
 ```
 Perform
@@ -338,14 +338,14 @@ where `x` and `y` are vectors of length _n_, and `rho` is a scalar.
 ```c
 void bli_?dotxv
      (
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  beta,
-       ctype*  rho
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   n,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+       const ctype*  beta,
+             ctype*  rho
      );
 ```
 Perform
@@ -372,10 +372,10 @@ Invert all elements of an _n_-length vector `x`.
 ```c
 void bli_?invscalv
      (
-       conj_t  conjalpha,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx
+             conj_t  conjalpha,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  x, inc_t incx
      );
 ```
 Perform
@@ -390,10 +390,10 @@ where `x` is a vector of length _n_, and `alpha` is a scalar.
 ```c
 void bli_?scalv
      (
-       conj_t  conjalpha,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx
+             conj_t  conjalpha,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  x, inc_t incx
      );
 ```
 Perform
@@ -408,11 +408,11 @@ where `x` is a vector of length _n_, and `alpha` is a scalar.
 ```c
 void bli_?scal2v
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -427,10 +427,10 @@ where `x` and `y` are vectors of length _n_, and `alpha` is a scalar.
 ```c
 void bli_?setv
      (
-       conj_t  conjalpha,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx
+             conj_t  conjalpha,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  x, inc_t incx
      );
 ```
 Perform
@@ -445,10 +445,10 @@ That is, set all elements of an _n_-length vector `x` to scalar `conjalpha(alpha
 ```c
 void bli_?subv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -476,11 +476,11 @@ Swap corresponding elements of two _n_-length vectors `x` and `y`.
 ```c
 void bli_?xpbyv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+       const ctype*  beta,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -507,13 +507,13 @@ Most of these operations are similar to level-1m counterparts, except they only 
 ```c
 void bli_?addd
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -523,14 +523,14 @@ void bli_?addd
 ```c
 void bli_?axpyd
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -540,13 +540,13 @@ void bli_?axpyd
 ```c
 void bli_?copyd
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -569,12 +569,12 @@ void bli_?invertd
 ```c
 void bli_?invscald
      (
-       conj_t  conjalpha,
-       doff_t  diagoffa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjalpha,
+             doff_t  diagoffa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 
@@ -584,12 +584,12 @@ void bli_?invscald
 ```c
 void bli_?scald
      (
-       conj_t  conjalpha,
-       doff_t  diagoffa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjalpha,
+             doff_t  diagoffa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 
@@ -599,14 +599,14 @@ void bli_?scald
 ```c
 void bli_?scal2d
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -616,12 +616,12 @@ void bli_?scal2d
 ```c
 void bli_?setd
      (
-       conj_t  conjalpha,
-       doff_t  diagoffa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjalpha,
+             doff_t  diagoffa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 
@@ -631,11 +631,11 @@ void bli_?setd
 ```c
 void bli_?setid
      (
-       doff_t    diagoffa,
-       dim_t     m,
-       dim_t     n,
-       ctype_r*  alpha,
-       ctype*    a, inc_t rsa, inc_t csa
+             doff_t    diagoffa,
+             dim_t     m,
+             dim_t     n,
+       const ctype_r*  alpha,
+             ctype*    a, inc_t rsa, inc_t csa
      );
 ```
 Set the imaginary components of every element along the diagonal of `a`, as
@@ -649,11 +649,11 @@ of `a`.
 ```c
 void bli_?shiftd
      (
-       doff_t  diagoffa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             doff_t  diagoffa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Add a constant value `alpha` to every element along the diagonal of `a`, as
@@ -665,13 +665,13 @@ specified by `diagoffa`.
 ```c
 void bli_?subd
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -681,14 +681,14 @@ void bli_?subd
 ```c
 void bli_?xpbyd
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   beta,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   beta,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 
@@ -706,14 +706,14 @@ Level-1m operations perform various level-1 BLAS-like operations on matrices (he
 ```c
 void bli_?addm
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       uplo_t   uploa,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             uplo_t   uploa,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -728,15 +728,15 @@ where `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or up
 ```c
 void bli_?axpym
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       uplo_t   uploa,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             uplo_t   uploa,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -751,14 +751,14 @@ where `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or up
 ```c
 void bli_?copym
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       uplo_t   uploa,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             uplo_t   uploa,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -773,13 +773,13 @@ where `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or up
 ```c
 void bli_?invscalm
      (
-       conj_t  conjalpha,
-       doff_t  diagoffa,
-       uplo_t  uploa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjalpha,
+             doff_t  diagoffa,
+             uplo_t  uploa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -794,13 +794,13 @@ where `A` is an _m x n_ matrix stored as a dense matrix, or lower- or upper-tria
 ```c
 void bli_?scalm
      (
-       conj_t  conjalpha,
-       doff_t  diagoffa,
-       uplo_t  uploa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjalpha,
+             doff_t  diagoffa,
+             uplo_t  uploa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -815,15 +815,15 @@ where `A` is an _m x n_ matrix stored as a dense matrix, or lower- or upper-tria
 ```c
 void bli_?scal2m
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       uplo_t   uploa,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             uplo_t   uploa,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -838,14 +838,14 @@ where `B` is an _m x n_ matrix, `A` is stored as a dense matrix, or lower- or up
 ```c
 void bli_?setm
      (
-       conj_t  conjalpha,
-       doff_t  diagoffa,
-       diag_t  diaga,
-       uplo_t  uploa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjalpha,
+             doff_t  diagoffa,
+             diag_t  diaga,
+             uplo_t  uploa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Set all elements of an _m x n_ matrix `A` to `conjalpha(alpha)`, where `A` is stored as a dense matrix, or lower- or upper- triangular/trapezoidal matrix, as specified by `uploa`, with the diagonal offset of `A` specified by `diagoffa` and unit/non-unit nature of the diagonal specified by `diaga`. If `uploa` indicates lower or upper storage, only that part of matrix `A` will be updated.
@@ -856,14 +856,14 @@ Set all elements of an _m x n_ matrix `A` to `conjalpha(alpha)`, where `A` is st
 ```c
 void bli_?subm
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       uplo_t   uploa,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             doff_t   diagoffa,
+             diag_t   diaga,
+             uplo_t   uploa,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -892,14 +892,14 @@ Level-1f kernels are employed when optimizing level-2 operations.
 ```c
 void bli_?axpy2v
      (
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   m,
-       ctype*  alphax,
-       ctype*  alphay,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  z, inc_t incz
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   m,
+       const ctype*  alphax,
+       const ctype*  alphay,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             ctype*  z, inc_t incz
      );
 ```
 Perform
@@ -914,15 +914,15 @@ where `x`, `y`, and `z` are vectors of length _m_. The kernel, if optimized, is 
 ```c
 void bli_?dotaxpyv
      (
-       conj_t  conjxt,
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  rho,
-       ctype*  z, inc_t incz
+             conj_t  conjxt,
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   m,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             ctype*  rho,
+             ctype*  z, inc_t incz
      );
 ```
 Perform
@@ -938,14 +938,14 @@ where `x`, `y`, and `z` are vectors of length _m_ and `alpha` and `rho` are scal
 ```c
 void bli_?axpyf
      (
-       conj_t  conja,
-       conj_t  conjx,
-       dim_t   m,
-       dim_t   b,
-       ctype*  alpha,
-       ctype*  a, inc_t inca, inc_t lda,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy
+             conj_t  conja,
+             conj_t  conjx,
+             dim_t   m,
+             dim_t   b,
+       const ctype*  alpha,
+       const ctype*  a, inc_t inca, inc_t lda,
+       const ctype*  x, inc_t incx,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -960,15 +960,15 @@ where `A` is an _m x b_ matrix, and `y` and `x` are vectors. The kernel, if opti
 ```c
 void bli_?dotxf
      (
-       conj_t  conjat,
-       conj_t  conjx,
-       dim_t   m,
-       dim_t   b,
-       ctype*  alpha,
-       ctype*  a, inc_t inca, inc_t lda,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy
+             conj_t  conjat,
+             conj_t  conjx,
+             dim_t   m,
+             dim_t   b,
+       const ctype*  alpha,
+       const ctype*  a, inc_t inca, inc_t lda,
+       const ctype*  x, inc_t incx,
+       const ctype*  beta,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -983,19 +983,19 @@ where `A` is an _m x b_ matrix, and `y` and `x` are vectors. The kernel, if opti
 ```c
 void bli_?dotxaxpyf
      (
-       conj_t  conjat,
-       conj_t  conja,
-       conj_t  conjw,
-       conj_t  conjx,
-       dim_t   m,
-       dim_t   b,
-       ctype*  alpha,
-       ctype*  a, inc_t inca, inc_t lda,
-       ctype*  w, inc_t incw,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy,
-       ctype*  z, inc_t incz
+             conj_t  conjat,
+             conj_t  conja,
+             conj_t  conjw,
+             conj_t  conjx,
+             dim_t   m,
+             dim_t   b,
+       const ctype*  alpha,
+       const ctype*  a, inc_t inca, inc_t lda,
+       const ctype*  w, inc_t incw,
+       const ctype*  x, inc_t incx,
+       const ctype*  beta,
+             ctype*  y, inc_t incy,
+             ctype*  z, inc_t incz
      );
 ```
 Perform
@@ -1018,15 +1018,15 @@ Level-2 operations perform various level-2 BLAS-like operations.
 ```c
 void bli_?gemv
      (
-       trans_t  transa,
-       conj_t   conjx,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   x, inc_t incx,
-       ctype*   beta,
-       ctype*   y, inc_t incy
+             trans_t  transa,
+             conj_t   conjx,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   x, inc_t incx,
+       const ctype*   beta,
+             ctype*   y, inc_t incy
      );
 ```
 Perform
@@ -1041,14 +1041,14 @@ where `transa(A)` is an _m x n_ matrix, and `y` and `x` are vectors.
 ```c
 void bli_?ger
      (
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   m,
-       dim_t   n,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  a, inc_t rsa, inc_t csa
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -1063,15 +1063,15 @@ where `A` is an _m x n_ matrix, and `x` and `y` are vectors of length _m_ and _n
 ```c
 void bli_?hemv
      (
-       uplo_t  uploa,
-       conj_t  conja,
-       conj_t  conjx,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy
+             uplo_t  uploa,
+             conj_t  conja,
+             conj_t  conjx,
+             dim_t   m,
+       const ctype*  alpha,
+       const ctype*  a, inc_t rsa, inc_t csa,
+       const ctype*  x, inc_t incx,
+       const ctype*  beta,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -1086,12 +1086,12 @@ where `A` is an _m x m_ Hermitian matrix stored in the lower or upper triangle a
 ```c
 void bli_?her
      (
-       uplo_t  uploa,
-       conj_t  conjx,
-       dim_t   m,
-       rtype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  a, inc_t rsa, inc_t csa
+             uplo_t  uploa,
+             conj_t  conjx,
+             dim_t   m,
+       const rtype*  alpha,
+       const ctype*  x, inc_t incx,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -1108,14 +1108,14 @@ where `A` is an _m x m_ Hermitian matrix stored in the lower or upper triangle a
 ```c
 void bli_?her2
      (
-       uplo_t  uploa,
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  a, inc_t rsa, inc_t csa
+             uplo_t  uploa,
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   m,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -1130,15 +1130,15 @@ where `A` is an _m x m_ Hermitian matrix stored in the lower or upper triangle a
 ```c
 void bli_?symv
      (
-       uplo_t  uploa,
-       conj_t  conja,
-       conj_t  conjx,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  a, inc_t rsa, inc_t csa,
-       ctype*  x, inc_t incx,
-       ctype*  beta,
-       ctype*  y, inc_t incy
+             uplo_t  uploa,
+             conj_t  conja,
+             conj_t  conjx,
+             dim_t   m,
+       const ctype*  alpha,
+       const ctype*  a, inc_t rsa, inc_t csa,
+       const ctype*  x, inc_t incx,
+       const ctype*  beta,
+             ctype*  y, inc_t incy
      );
 ```
 Perform
@@ -1153,12 +1153,12 @@ where `A` is an _m x m_ symmetric matrix stored in the lower or upper triangle a
 ```c
 void bli_?syr
      (
-       uplo_t  uploa,
-       conj_t  conjx,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  a, inc_t rsa, inc_t csa
+             uplo_t  uploa,
+             conj_t  conjx,
+             dim_t   m,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -1173,14 +1173,14 @@ where `A` is an _m x m_ symmetric matrix stored in the lower or upper triangle a
 ```c
 void bli_?syr2
      (
-       uplo_t  uploa,
-       conj_t  conjx,
-       conj_t  conjy,
-       dim_t   m,
-       ctype*  alpha,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       ctype*  a, inc_t rsa, inc_t csa
+             uplo_t  uploa,
+             conj_t  conjx,
+             conj_t  conjy,
+             dim_t   m,
+       const ctype*  alpha,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             ctype*  a, inc_t rsa, inc_t csa
      );
 ```
 Perform
@@ -1195,13 +1195,13 @@ where `A` is an _m x m_ symmetric matrix stored in the lower or upper triangle a
 ```c
 void bli_?trmv
      (
-       uplo_t   uploa,
-       trans_t  transa,
-       diag_t   diaga,
-       dim_t    m,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   x, inc_t incx
+             uplo_t   uploa,
+             trans_t  transa,
+             diag_t   diaga,
+             dim_t    m,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   x, inc_t incx
      );
 ```
 Perform
@@ -1216,13 +1216,13 @@ where `A` is an _m x m_ triangular matrix stored in the lower or upper triangle 
 ```c
 void bli_?trsv
      (
-       uplo_t   uploa,
-       trans_t  transa,
-       diag_t   diaga,
-       dim_t    m,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   y, inc_t incy
+             uplo_t   uploa,
+             trans_t  transa,
+             diag_t   diaga,
+             dim_t    m,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   y, inc_t incy
      );
 ```
 Solve the linear system
@@ -1247,16 +1247,16 @@ Level-3 operations perform various level-3 BLAS-like operations.
 ```c
 void bli_?gemm
      (
-       trans_t  transa,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    n,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             trans_t  transa,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    n,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1271,16 +1271,16 @@ where C is an _m x n_ matrix, `transa(A)` is an _m x k_ matrix, and `transb(B)` 
 ```c
 void bli_?gemmt
      (
-       uplo_t   uploc,
-       trans_t  transa,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             uplo_t   uploc,
+             trans_t  transa,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1295,17 +1295,17 @@ where C is an _m x m_ matrix, `transa(A)` is an _m x k_ matrix, and `transb(B)` 
 ```c
 void bli_?hemm
      (
-       side_t   sidea,
-       uplo_t   uploa,
-       conj_t   conja,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             side_t   sidea,
+             uplo_t   uploa,
+             conj_t   conja,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1324,14 +1324,14 @@ if `sidea` is `BLIS_RIGHT`, where `C` and `B` are _m x n_ matrices and `A` is a 
 ```c
 void bli_?herk
      (
-       uplo_t   uploc,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    k,
-       rtype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       rtype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             uplo_t   uploc,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    k,
+       const rtype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const rtype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1348,16 +1348,16 @@ where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as 
 ```c
 void bli_?her2k
      (
-       uplo_t   uploc,
-       trans_t  transa,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       rtype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             uplo_t   uploc,
+             trans_t  transa,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const rtype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1374,17 +1374,17 @@ where C is an _m x m_ Hermitian matrix stored in the lower or upper triangle as 
 ```c
 void bli_?symm
      (
-       side_t   sidea,
-       uplo_t   uploa,
-       conj_t   conja,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             side_t   sidea,
+             uplo_t   uploa,
+             conj_t   conja,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1403,14 +1403,14 @@ if `sidea` is `BLIS_RIGHT`, where `C` and `B` are _m x n_ matrices and `A` is a 
 ```c
 void bli_?syrk
      (
-       uplo_t   uploc,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             uplo_t   uploc,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1425,16 +1425,16 @@ where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as 
 ```c
 void bli_?syr2k
      (
-       uplo_t   uploc,
-       trans_t  transa,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    k,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             uplo_t   uploc,
+             trans_t  transa,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    k,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1449,15 +1449,15 @@ where C is an _m x m_ symmetric matrix stored in the lower or upper triangle as 
 ```c
 void bli_?trmm
      (
-       side_t   sidea,
-       uplo_t   uploa,
-       trans_t  transa,
-       diag_t   diaga,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             side_t   sidea,
+             uplo_t   uploa,
+             trans_t  transa,
+             diag_t   diaga,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Perform
@@ -1476,18 +1476,18 @@ if `sidea` is `BLIS_RIGHT`, where `B` is an _m x n_ matrix and `A` is a triangul
 ```c
 void bli_?trmm3
      (
-       side_t   sidea,
-       uplo_t   uploa,
-       trans_t  transa,
-       diag_t   diaga,
-       trans_t  transb,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb,
-       ctype*   beta,
-       ctype*   c, inc_t rsc, inc_t csc
+             side_t   sidea,
+             uplo_t   uploa,
+             trans_t  transa,
+             diag_t   diaga,
+             trans_t  transb,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+       const ctype*   b, inc_t rsb, inc_t csb,
+       const ctype*   beta,
+             ctype*   c, inc_t rsc, inc_t csc
      );
 ```
 Perform
@@ -1506,15 +1506,15 @@ if `sidea` is `BLIS_RIGHT`, where `C` and `transb(B)` are _m x n_ matrices and `
 ```c
 void bli_?trsm
      (
-       side_t   sidea,
-       uplo_t   uploa,
-       trans_t  transa,
-       diag_t   diaga,
-       dim_t    m,
-       dim_t    n,
-       ctype*   alpha,
-       ctype*   a, inc_t rsa, inc_t csa,
-       ctype*   b, inc_t rsb, inc_t csb
+             side_t   sidea,
+             uplo_t   uploa,
+             trans_t  transa,
+             diag_t   diaga,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   alpha,
+       const ctype*   a, inc_t rsa, inc_t csa,
+             ctype*   b, inc_t rsb, inc_t csb
      );
 ```
 Solve the linear system with multiple right-hand sides
@@ -1538,9 +1538,9 @@ if `sidea` is `BLIS_RIGHT`, where `X` and `B` are an _m x n_ matrices and `A` is
 ```c
 void bli_?asumv
      (
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       rtype*  asum
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             rtype*  asum
      );
 ```
 Compute the sum of the absolute values of the fundamental elements of vector `x`. The resulting sum is stored to `asum`.
@@ -1556,13 +1556,13 @@ Compute the sum of the absolute values of the fundamental elements of vector `x`
 ```c
 void bli_?norm[1fi]m
      (
-       doff_t  diagoffa,
-       doff_t  diaga,
-       uplo_t  uploa,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rs_a, inc_t cs_a,
-       rtype*  norm
+             doff_t  diagoffa,
+             doff_t  diaga,
+             uplo_t  uploa,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  a, inc_t rs_a, inc_t cs_a,
+             rtype*  norm
      );
 ```
 Compute the one-norm (`bli_?norm1m()`), Frobenius norm (`bli_?normfm()`), or infinity norm (`bli_?normim()`) of the elements in an _m x n_ matrix `A`. If `uploa` is `BLIS_LOWER` or `BLIS_UPPER` then `A` is assumed to be lower or upper triangular, respectively, with the main diagonal located at offset `diagoffa`. The resulting norm is stored to `norm`.
@@ -1577,9 +1577,9 @@ Compute the one-norm (`bli_?norm1m()`), Frobenius norm (`bli_?normfm()`), or inf
 ```c
 void bli_?norm[1fi]v
      (
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       rtype*  norm
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             rtype*  norm
      );
 ```
 Compute the one-norm (`bli_?norm1v()`), Frobenius norm (`bli_?normfv()`), or infinity norm (`bli_?normiv()`) of the elements in a vector `x` of length _n_. The resulting norm is stored to `norm`.
@@ -1631,12 +1631,12 @@ Make an _m x m_ matrix `A` explicitly triangular by preserving the triangle spec
 ```c
 void bli_?fprintv
      (
-       FILE*   file,
-       char*   s1,
-       dim_t   m,
-       ctype*  x, inc_t incx,
-       char*   format,
-       char*   s2
+             FILE*   file,
+       const char*   s1,
+             dim_t   m,
+       const ctype*  x, inc_t incx,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print a vector `x` of length _m_ to file stream `file`, where `file` is a file pointer returned by the standard C library function `fopen()`. The caller may also pass in a global file pointer such as `stdout` or `stderr`. The strings `s1` and `s2` are printed immediately before and after the output (respectively), and the format specifier `format` is used to format the individual elements. For valid format specifiers, please see documentation for the standard C library function `printf()`.
@@ -1649,13 +1649,13 @@ Print a vector `x` of length _m_ to file stream `file`, where `file` is a file p
 ```c
 void bli_?fprintm
      (
-       FILE*   file,
-       char*   s1,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rs_a, inc_t cs_a,
-       char*   format,
-       char*   s2
+             FILE*   file,
+       const char*   s1,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  a, inc_t rs_a, inc_t cs_a,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print an _m x n_ matrix `A` to file stream `file`, where `file` is a file pointer returned by the standard C library function `fopen()`. The caller may also pass in a global file pointer such as `stdout` or `stderr`. The strings `s1` and `s2` are printed immediately before and after the output (respectively), and the format specifier `format` is used to format the individual elements. For valid format specifiers, please see documentation for the standard C library function `printf()`.
@@ -1668,11 +1668,11 @@ Print an _m x n_ matrix `A` to file stream `file`, where `file` is a file pointe
 ```c
 void bli_?printv
      (
-       char*   s1,
-       dim_t   m,
-       ctype*  x, inc_t incx,
-       char*   format,
-       char*   s2
+       const char*   s1,
+             dim_t   m,
+       const ctype*  x, inc_t incx,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print a vector `x` of length _m_ to standard output. This function call is equivalent to calling `bli_?fprintv()` with `stdout` as the file pointer.
@@ -1683,12 +1683,12 @@ Print a vector `x` of length _m_ to standard output. This function call is equiv
 ```c
 void bli_?printm
      (
-       char*   s1,
-       dim_t   m,
-       dim_t   n,
-       ctype*  a, inc_t rs_a, inc_t cs_a,
-       char*   format,
-       char*   s2
+       const char*   s1,
+             dim_t   m,
+             dim_t   n,
+       const ctype*  a, inc_t rs_a, inc_t cs_a,
+       const char*   format,
+       const char*   s2
      );
 ```
 Print an _m x n_ matrix `a` to standard output. This function call is equivalent to calling `bli_?fprintm()` with `stdout` as the file pointer.
@@ -1730,10 +1730,10 @@ Set the elements of an _m x n_ matrix `A` to random values on the interval `[-1,
 ```c
 void bli_?sumsqv
      (
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       rtype*  scale,
-       rtype*  sumsq
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+             rtype*  scale,
+             rtype*  sumsq
      );
 ```
 Compute the sum of the squares of the elements in a vector `x` of length _n_. The result is computed in scaled form, and in such a way that it may be used repeatedly to accumulate the sum of the squares of several vectors.
@@ -1752,9 +1752,9 @@ where, on entry, `scale` and `sumsq` contain `scale_old` and `sumsq_old`, respec
 ```c
 void bli_?getsc
      (
-       ctype*   chi,
-       double*  zeta_r,
-       double*  zeta_i
+       const ctype*   chi,
+             double*  zeta_r,
+             double*  zeta_i
      );
 ```
 Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and `zeta_i`. If `chi` is stored as a real type, then `zeta_i` is set to zero. (If `chi` is stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -1765,10 +1765,10 @@ Copy the real and imaginary values from the scalar object `chi` to `zeta_r` and 
 ```c
 err_t bli_?getijv
      (
-       dim_t    i,
-       ctype*   x, inc_t incx,
-       double*  ar,
-       double*  ai
+             dim_t    i,
+       const ctype*   x, inc_t incx,
+             double*  ar,
+             double*  ai
      );
 ```
 Copy the real and imaginary values at the `i`th element of vector `x` to `ar` and `ai`. For real domain invocations, only `ar` is overwritten and `ai` is left unchanged. (If `x` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -1780,11 +1780,11 @@ Note that the object-based analogue of [getijv](BLISObjectAPI.md#getijv) does bo
 ```c
 err_t bli_?getijm
      (
-       dim_t    i,
-       dim_t    j,
-       ctype*   b, inc_t rs_b, inc_t cs_b,
-       double*  ar,
-       double*  ai
+             dim_t    i,
+             dim_t    j,
+       const ctype*   b, inc_t rs_b, inc_t cs_b,
+             double*  ar,
+             double*  ai
      );
 ```
 Copy the real and imaginary values at the (`i`,`j`) element of object `b` to `ar` and `ai`. For real domain invocations, only `ar` is overwritten and `ai` is left unchanged. (If `b` contains elements stored in single precision, the corresponding elements are typecast/promoted during the copy.)
@@ -1840,10 +1840,10 @@ Note that the object-based analogue of [setijm](BLISObjectAPI.md#setijm) does bo
 ```c
 void bli_?eqsc
      (
-       conj_t  conjchi,
-       ctype*  chi,
-       ctype*  psi,
-       bool*   is_eq
+             conj_t  conjchi,
+       const ctype*  chi,
+       const ctype*  psi,
+             bool*   is_eq
      );
 ```
 Perform an element-wise comparison between scalars `chi` and `psi` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -1855,11 +1855,11 @@ If `conjchi` indicates a conjugation, `chi` will be implicitly conjugated for pu
 ```c
 void bli_?eqv
      (
-       conj_t  conjx,
-       dim_t   n,
-       ctype*  x, inc_t incx,
-       ctype*  y, inc_t incy,
-       bool*   is_eq
+             conj_t  conjx,
+             dim_t   n,
+       const ctype*  x, inc_t incx,
+       const ctype*  y, inc_t incy,
+             bool*   is_eq
      );
 ```
 Perform an element-wise comparison between length _n_ vectors `x` and `y` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -1871,15 +1871,15 @@ If `conjx` indicates a conjugation, `x` will be implicitly conjugated for purpos
 ```c
 void bli_?eqm
      (
-       doff_t   diagoffa,
-       diag_t   diaga,
-       uplo_t   uploa,
-       trans_t  transa,
-       dim_t    m,
-       dim_t    n,
-       ctype*   a, inc_t rs_a, inc_t cs_a,
-       ctype*   b, inc_t rs_b, inc_t cs_b,
-       bool*    is_eq
+             doff_t   diagoffa,
+             diag_t   diaga,
+             uplo_t   uploa,
+             trans_t  transa,
+             dim_t    m,
+             dim_t    n,
+       const ctype*   a, inc_t rs_a, inc_t cs_a,
+       const ctype*   b, inc_t rs_b, inc_t cs_b,
+             bool*    is_eq
      );
 ```
 Perform an element-wise comparison between matrices `A` and `B` and store the boolean result in the `bool` pointed to by `is_eq`.
@@ -1902,16 +1902,16 @@ If `transa` indicates a conjugation and/or transposition, then `A` will be conju
 ```c
 void bli_?gemm_*
      (
-       dim_t                m,
-       dim_t                n,
-       dim_t                k,
-       ctype*      restrict alpha,
-       ctype*      restrict a1,
-       ctype*      restrict b1,
-       ctype*      restrict beta,
-       ctype*      restrict c11, inc_t rsc, inc_t csc,
-       auxinfo_t*  restrict data,
-       cntx_t*     restrict cntx
+             dim_t       m,
+             dim_t       n,
+             dim_t       k,
+       const ctype*      alpha,
+       const ctype*      a1,
+       const ctype*      b1,
+       const ctype*      beta,
+             ctype*      c11, inc_t rsc, inc_t csc,
+       const auxinfo_t*  data,
+       const cntx_t*     cntx
      );
 ```
 Perform
@@ -1929,20 +1929,20 @@ Please see the [Kernel Guide](KernelsHowTo.md) for more information on the `gemm
 ```c
 void bli_?trsm_l_*
      (
-       ctype*      restrict a11,
-       ctype*      restrict b11,
-       ctype*      restrict c11, inc_t rsc, inc_t csc
-       auxinfo_t*  restrict data,
-       cntx_t*     restrict cntx
+       const ctype*      a11,
+             ctype*      b11,
+             ctype*      c11, inc_t rsc, inc_t csc
+       const auxinfo_t*  data,
+       const cntx_t*     cntx
      );
 
 void bli_?trsm_u_*
      (
-       ctype*      restrict a11,
-       ctype*      restrict b11,
-       ctype*      restrict c11, inc_t rsc, inc_t csc
-       auxinfo_t*  restrict data,
-       cntx_t*     restrict cntx
+       const ctype*      a11,
+             ctype*      b11,
+             ctype*      c11, inc_t rsc, inc_t csc
+       const auxinfo_t*  data,
+       const cntx_t*     cntx
      );
 ```
 Perform
@@ -1960,32 +1960,32 @@ Please see the [Kernel Guide](KernelsHowTo.md) for more information on the `trsm
 ```c
 void bli_?gemmtrsm_l_*
      (
-       dim_t                m,
-       dim_t                n,
-       dim_t                k,
-       ctype*      restrict alpha,
-       ctype*      restrict a10,
-       ctype*      restrict a11,
-       ctype*      restrict b01,
-       ctype*      restrict b11,
-       ctype*      restrict c11, inc_t rs_c, inc_t cs_c,
-       auxinfo_t*  restrict data,
-       cntx_t*     restrict cntx
+             dim_t       m,
+             dim_t       n,
+             dim_t       k,
+       const ctype*      alpha,
+       const ctype*      a10,
+       const ctype*      a11,
+       const ctype*      b01,
+             ctype*      b11,
+             ctype*      c11, inc_t rs_c, inc_t cs_c,
+       const auxinfo_t*  data,
+       const cntx_t*     cntx
      );
 
 void bli_?gemmtrsm_u_*
      (
-       dim_t                m,
-       dim_t                n,
-       dim_t                k,
-       ctype*      restrict alpha,
-       ctype*      restrict a12,
-       ctype*      restrict a11,
-       ctype*      restrict b21,
-       ctype*      restrict b11,
-       ctype*      restrict c11, inc_t rs_c, inc_t cs_c,
-       auxinfo_t*  restrict data,
-       cntx_t*     restrict cntx
+             dim_t       m,
+             dim_t       n,
+             dim_t       k,
+       const ctype*      alpha,
+       const ctype*      a12,
+       const ctype*      a11,
+       const ctype*      b21,
+             ctype*      b11,
+             ctype*      c11, inc_t rs_c, inc_t cs_c,
+       const auxinfo_t*  data,
+       const cntx_t*     cntx
      );
 ```
 Perform
@@ -2013,7 +2013,7 @@ Please see the [Kernel Guide](KernelsHowTo.md) for more information on the `gemm
 
 BLIS allows applications to query information about how BLIS was configured. The `bli_info_` API provides several categories of query routines. Most values are returned as a `gint_t`, which is a signed integer. The size of this integer can be queried through a special routine that returns the size in a character string:
 ```c
-char* bli_info_get_int_type_size_str( void );
+const char* bli_info_get_int_type_size_str( void );
 ```
 **Note:** All of the `bli_info_` functions are **always** thread-safe, no matter how BLIS was configured.
 
@@ -2021,7 +2021,7 @@ char* bli_info_get_int_type_size_str( void );
 
 The following routine returns the address the full BLIS version string:
 ```c
-char* bli_info_get_version_str( void );
+const char* bli_info_get_version_str( void );
 ```
 
 ## Specific configuration
@@ -2034,7 +2034,7 @@ This is most useful when BLIS is configured with multiple configurations. (When 
 
 Once the configuration's ID is known, it can be used to query a string that contains the name of the configuration:
 ```c
-char* bli_arch_string( arch_t id );
+const char* bli_arch_string( arch_t id );
 ```
 
 ## General configuration
@@ -2089,11 +2089,11 @@ gint_t bli_info_get_enable_sandbox( void );
 The following routines allow the caller to obtain a string that identifies the implementation type of each microkernel that is currently active (ie: part of the current active configuration, as identified bi `bli_arch_query_id()`).
 
 ```c
-char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt );
-char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_gemm_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_gemmtrsm_l_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_gemmtrsm_u_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_trsm_l_ukr_impl_string( ind_t method, num_t dt );
+const char* bli_info_get_trsm_u_ukr_impl_string( ind_t method, num_t dt );
 ```
 
 Possible implementation (ie: the `ind_t method` argument) types are:
@@ -2111,16 +2111,17 @@ Possible microkernel types (ie: the return values for `bli_info_get_*_ukr_impl_s
 
 The following routines allow the caller to obtain a string that identifies the implementation (`ind_t`) that is currently active (ie: implemented and enabled) for each level-3 operation. Possible implementation types are listed in the section above covering [microkernel implemenation query](BLISTypedAPI.md#microkernel-implementation-type-query).
 ```c
-char* bli_info_get_gemm_impl_string( num_t dt );
-char* bli_info_get_hemm_impl_string( num_t dt );
-char* bli_info_get_herk_impl_string( num_t dt );
-char* bli_info_get_her2k_impl_string( num_t dt );
-char* bli_info_get_symm_impl_string( num_t dt );
-char* bli_info_get_syrk_impl_string( num_t dt );
-char* bli_info_get_syr2k_impl_string( num_t dt );
-char* bli_info_get_trmm_impl_string( num_t dt );
-char* bli_info_get_trmm3_impl_string( num_t dt );
-char* bli_info_get_trsm_impl_string( num_t dt );
+const char* bli_info_get_gemm_impl_string( num_t dt );
+const char* bli_info_get_gemmt_impl_string( num_t dt );
+const char* bli_info_get_hemm_impl_string( num_t dt );
+const char* bli_info_get_herk_impl_string( num_t dt );
+const char* bli_info_get_her2k_impl_string( num_t dt );
+const char* bli_info_get_symm_impl_string( num_t dt );
+const char* bli_info_get_syrk_impl_string( num_t dt );
+const char* bli_info_get_syr2k_impl_string( num_t dt );
+const char* bli_info_get_trmm_impl_string( num_t dt );
+const char* bli_info_get_trmm3_impl_string( num_t dt );
+const char* bli_info_get_trsm_impl_string( num_t dt );
 ```
 
 

--- a/docs/KernelsHowTo.md
+++ b/docs/KernelsHowTo.md
@@ -659,7 +659,7 @@ void bli_?axpy2v_<suffix>
        ctype*  restrict y, inc_t incy,
        ctype*  restrict z, inc_t incz,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -683,7 +683,7 @@ void bli_?dotaxpyv_<suffix>
        ctype*  restrict rho,
        ctype*  restrict z, inc_t incz,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -707,7 +707,7 @@ void bli_?axpyf_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -731,7 +731,7 @@ void bli_?dotxf_<suffix>
        ctype*  restrict beta,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -761,7 +761,7 @@ void bli_?dotxaxpyf_<suffix>
        ctype*  restrict y, inc_t incy,
        ctype*  restrict z, inc_t incz,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -789,7 +789,7 @@ void bli_?addv_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -807,7 +807,7 @@ void bli_?amaxv_<suffix>
        ctype*  restrict x, inc_t incx,
        dim_t*  restrict index,
        cntx_t* restrict cntx
-     )
+     );
 ```
 Given a vector of length _n_, this kernel returns the zero-based index `index` of the element of vector `x` that contains the largest absolute value (or, in the complex domain, the largest complex modulus).
 
@@ -825,7 +825,7 @@ void bli_?axpyv_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -846,7 +846,7 @@ void bli_?axpbyv_<suffix>
        ctype*  restrict beta,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -865,7 +865,7 @@ void bli_?copyv_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -886,7 +886,7 @@ void bli_?dotv_<suffix>
        ctype*  restrict y, inc_t incy,
        ctype*  restrict rho,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -909,7 +909,7 @@ void bli_?dotxv_<suffix>
        ctype*  restrict beta,
        ctype*  restrict rho,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -926,7 +926,7 @@ void bli_?invertv_<suffix>
        dim_t            n,
        ctype*  restrict x, inc_t incx,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel inverts all elements of an _n_-length vector `x`.
 
@@ -941,7 +941,7 @@ void bli_?invscalv_<suffix>
        ctype*  restrict alpha,
        ctype*  restrict x, inc_t incx,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -960,7 +960,7 @@ void bli_?scalv_<suffix>
        ctype*  restrict alpha,
        ctype*  restrict x, inc_t incx,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -980,7 +980,7 @@ void bli_?scal2v_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -999,7 +999,7 @@ void bli_?setv_<suffix>
        ctype*  restrict alpha,
        ctype*  restrict x, inc_t incx,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -1018,7 +1018,7 @@ void bli_?subv_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```
@@ -1036,7 +1036,7 @@ void bli_?swapv_<suffix>
        ctype*  restrict x, inc_t incx,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel swaps corresponding elements of two _n_-length vectors `x` and `y` stored with strides `incx` and `incy`, respectively.
 
@@ -1052,7 +1052,7 @@ void bli_?xpbyv_<suffix>
        ctype*  restrict beta,
        ctype*  restrict y, inc_t incy,
        cntx_t* restrict cntx
-     )
+     );
 ```
 This kernel performs the following operation:
 ```

--- a/docs/KernelsHowTo.md
+++ b/docs/KernelsHowTo.md
@@ -315,20 +315,20 @@ Parameters:
 The diagram below shows the packed micropanel operands and how elements of each would be stored when _MR_ = _NR_ = 4. The hex digits indicate the layout and order (but NOT the numeric contents) of the elements in memory. Note that the storage of `C11` is not shown since it is determined by the row and column strides of `C11`.
 
 ```
-         c11:           a1:                        b1:                  
-         _______        ______________________     _______              
-        |       |      |0 4 8 C               |   |0 1 2 3|             
-    MR  |       |      |1 5 9 D . . .         |   |4 5 6 7|             
-        |       |  +=  |2 6 A E               |   |8 9 A B|             
-        |_______|      |3_7_B_F_______________|   |C D E F|             
-                                                  |   .   |             
-            NR                    k               |   .   | k           
-                                                  |   .   |             
-                                                  |       |             
-                                                  |       |             
-                                                  |_______|             
-                                                                        
-                                                      NR                
+         c11:           a1:                        b1:
+         _______        ______________________     _______
+        |       |      |0 4 8 C               |   |0 1 2 3|
+    MR  |       |      |1 5 9 D . . .         |   |4 5 6 7|
+        |       |  +=  |2 6 A E               |   |8 9 A B|
+        |_______|      |3_7_B_F_______________|   |C D E F|
+                                                  |   .   |
+            NR                    k               |   .   | k
+                                                  |   .   |
+                                                  |       |
+                                                  |       |
+                                                  |_______|
+
+                                                      NR
 ```
 
 #### Implementation Notes for gemm
@@ -573,8 +573,8 @@ Parameters:
 The diagram below shows the packed micropanel operands for `trsm_l` and how elements of each would be stored when _MR_ = _NR_ = 4. (The hex digits indicate the layout and order (but NOT the numeric contents) in memory. Here, matrix `A11` (referenced by `a11`) is **lower triangular**. Matrix `A11` **does contain** elements corresponding to the strictly upper triangle, however, they are not guaranteed to contain zeros and thus these elements should not be referenced.
 
 ```
-                                              NR    
-                                            _______ 
+                                              NR
+                                            _______
                                        b01:|0 1 2 3|
                                            |4 5 6 7|
                                            |8 9 A B|
@@ -587,8 +587,8 @@ The diagram below shows the packed micropanel operands for `trsm_l` and how elem
   MR  |1 5 9 D . . .      |  `.    |       |       |
       |2 6 A E            |    `.  |    MR |       |
       |3_7_B_F____________|______`.|       |_______|
-                                                    
-                k             MR                    
+
+                k             MR
 ```
 
 
@@ -597,8 +597,8 @@ The diagram below shows the packed micropanel operands for `trsm_l` and how elem
 The diagram below shows the packed micropanel operands for `trsm_u` and how elements of each would be stored when _MR_ = _NR_ = 4. (The hex digits indicate the layout and order (but NOT the numeric contents) in memory. Here, matrix `A11` (referenced by `a11`) is **upper triangular**. Matrix `A11` **does contain** elements corresponding to the strictly lower triangle, however, they are not guaranteed to contain zeros and thus these elements should not be referenced.
 
 ```
-       a11:     a12:                          NR    
-       ________ ___________________         _______ 
+       a11:     a12:                          NR
+       ________ ___________________         _______
       |`.      |0 4 8              |   b11:|0 1 2 3|
   MR  |  `.    |1 5 9 . . .        |       |4 5 6 7|
       |    `.  |2 6 A              |    MR |8 9 A B|
@@ -611,7 +611,7 @@ The diagram below shows the packed micropanel operands for `trsm_u` and how elem
      starting with a12 to avoid            |       |
      obscuring triangular structure        |       |
      of a11.                               |_______|
-                                                                            
+
 ```
 
 

--- a/docs/Multithreading.md
+++ b/docs/Multithreading.md
@@ -284,6 +284,15 @@ If you want to initialize it as part of the declaration, you may do so via the d
 rntm_t rntm = BLIS_RNTM_INITIALIZER;
 ```
 As of this writing, BLIS treats a default-initialized `rntm_t` as a request for single-threaded execution.
+If your application needs to know the ways of parallelism that were conveyed via environment variables, then there is an another way by copying the global `rntm_t` object via
+```c
+void bli_rntm_init_from_global( rntm_t* rntm );
+```
+Which may be called as:
+```c
+bli_rntm_init_from_global( &rntm );
+```
+This way is necessary when running application with multiple BLIS threads.
 
 **Note**: If you choose to **not** initialize the `rntm_t` object and then pass it into a level-3 operation, **you will almost surely observe undefined behavior!** Please don't do this!
 

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -503,7 +503,7 @@ The `runthese.m` file will contain example invocations of the function.
     * Multithreaded (64 core) execution requested via `export MKL_NUM_THREADS=64`
     * Multithreaded (128 core) execution requested via `export MKL_NUM_THREADS=128`
 * Affinity:
-  * Thread affinity for BLIS was specified manually via `GOMP_CPU_AFFINITY="0-127"`. However, multithreaded OpenBLAS appears to revert to single-threaded execution if `GOMP_CPU_AFFINITY` is set. Therefore, when measuring OpenBLAS performance, the `GOMP_CPU_AFFINITY` environment variable was unset. 
+  * Thread affinity for BLIS was specified manually via `GOMP_CPU_AFFINITY="0-127"`. However, multithreaded OpenBLAS appears to revert to single-threaded execution if `GOMP_CPU_AFFINITY` is set. Therefore, when measuring OpenBLAS performance, the `GOMP_CPU_AFFINITY` environment variable was unset.
   * All executables were run through `numactl --interleave=all`.
 * Frequency throttling (via `cpupower`):
   * Driver: acpi-cpufreq

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -972,7 +972,7 @@ July 18, 2013
 - Optional (and very much untested) C99 built-in complex type/arithmetic support.
 
 Note that `bli_config.h` has changed since 0.0.8. Added configuration macros are:
-```
+```c
   #define BLIS_ENABLE_C99_COMPLEX
   #define BLIS_ENABLE_BLAS2BLIS_INT64
   #define PASTEF770(name) // ...


### PR DESCRIPTION
Details:
- fix errors and typos,
- format according to coding style guide,
- unify a bit the formatting and content in `docs/BLIS*API.md`,
- sync the content in `docs/BLIS*API.md` with the current code base.

BTW, questions:
- There is one discrepancy in function signatures: `bli_?print[vm]` use the type `const void*` for `x` parameter, but `bli_?fprint[vm]` use the type `const ctype*`. Is this made intentionally?
- Why `bli_rntm_print` function is not exported?
- A `bli_info_get_enable_stay_auto_init` function is declared, but not defined.

Note: this is a refreshed version of my PR #838 closed that differs as follows:
- is rebased to the current master,
- commits are reordered a bit.