### PR TITLE
Alias *gemmt_ as *gemmtr_ to fix lapack 3.12.1 compatibility. (Closes: #848)

### DIFF
--- a/build/libblis-symbols.def
+++ b/build/libblis-symbols.def
@@ -1248,6 +1248,7 @@ cblas_cgemm
 cblas_cgemm3m
 cblas_cgemm_batch
 cblas_cgemmt
+cblas_cgemmtr
 cblas_cgemv
 cblas_cgerc
 cblas_cgeru
@@ -1284,6 +1285,7 @@ cblas_dgbmv
 cblas_dgemm
 cblas_dgemm_batch
 cblas_dgemmt
+cblas_dgemmtr
 cblas_dgemv
 cblas_dger
 cblas_dnrm2
@@ -1330,6 +1332,7 @@ cblas_sgbmv
 cblas_sgemm
 cblas_sgemm_batch
 cblas_sgemmt
+cblas_sgemmtr
 cblas_sgemv
 cblas_sger
 cblas_snrm2
@@ -1369,6 +1372,7 @@ cblas_zgemm
 cblas_zgemm3m
 cblas_zgemm_batch
 cblas_zgemmt
+cblas_zgemmtr
 cblas_zgemv
 cblas_zgerc
 cblas_zgeru
@@ -1405,6 +1409,7 @@ cgemm3m_
 cgemm_
 cgemm_batch_
 cgemmt_
+cgemmtr_
 cgemv_
 cgerc_
 cgeru_
@@ -1446,6 +1451,7 @@ dgbmv_
 dgemm_
 dgemm_batch_
 dgemmt_
+dgemmtr_
 dgemv_
 dger_
 dnrm2_
@@ -1507,6 +1513,7 @@ sgbmv_
 sgemm_
 sgemm_batch_
 sgemmt_
+sgemmtr_
 sgemv_
 sger_
 snrm2_
@@ -1551,6 +1558,7 @@ zgemm3m_
 zgemm_
 zgemm_batch_
 zgemmt_
+zgemmtr_
 zgemv_
 zgerc_
 zgeru_

--- a/frame/compat/cblas/src/cblas.h
+++ b/frame/compat/cblas/src/cblas.h
@@ -608,21 +608,25 @@ void BLIS_EXPORT_BLAS cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  f77_int N, f77_int K, float alpha, const float *A,
                  f77_int lda, const float *B, f77_int ldb,
                  float beta, float *C, f77_int ldc);
+void BLIS_EXPORT_BLAS cblas_sgemmtr();  // alias to cblas_sgemmt
 void BLIS_EXPORT_BLAS cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
                  f77_int N, f77_int K, double alpha, const double *A,
                  f77_int lda, const double *B, f77_int ldb,
                  double beta, double *C, f77_int ldc);
+void BLIS_EXPORT_BLAS cblas_dgemmtr();  // alias to cblas_dgemmt
 void BLIS_EXPORT_BLAS cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
                  f77_int N, f77_int K, const void *alpha, const void *A,
                  f77_int lda, const void *B, f77_int ldb,
                  const void *beta, void *C, f77_int ldc);
+void BLIS_EXPORT_BLAS cblas_cgemmtr();  // alias to cblas_cgemmt
 void BLIS_EXPORT_BLAS cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
                  f77_int N, f77_int K, const void *alpha, const void *A,
                  f77_int lda, const void *B, f77_int ldb,
                  const void *beta, void *C, f77_int ldc);
+void BLIS_EXPORT_BLAS cblas_zgemmtr();  // alias to cblas_zgemmt
 
 // -- Batch APIs --
 

--- a/frame/compat/cblas/src/extra/cblas_cgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_cgemmt.c
@@ -163,4 +163,6 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
    RowMajorStrg = 0;
    return;
 }
+
+void cblas_cgemmtr() __attribute__((alias("cblas_cgemmt")));
 #endif

--- a/frame/compat/cblas/src/extra/cblas_dgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_dgemmt.c
@@ -163,4 +163,6 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
    RowMajorStrg = 0;
    return;
 }
+
+void cblas_dgemmtr() __attribute__((alias("cblas_dgemmt")));
 #endif

--- a/frame/compat/cblas/src/extra/cblas_sgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_sgemmt.c
@@ -163,4 +163,6 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
    RowMajorStrg = 0;
    return;
 }
+
+void cblas_sgemmtr() __attribute__((alias("cblas_sgemmt")));
 #endif

--- a/frame/compat/cblas/src/extra/cblas_zgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_zgemmt.c
@@ -163,4 +163,6 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
    RowMajorStrg = 0;
    return;
 }
+
+void cblas_zgemmtr() __attribute__((alias("cblas_zgemmt")));
 #endif

--- a/frame/compat/extra/bla_gemmt.c
+++ b/frame/compat/extra/bla_gemmt.c
@@ -39,6 +39,8 @@
 //
 // Define BLAS-to-BLIS interfaces.
 //
+#define STRINGIFY( name ) #name
+#define EXPAND_AND_STRINGIFY( name ) STRINGIFY( name )
 
 #ifdef BLIS_BLAS3_CALLS_TAPI
 
@@ -118,7 +120,9 @@ void PASTEF77(ch,blasname) \
 \
 	/* Finalize BLIS. */ \
 	bli_finalize_auto(); \
-}
+}; \
+void PASTEF77 (ch, blasname ## r )() \
+	__attribute__ ((alias(EXPAND_AND_STRINGIFY(PASTEF77(ch,blasname)))));
 
 #else
 
@@ -221,7 +225,9 @@ void PASTEF77(ch,blasname) \
 \
 	/* Finalize BLIS. */ \
 	bli_finalize_auto(); \
-}
+}; \
+void PASTEF77 (ch, blasname ## r )() \
+	__attribute__ ((alias(EXPAND_AND_STRINGIFY(PASTEF77(ch,blasname)))));
 
 #endif
 

--- a/frame/compat/extra/bla_gemmt.h
+++ b/frame/compat/extra/bla_gemmt.h
@@ -56,5 +56,6 @@ BLIS_EXPORT_BLAS void PASTEF77(ch,blasname) \
 
 #ifdef BLIS_ENABLE_BLAS
 INSERT_GENTPROT_BLAS( gemmt )
+INSERT_GENTPROT_BLAS( gemmtr )
 #endif
 


### PR DESCRIPTION
The patch is sufficient to address the issue that `liblapack.so` says it cannot find symbol `sgemmtr_`. The `cblas` part is not yet done. I'll look into that and update this PR. Or if it works for you, I can do a separate PR for the `cblas` alias.