### PR TITLE
Fix problem with clang-14.0.0 and reference `gemm` ukr.

### DIFF
--- a/ref_kernels/3/bli_gemm_ref.c
+++ b/ref_kernels/3/bli_gemm_ref.c
@@ -194,16 +194,15 @@ void PASTEMAC(ch,ch,opname,arch,suf) \
 		return; \
 	} \
 \
-	      ctype ab[ BLIS_STACK_BUF_MAX_SIZE \
-	                / sizeof( ctype ) ] \
-	                __attribute__((aligned(BLIS_STACK_BUF_ALIGN_SIZE))); \
-	const inc_t rs_ab  = nr; \
-	const inc_t cs_ab  = 1; \
+	      char   ab_[ BLIS_STACK_BUF_MAX_SIZE ] __attribute__((aligned(BLIS_STACK_BUF_ALIGN_SIZE))) = { 0 }; \
+	      ctype* ab    = (ctype*)ab_; \
+	const inc_t  rs_ab = nr; \
+	const inc_t  cs_ab = 1; \
 \
-	const inc_t rs_a   = PASTECH(BLIS_BBM_,ch); \
-	const inc_t cs_a   = PASTECH(BLIS_PACKMR_,ch); \
-	const inc_t rs_b   = PASTECH(BLIS_PACKNR_,ch); \
-	const inc_t cs_b   = PASTECH(BLIS_BBN_,ch); \
+	const inc_t  rs_a  = PASTECH(BLIS_BBM_,ch); \
+	const inc_t  cs_a  = PASTECH(BLIS_PACKMR_,ch); \
+	const inc_t  rs_b  = PASTECH(BLIS_PACKNR_,ch); \
+	const inc_t  cs_b  = PASTECH(BLIS_BBN_,ch); \
 \
 \
 	/* Initialize the accumulator elements in ab to zero. */ \


### PR DESCRIPTION
Details:
- clang 14.0.0 apparently makes some invalid assumptions about whether or not the AB microtile is initialized in the `gemm` reference microkernel. This leads to the "scale by alpha" part doing something strange (all sorts of random and even NaN values pop up). I do not know why this only manifested for `ztrsm` on `skx` (in `zgemm_skx_ref` via `zgemmtrsm_skx_ref`). See #852.
- Aliasing the AB microtile (in the proper datatype) as a pointer to a raw character array, and then initializing the character array with `= { 0 }` convinces the compiler to do the right thing.
- The problem did not occur in 14.0.6 or 15.0.7. It may only be a narrow band of versions which are problematic.
- This commit adds the char array workaround and fixes #852.