### PR TITLE
Increase the max size for stack buffers.

### DIFF
--- a/docs/ConfigurationHowTo.md
+++ b/docs/ConfigurationHowTo.md
@@ -215,9 +215,9 @@ _**SIMD register file.**_ BLIS allows you to specify the _maximum_ number of SIM
 #define BLIS_SIMD_MAX_NUM_REGISTERS  32
 #define BLIS_SIMD_MAX_SIZE           64
 ```
-These macros are used in computing the maximum amount of temporary storage (typically allocated statically, on the function stack) that will be needed to hold a single micro-tile of any datatype (and for any induced method):
+These macros are used in computing the maximum amount of temporary storage (typically allocated statically, on the function stack) that will be needed to hold a single micro-tile of any datatype (and for any induced method or mixed-precision computation):
 ```c
-#define BLIS_STACK_BUF_MAX_SIZE  ( BLIS_SIMD_MAX_NUM_REGISTERS * BLIS_SIMD_MAX_SIZE * 2 )
+#define BLIS_STACK_BUF_MAX_SIZE  ( BLIS_SIMD_MAX_NUM_REGISTERS * BLIS_SIMD_MAX_SIZE * 4 )
 ```
 These temporary buffers are used when handling edge cases (m % _MR_ != 0 || n % _NR_ != 0) within the level-3 macrokernels, and also in the virtual microkernels of various implementations of induced methods for complex matrix multiplication. It is **very important** that these values be set correctly; otherwise, you may experience undefined behavior as stack data is overwritten at run-time. A kernel developer may set `BLIS_SIMD_MAX_NUM_REGISTERS` and `BLIS_SIMD_MAX_SIZE`, which will indirectly affect `BLIS_STACK_BUF_MAX_SIZE`, or he may set `BLIS_STACK_BUF_MAX_SIZE` directly. Notice that the default values are already set to work with modern x86_64 systems.
 

--- a/frame/base/bli_check.c
+++ b/frame/base/bli_check.c
@@ -826,7 +826,9 @@ err_t bli_check_sufficient_stack_buf_size( const cntx_t* cntx )
 	{
 		dim_t mr      = bli_cntx_get_blksz_def_dt( dt, BLIS_MR, cntx );
 		dim_t nr      = bli_cntx_get_blksz_def_dt( dt, BLIS_NR, cntx );
-		siz_t dt_size = bli_dt_size( dt );
+		// Always use the size of the largest data type to account for
+		// conversions during mixed-domain/mixed-precision computation.
+		siz_t dt_size = bli_dt_size( BLIS_DCOMPLEX );
 
 		// NOTE: For induced methods, we use the size of the complex datatypes
 		// (rather than the size of the native micro-kernels' datatype) because

--- a/frame/include/bli_kernel_macro_defs.h
+++ b/frame/include/bli_kernel_macro_defs.h
@@ -183,14 +183,15 @@
 
 // The maximum size in bytes of local stack buffers within macro-kernel
 // functions. These buffers are usually used to store a temporary copy
-// of a single microtile. The reason we multiply by 2 is to handle induced
+// of a single microtile. The reason we multiply by 4 is to handle induced
 // methods, where we use real domain register blocksizes in units of
-// complex elements. Specifically, the macro-kernels will need this larger
+// complex elements, as well as mixed-precision, where data may be
+// converted to a wider type. Specifically, the macro-kernels will need this larger
 // micro-tile footprint, even though the virtual micro-kernels will only
 // ever be writing to half (real or imaginary part) at a time.
 #ifndef BLIS_STACK_BUF_MAX_SIZE
 #define BLIS_STACK_BUF_MAX_SIZE          ( BLIS_SIMD_MAX_NUM_REGISTERS * \
-                                           BLIS_SIMD_MAX_SIZE * 2 )
+                                           BLIS_SIMD_MAX_SIZE * 4 )
 #endif
 
 // Alignment size used to align local stack buffers within macro-kernel


### PR DESCRIPTION
Details:
- See #850 for details on the problem.
- This is a temporary fix which should work for sdcz data types.
- Altra architectures may still not fully work for MP/MD as the stack buffer size is hard-coded.