### PR TITLE
Do not use symbol aliases on macOS.

### DIFF
--- a/frame/compat/cblas/src/cblas.h
+++ b/frame/compat/cblas/src/cblas.h
@@ -87,7 +87,7 @@ BLIS_EXPORT_BLAS f77_int cblas_izamax(f77_int N, const void   *X, f77_int incX);
  * ===========================================================================
  */
 
-/* 
+/*
  * Routines with standard 4 prefixes (s, d, c, z)
  */
 void BLIS_EXPORT_BLAS cblas_sswap(f77_int N, float *X, f77_int incX,
@@ -119,7 +119,7 @@ void BLIS_EXPORT_BLAS cblas_zaxpy(f77_int N, const void *alpha, const void *X,
                  f77_int incX, void *Y, f77_int incY);
 
 
-/* 
+/*
  * Routines with S and D prefix only
  */
 void BLIS_EXPORT_BLAS cblas_srotg(float *a, float *b, float *c, float *s);
@@ -137,7 +137,7 @@ void BLIS_EXPORT_BLAS cblas_drotm(f77_int N, double *X, f77_int incX,
                 double *Y, f77_int incY, const double *P);
 
 
-/* 
+/*
  * Routines with S D C Z CS and ZD prefixes
  */
 void BLIS_EXPORT_BLAS cblas_sscal(f77_int N, float alpha, float *X, f77_int incX);
@@ -153,7 +153,7 @@ void BLIS_EXPORT_BLAS cblas_zdscal(f77_int N, double alpha, void *X, f77_int inc
  * ===========================================================================
  */
 
-/* 
+/*
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void BLIS_EXPORT_BLAS cblas_sgemv(enum CBLAS_ORDER order,
@@ -289,7 +289,7 @@ void BLIS_EXPORT_BLAS cblas_ztpsv(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
                  f77_int N, const void *Ap, void *X, f77_int incX);
 
 
-/* 
+/*
  * Routines with S and D prefixes only
  */
 void BLIS_EXPORT_BLAS cblas_ssymv(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
@@ -351,7 +351,7 @@ void BLIS_EXPORT_BLAS cblas_dspr2(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
                 f77_int incX, const double *Y, f77_int incY, double *A);
 
 
-/* 
+/*
  * Routines with C and Z prefixes only
  */
 void BLIS_EXPORT_BLAS cblas_chemv(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
@@ -422,7 +422,7 @@ void BLIS_EXPORT_BLAS cblas_zhpr2(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, 
  * ===========================================================================
  */
 
-/* 
+/*
  * Routines with standard 4 prefixes (S, D, C, Z)
  */
 void BLIS_EXPORT_BLAS cblas_sgemm(enum CBLAS_ORDER Order, enum CBLAS_TRANSPOSE TransA,
@@ -546,7 +546,7 @@ void BLIS_EXPORT_BLAS cblas_ztrsm(enum CBLAS_ORDER Order, enum CBLAS_SIDE Side,
                  void *B, f77_int ldb);
 
 
-/* 
+/*
  * Routines with prefixes C and Z only
  */
 void BLIS_EXPORT_BLAS cblas_chemm(enum CBLAS_ORDER Order, enum CBLAS_SIDE Side,
@@ -608,25 +608,41 @@ void BLIS_EXPORT_BLAS cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  f77_int N, f77_int K, float alpha, const float *A,
                  f77_int lda, const float *B, f77_int ldb,
                  float beta, float *C, f77_int ldc);
-void BLIS_EXPORT_BLAS cblas_sgemmtr();  // alias to cblas_sgemmt
+void BLIS_EXPORT_BLAS cblas_sgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                 enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
+                 f77_int N, f77_int K, float alpha, const float *A,
+                 f77_int lda, const float *B, f77_int ldb,
+                 float beta, float *C, f77_int ldc);
 void BLIS_EXPORT_BLAS cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
                  f77_int N, f77_int K, double alpha, const double *A,
                  f77_int lda, const double *B, f77_int ldb,
                  double beta, double *C, f77_int ldc);
-void BLIS_EXPORT_BLAS cblas_dgemmtr();  // alias to cblas_dgemmt
+void BLIS_EXPORT_BLAS cblas_dgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                 enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
+                 f77_int N, f77_int K, double alpha, const double *A,
+                 f77_int lda, const double *B, f77_int ldb,
+                 double beta, double *C, f77_int ldc);
 void BLIS_EXPORT_BLAS cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
                  f77_int N, f77_int K, const void *alpha, const void *A,
                  f77_int lda, const void *B, f77_int ldb,
                  const void *beta, void *C, f77_int ldc);
-void BLIS_EXPORT_BLAS cblas_cgemmtr();  // alias to cblas_cgemmt
+void BLIS_EXPORT_BLAS cblas_cgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                 enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
+                 f77_int N, f77_int K, const void *alpha, const void *A,
+                 f77_int lda, const void *B, f77_int ldb,
+                 const void *beta, void *C, f77_int ldc);
 void BLIS_EXPORT_BLAS cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                  enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
                  f77_int N, f77_int K, const void *alpha, const void *A,
                  f77_int lda, const void *B, f77_int ldb,
                  const void *beta, void *C, f77_int ldc);
-void BLIS_EXPORT_BLAS cblas_zgemmtr();  // alias to cblas_zgemmt
+void BLIS_EXPORT_BLAS cblas_zgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                 enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANSPOSE TransB,
+                 f77_int N, f77_int K, const void *alpha, const void *A,
+                 f77_int lda, const void *B, f77_int ldb,
+                 const void *beta, void *C, f77_int ldc);
 
 // -- Batch APIs --
 

--- a/frame/compat/cblas/src/extra/cblas_cgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_cgemmt.c
@@ -48,13 +48,13 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                   f77_int lda, const void  *B, f77_int ldb,
                   const void *beta, void  *C, f77_int ldc)
 {
-   char UL, TA, TB;   
+   char UL, TA, TB;
 #ifdef F77_CHAR
    F77_CHAR F77_UL, F77_TA, F77_TB;
 #else
-   #define F77_UL &UL  
-   #define F77_TA &TA  
-   #define F77_TB &TB  
+   #define F77_UL &UL
+   #define F77_TA &TA
+   #define F77_TB &TB
 #endif
 
 #ifdef F77_INT
@@ -78,7 +78,7 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       if( Uplo == CblasUpper) UL='U';
       else if ( Uplo == CblasLower ) UL='L';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_cgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -89,7 +89,7 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TA='T';
       else if ( TransA == CblasConjTrans ) TA='C';
       else if ( TransA == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_cgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -100,7 +100,7 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TB='T';
       else if ( TransB == CblasConjTrans ) TB='C';
       else if ( TransB == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_cgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -121,7 +121,7 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       RowMajorStrg = 1;
       if( Uplo == CblasUpper) UL='L';
       else if ( Uplo == CblasLower ) UL='U';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_cgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -132,7 +132,7 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TB='T';
       else if ( TransA == CblasConjTrans ) TB='C';
       else if ( TransA == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_cgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -142,7 +142,7 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TA='T';
       else if ( TransB == CblasConjTrans ) TA='C';
       else if ( TransB == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_cgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -157,12 +157,23 @@ void cblas_cgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       F77_cgemmt(F77_UL, F77_TA, F77_TB, &F77_M, &F77_K, (scomplex*)alpha, (scomplex*)B,
                   &F77_ldb, (scomplex*)A, &F77_lda, (scomplex*)beta, (scomplex*)C, &F77_ldc);
-   } 
+   }
    else  cblas_xerbla(1, "cblas_cgemmt", "Illegal Order setting, %d\n", Order);
    CBLAS_CallFromC = 0;
    RowMajorStrg = 0;
    return;
 }
 
-void cblas_cgemmtr() __attribute__((alias("cblas_cgemmt")));
+void cblas_cgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                  enum CBLAS_TRANSPOSE TransA,
+                  enum CBLAS_TRANSPOSE TransB, f77_int M, f77_int K,
+                  const void* alpha, const void  *A,
+                  f77_int lda, const void  *B, f77_int ldb,
+                  const void* beta, void  *C, f77_int ldc)
+#ifdef BLIS_OS_OSX
+{ cblas_cgemmt(Order, Uplo, TransA, TransB, M, K, alpha, A, lda, B, ldb, beta, C, ldc); }
+#else
+__attribute__((alias("cblas_cgemmt")));
+#endif
+
 #endif

--- a/frame/compat/cblas/src/extra/cblas_dgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_dgemmt.c
@@ -48,13 +48,13 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                   f77_int lda, const double  *B, f77_int ldb,
                   double beta, double  *C, f77_int ldc)
 {
-   char UL, TA, TB;   
+   char UL, TA, TB;
 #ifdef F77_CHAR
    F77_CHAR F77_UL, F77_TA, F77_TB;
 #else
-   #define F77_UL &UL  
-   #define F77_TA &TA  
-   #define F77_TB &TB  
+   #define F77_UL &UL
+   #define F77_TA &TA
+   #define F77_TB &TB
 #endif
 
 #ifdef F77_INT
@@ -78,7 +78,7 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       if( Uplo == CblasUpper) UL='U';
       else if ( Uplo == CblasLower ) UL='L';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_dgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -89,7 +89,7 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TA='T';
       else if ( TransA == CblasConjTrans ) TA='C';
       else if ( TransA == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_dgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -100,7 +100,7 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TB='T';
       else if ( TransB == CblasConjTrans ) TB='C';
       else if ( TransB == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_dgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -121,7 +121,7 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       RowMajorStrg = 1;
       if( Uplo == CblasUpper) UL='L';
       else if ( Uplo == CblasLower ) UL='U';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_dgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -132,7 +132,7 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TB='T';
       else if ( TransA == CblasConjTrans ) TB='C';
       else if ( TransA == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_dgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -142,7 +142,7 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TA='T';
       else if ( TransB == CblasConjTrans ) TA='C';
       else if ( TransB == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_dgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -157,12 +157,23 @@ void cblas_dgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       F77_dgemmt(F77_UL, F77_TA, F77_TB, &F77_M, &F77_K, &alpha, B,
                   &F77_ldb, A, &F77_lda, &beta, C, &F77_ldc);
-   } 
+   }
    else  cblas_xerbla(1, "cblas_dgemmt", "Illegal Order setting, %d\n", Order);
    CBLAS_CallFromC = 0;
    RowMajorStrg = 0;
    return;
 }
 
-void cblas_dgemmtr() __attribute__((alias("cblas_dgemmt")));
+void cblas_dgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                  enum CBLAS_TRANSPOSE TransA,
+                  enum CBLAS_TRANSPOSE TransB, f77_int M, f77_int K,
+                  double alpha, const double  *A,
+                  f77_int lda, const double  *B, f77_int ldb,
+                  double beta, double  *C, f77_int ldc)
+#ifdef BLIS_OS_OSX
+{ cblas_dgemmt(Order, Uplo, TransA, TransB, M, K, alpha, A, lda, B, ldb, beta, C, ldc); }
+#else
+__attribute__((alias("cblas_dgemmt")));
+#endif
+
 #endif

--- a/frame/compat/cblas/src/extra/cblas_sgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_sgemmt.c
@@ -48,13 +48,13 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                   f77_int lda, const float  *B, f77_int ldb,
                   float beta, float  *C, f77_int ldc)
 {
-   char UL, TA, TB;   
+   char UL, TA, TB;
 #ifdef F77_CHAR
    F77_CHAR F77_UL, F77_TA, F77_TB;
 #else
-   #define F77_UL &UL  
-   #define F77_TA &TA  
-   #define F77_TB &TB  
+   #define F77_UL &UL
+   #define F77_TA &TA
+   #define F77_TB &TB
 #endif
 
 #ifdef F77_INT
@@ -78,7 +78,7 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       if( Uplo == CblasUpper) UL='U';
       else if ( Uplo == CblasLower ) UL='L';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_sgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -89,7 +89,7 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TA='T';
       else if ( TransA == CblasConjTrans ) TA='C';
       else if ( TransA == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_sgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -100,7 +100,7 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TB='T';
       else if ( TransB == CblasConjTrans ) TB='C';
       else if ( TransB == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_sgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -121,7 +121,7 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       RowMajorStrg = 1;
       if( Uplo == CblasUpper) UL='L';
       else if ( Uplo == CblasLower ) UL='U';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_sgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -132,7 +132,7 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TB='T';
       else if ( TransA == CblasConjTrans ) TB='C';
       else if ( TransA == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_sgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -142,7 +142,7 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TA='T';
       else if ( TransB == CblasConjTrans ) TA='C';
       else if ( TransB == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_sgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -157,12 +157,23 @@ void cblas_sgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       F77_sgemmt(F77_UL, F77_TA, F77_TB, &F77_M, &F77_K, &alpha, B,
                   &F77_ldb, A, &F77_lda, &beta, C, &F77_ldc);
-   } 
+   }
    else  cblas_xerbla(1, "cblas_sgemmt", "Illegal Order setting, %d\n", Order);
    CBLAS_CallFromC = 0;
    RowMajorStrg = 0;
    return;
 }
 
-void cblas_sgemmtr() __attribute__((alias("cblas_sgemmt")));
+void cblas_sgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                  enum CBLAS_TRANSPOSE TransA,
+                  enum CBLAS_TRANSPOSE TransB, f77_int M, f77_int K,
+                  float alpha, const float  *A,
+                  f77_int lda, const float  *B, f77_int ldb,
+                  float beta, float  *C, f77_int ldc)
+#ifdef BLIS_OS_OSX
+{ cblas_sgemmt(Order, Uplo, TransA, TransB, M, K, alpha, A, lda, B, ldb, beta, C, ldc); }
+#else
+__attribute__((alias("cblas_sgemmt")));
+#endif
+
 #endif

--- a/frame/compat/cblas/src/extra/cblas_zgemmt.c
+++ b/frame/compat/cblas/src/extra/cblas_zgemmt.c
@@ -48,13 +48,13 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
                   f77_int lda, const void  *B, f77_int ldb,
                   const void *beta, void  *C, f77_int ldc)
 {
-   char UL, TA, TB;   
+   char UL, TA, TB;
 #ifdef F77_CHAR
    F77_CHAR F77_UL, F77_TA, F77_TB;
 #else
-   #define F77_UL &UL  
-   #define F77_TA &TA  
-   #define F77_TB &TB  
+   #define F77_UL &UL
+   #define F77_TA &TA
+   #define F77_TB &TB
 #endif
 
 #ifdef F77_INT
@@ -78,7 +78,7 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       if( Uplo == CblasUpper) UL='U';
       else if ( Uplo == CblasLower ) UL='L';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_zgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -89,7 +89,7 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TA='T';
       else if ( TransA == CblasConjTrans ) TA='C';
       else if ( TransA == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_zgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -100,7 +100,7 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TB='T';
       else if ( TransB == CblasConjTrans ) TB='C';
       else if ( TransB == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_zgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -121,7 +121,7 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       RowMajorStrg = 1;
       if( Uplo == CblasUpper) UL='L';
       else if ( Uplo == CblasLower ) UL='U';
-      else 
+      else
       {
          cblas_xerbla(2, "cblas_zgemmt","Illegal Uplo setting, %d\n", Uplo);
          CBLAS_CallFromC = 0;
@@ -132,7 +132,7 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransA == CblasTrans) TB='T';
       else if ( TransA == CblasConjTrans ) TB='C';
       else if ( TransA == CblasNoTrans )   TB='N';
-      else 
+      else
       {
          cblas_xerbla(3, "cblas_zgemmt","Illegal TransA setting, %d\n", TransA);
          CBLAS_CallFromC = 0;
@@ -142,7 +142,7 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
       if(TransB == CblasTrans) TA='T';
       else if ( TransB == CblasConjTrans ) TA='C';
       else if ( TransB == CblasNoTrans )   TA='N';
-      else 
+      else
       {
          cblas_xerbla(4, "cblas_zgemmt","Illegal TransB setting, %d\n", TransB);
          CBLAS_CallFromC = 0;
@@ -157,12 +157,23 @@ void cblas_zgemmt(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
 
       F77_zgemmt(F77_UL, F77_TA, F77_TB, &F77_M, &F77_K, (dcomplex*)alpha, (dcomplex*)B,
                   &F77_ldb, (dcomplex*)A, &F77_lda, (dcomplex*)beta, (dcomplex*)C, &F77_ldc);
-   } 
+   }
    else  cblas_xerbla(1, "cblas_zgemmt", "Illegal Order setting, %d\n", Order);
    CBLAS_CallFromC = 0;
    RowMajorStrg = 0;
    return;
 }
 
-void cblas_zgemmtr() __attribute__((alias("cblas_zgemmt")));
+void cblas_zgemmtr(enum CBLAS_ORDER Order, enum CBLAS_UPLO Uplo,
+                  enum CBLAS_TRANSPOSE TransA,
+                  enum CBLAS_TRANSPOSE TransB, f77_int M, f77_int K,
+                  const void* alpha, const void  *A,
+                  f77_int lda, const void  *B, f77_int ldb,
+                  const void* beta, void  *C, f77_int ldc)
+#ifdef BLIS_OS_OSX
+{ cblas_zgemmt(Order, Uplo, TransA, TransB, M, K, alpha, A, lda, B, ldb, beta, C, ldc); }
+#else
+__attribute__((alias("cblas_zgemmt")));
+#endif
+
 #endif

--- a/frame/compat/extra/bla_gemmt.c
+++ b/frame/compat/extra/bla_gemmt.c
@@ -226,12 +226,42 @@ void PASTEF77(ch,blasname) \
 #endif
 
 #ifdef BLIS_ENABLE_BLAS
-
 INSERT_GENTFUNC_BLAS( gemmt, gemmt )
+#endif
 
 #ifdef BLIS_OS_OSX
 
-INSERT_GENTFUNC_BLAS( gemmtr, gemmt )
+#undef  GENTFUNC
+#define GENTFUNC( ftype, ch, blasname, blisname ) \
+\
+void PASTEF77(ch,blasname##r) \
+     ( \
+       const f77_char* uploc, \
+       const f77_char* transa, \
+       const f77_char* transb, \
+       const f77_int*  m, \
+       const f77_int*  k, \
+       const ftype*    alpha, \
+       const ftype*    a, const f77_int* lda, \
+       const ftype*    b, const f77_int* ldb, \
+       const ftype*    beta, \
+             ftype*    c, const f77_int* ldc  \
+     ) \
+{ \
+	PASTEF77(ch,blasname) \
+	( \
+	  uploc, \
+	  transa, \
+	  transb, \
+	  m, \
+	  k, \
+	  alpha, \
+	  a, lda, \
+	  b, ldb, \
+	  beta, \
+	  c, ldc  \
+	); \
+}
 
 #else
 
@@ -252,9 +282,9 @@ void PASTEF77(ch,blasname##r) \
              ftype*    c, const f77_int* ldc  \
      ) __attribute__ ((alias(STRINGIFY_INT(PASTEF77(ch,blasname)))));
 
-INSERT_GENTFUNC_BLAS( gemmt, gemmt )
-
 #endif
 
+#ifdef BLIS_ENABLE_BLAS
+INSERT_GENTFUNC_BLAS( gemmt, gemmt )
 #endif
 

--- a/frame/compat/extra/bla_gemmt.c
+++ b/frame/compat/extra/bla_gemmt.c
@@ -39,8 +39,6 @@
 //
 // Define BLAS-to-BLIS interfaces.
 //
-#define STRINGIFY( name ) #name
-#define EXPAND_AND_STRINGIFY( name ) STRINGIFY( name )
 
 #ifdef BLIS_BLAS3_CALLS_TAPI
 
@@ -120,9 +118,7 @@ void PASTEF77(ch,blasname) \
 \
 	/* Finalize BLIS. */ \
 	bli_finalize_auto(); \
-}; \
-void PASTEF77 (ch, blasname ## r )() \
-	__attribute__ ((alias(EXPAND_AND_STRINGIFY(PASTEF77(ch,blasname)))));
+};
 
 #else
 
@@ -225,13 +221,40 @@ void PASTEF77(ch,blasname) \
 \
 	/* Finalize BLIS. */ \
 	bli_finalize_auto(); \
-}; \
-void PASTEF77 (ch, blasname ## r )() \
-	__attribute__ ((alias(EXPAND_AND_STRINGIFY(PASTEF77(ch,blasname)))));
+};
 
 #endif
 
 #ifdef BLIS_ENABLE_BLAS
+
 INSERT_GENTFUNC_BLAS( gemmt, gemmt )
+
+#ifdef BLIS_OS_OSX
+
+INSERT_GENTFUNC_BLAS( gemmtr, gemmt )
+
+#else
+
+#undef  GENTFUNC
+#define GENTFUNC( ftype, ch, blasname, blisname ) \
+\
+void PASTEF77(ch,blasname##r) \
+     ( \
+       const f77_char* uploc, \
+       const f77_char* transa, \
+       const f77_char* transb, \
+       const f77_int*  m, \
+       const f77_int*  k, \
+       const ftype*    alpha, \
+       const ftype*    a, const f77_int* lda, \
+       const ftype*    b, const f77_int* ldb, \
+       const ftype*    beta, \
+             ftype*    c, const f77_int* ldc  \
+     ) __attribute__ ((alias(STRINGIFY_INT(PASTEF77(ch,blasname)))));
+
+INSERT_GENTFUNC_BLAS( gemmt, gemmt )
+
+#endif
+
 #endif
 


### PR DESCRIPTION
Details:
- The BLAS/CBLAS function `?gemmtr` is currently implemented as a symbol alias of the already-existing `?gemmt`. This does not work on macOS/Darwin.
- Instead, use a minimal wrapper function which calls `?gemmt`/`?cblas_gemmt`, but only on macOS.
- Also clean up the CBLAS prototypes a bit.