### PR TITLE
Fix check for SVE instructions which caused problems on Windows.

### DIFF
--- a/config/armsve/bli_cntx_init_armsve.c
+++ b/config/armsve/bli_cntx_init_armsve.c
@@ -33,21 +33,24 @@
 */
 
 #include "blis.h"
-#include <sys/auxv.h>
-
-#ifndef HWCAP_SVE
-#define HWCAP_SVE (1 << 22)
-#endif
 
 void bli_cntx_init_armsve( cntx_t* cntx )
 {
-	if (!(getauxval( AT_HWCAP ) & HWCAP_SVE))
-		return;
-
-	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
-
 	// Set default kernel blocksizes and functions.
 	bli_cntx_init_armsve_ref( cntx );
+
+	// If we are autodetecting the correct aarch64 config, then we have to make sure
+	// that SVE instructions are actually available since these are used in determining
+	// the register blocksizes.
+	#ifdef BLIS_FAMILY_ARM64
+	uint32_t family, model, features = 0;
+	bli_cpuid_query( &family, &model, &features );
+
+	if ( ! bli_cpuid_has_features( features, FEATURE_SVE ) )
+		return;
+	#endif
+
+	blksz_t blkszs[ BLIS_NUM_BLKSZS ];
 
 	// -------------------------------------------------------------------------
 

--- a/configure
+++ b/configure
@@ -2142,7 +2142,7 @@ check_assembler()
 
 check_os()
 {
-	if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+	if [[ ( "$(uname -s)" == "Darwin" || "$is_win" == "yes" ) && "$(uname -m)" == "arm64" ]]; then
 		blacklistos_add "armsve"
 	fi
 }


### PR DESCRIPTION
Details:
- The context intialization for `armsve` was using the HWCAP functionality of Linux to check if SVE instructions are actually available, since these are used to determine the register blocksizes. Naturally, this causes problems on Windows.
- Instead, use functions from `bli_cpuid.c` to check for SVE. On Windows, no check is actually done and SVE is never detected.
- In the case that (sometime in the future) the user specifically requests the `armsve` config on Windows, only enable this check for the whole `arm64` family and just assume SVE is available otherwise.
- Fixes #858.
- `armsve` has been blacklisted for Windows due to other compilation issues.