### PR TITLE
Adjust CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
             $CC --version
             $CC -v
 
-            make -j2
+            make V=1 -j2
             make install
 
             if [ "$BLD" = "" ] && [ "$TESTSUITE_WRAPPER" = "" ] ; then $DIST_PATH/ci/cxx/cxx-test.sh $DIST_PATH $(ls -1 include); fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
           CC: clang
           THR: openmp,pthreads
           CXX: clang++
-          PACKAGES: clang
+          PACKAGES: clang libomp-dev
 
       # macOS with system compiler (clang)
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ workflows:
       - build:
           OOT: 1
           TEST: ALL
+          THR: openmp,pthreads
           CONF: x86_64
 
       # SDE testing for x86_64
@@ -51,24 +52,22 @@ workflows:
           SDE: 1
           CONF: x86_64
 
-      # openmp build + LEVEL0
+      # some other random tests
       - build:
           LEVEL0: 1
-          THR: openmp
-
-      # pthreads build
-      - build:
-          THR: pthreads
+          CONF: generic_broadcast
 
       # clang build
       - build:
           CC: clang
+          THR: openmp,pthreads
           CXX: clang++
           PACKAGES: clang
 
       # macOS with system compiler (clang)
       - build:
           os: macos
+          THR: pthreads
           CC: clang
           CXX: clang++
 
@@ -226,6 +225,11 @@ jobs:
               export TESTSUITE_WRAPPER="$DIST_PATH/../toolchain/qemu-riscv64 -cpu rv64,vext_spec=v1.0,v=true,vlen=512 -B 0x100000";
             fi
 
+            if [ "$CONF" = "generic_broadcast" ]; then
+              export CONF=generic
+              export CFLAGS="-DBLIS_BBM_s=2 -DBLIS_BBM_d=2 -DBLIS_BBM_c=2 -DBLIS_BBM_z=2 -DBLIS_BBN_s=4 -DBLIS_BBN_d=4 -DBLIS_BBN_c=4 -DBLIS_BBN_z=4"
+            fi
+
             echo "Configuration:"
             echo "CC                = $CC"
             echo "CXX               = $CXX"
@@ -237,6 +241,7 @@ jobs:
             echo "SDE               = $SDE"
             echo "LEVEL0            = $LEVEL0"
             echo "DIST_PATH         = $DIST_PATH"
+            echo "CFLAGS            = $CFLAGS"
             echo "LDFLAGS           = $LDFLAGS"
             echo "TESTSUITE_WRAPPER = $TESTSUITE_WRAPPER"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,15 +46,16 @@ workflows:
           CONF: x86_64
 
       # SDE testing for x86_64
+      # Also test LEVEL0 here because g++ uses tons of memory for test_taxpbys.cxx
       - build:
           # linuxvm must be used because it provides 8G RAM and SDE fails with 4G RAM
           os: linuxvm
           SDE: 1
+          LEVEL0: 1
           CONF: x86_64
 
-      # some other random tests
+      # test generic kernels
       - build:
-          LEVEL0: 1
           CONF: generic_broadcast
 
       # clang build

--- a/ci/do_sde.sh
+++ b/ci/do_sde.sh
@@ -31,7 +31,7 @@ tar xvf $SDE_TARBALL
 
 make -j2 testsuite-bin blastest-bin
 
-for ARCH in penryn sandybridge haswell skx knl piledriver steamroller excavator zen; do
+for ARCH in penryn sandybridge haswell skx knl piledriver steamroller excavator zen generic; do
     export BLIS_ARCH_TYPE=-1
 
     if [ "$ARCH" = "knl" ]; then
@@ -55,6 +55,9 @@ for ARCH in penryn sandybridge haswell skx knl piledriver steamroller excavator 
     elif [ "$ARCH" = "excavator" ]; then
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
         export BLIS_ARCH_TYPE=9
+    elif [ "$ARCH" = "generic" ]; then
+        TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
+        export BLIS_ARCH_TYPE=33
     else
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/$ARCH.def --"
     fi

--- a/ci/do_testsuite.sh
+++ b/ci/do_testsuite.sh
@@ -7,11 +7,19 @@ export BLIS_JC_NT=1
 export BLIS_IC_NT=2
 export BLIS_JR_NT=1
 export BLIS_IR_NT=1
+export BLIS_THREAD_IMPL="single"
 
 if [ "$TEST" = "FAST" -o "$TEST" = "ALL" ]; then
 	make testblis-fast
 	cat ./output.testsuite
 	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+
+	for impl in $(echo $THR | sed 's/none//' | tr , ' '); do
+		export BLIS_THREAD_IMPL="$impl"
+		make testblis-fast
+		cat ./output.testsuite
+		$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	done
 fi
 
 if [ "$TEST" = "MD" -o "$TEST" = "ALL" ]; then

--- a/ci/do_testsuite.sh
+++ b/ci/do_testsuite.sh
@@ -42,6 +42,7 @@ if [ "$TEST" = "1" -o "$TEST" = "ALL" ]; then
 	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
 fi
 
+export BLIS_THREAD_IMPL="single"
 make testblas
 cat ./output.testsuite
 $DIST_PATH/blastest/check-blastest.sh

--- a/frame/1m/packm/bli_packm_init.c
+++ b/frame/1m/packm/bli_packm_init.c
@@ -69,6 +69,7 @@ siz_t bli_packm_init
 	dim_t   bmult_m_def  = bli_packm_def_cntl_bmult_m_def( cntl );
 	dim_t   bmult_m_pack = bli_packm_def_cntl_bmult_m_pack( cntl );
 	dim_t   bmult_n_def  = bli_packm_def_cntl_bmult_n_def( cntl );
+	dim_t   bcast_p      = bli_packm_def_cntl_bmult_m_bcast( cntl );
 
 	// Typecast the internal scalar value to the target datatype.
 	// Note that if the typecasting is needed, this must happen BEFORE we
@@ -136,8 +137,9 @@ siz_t bli_packm_init
 	inc_t cs_p = bmult_m_pack;
 
 	// The "row stride" of a row-micropanel packed object is interpreted
-	// as the row stride WITHIN a micropanel. Thus, it is unit.
-	inc_t rs_p = 1;
+	// as the row stride WITHIN a micropanel. Thus, it is unit unless elemnents
+	// are duplicated (broadcast).
+	inc_t rs_p = bcast_p;
 
 	// The "panel stride" of a micropanel packed object is interpreted as
 	// the distance between the (0,0) element of panel k and the (0,0)

--- a/frame/include/bli_obj_macro_defs.h
+++ b/frame/include/bli_obj_macro_defs.h
@@ -1281,7 +1281,7 @@ BLIS_INLINE void bli_obj_imag_part( const obj_t* c, obj_t* i )
 
 		// Update the buffer.
 		inc_t is_c = bli_obj_imag_stride( c );
-		char* p    = ( char* )bli_obj_buffer_at_off( c );
+		char* p    = ( char* )bli_obj_buffer( c );
 		bli_obj_set_buffer( p + is_c * es_c/2, i );
 	}
 }

--- a/frame/include/level0/bli_assigns.h
+++ b/frame/include/level0/bli_assigns.h
@@ -43,9 +43,9 @@
 //   when that output exists only in the real domain (i.e. has no imaginary
 //   part to begin with).
 
-#define bli_rassigns( xr, xi, yr, yi ) { yr = xr;          }
-#define bli_cassigns( xr, xi, yr, yi ) { yr = xr; yi = xi; }
-#define bli_jassigns( xr, xi, yr, yi ) {          yi = xi; }
+#define bli_rassigns( xr, xi, yr, yi ) { yr = xr;          (void)(xi); (void)(yi); }
+#define bli_cassigns( xr, xi, yr, yi ) { yr = xr; yi = xi;                         }
+#define bli_jassigns( xr, xi, yr, yi ) {          yi = xi; (void)(xr); (void)(yr); }
 
 
 #endif

--- a/frame/include/level0/bli_complex_terms.h
+++ b/frame/include/level0/bli_complex_terms.h
@@ -50,21 +50,21 @@
 #define bli_cctermrr( pab, ab )  ab
 
 // ai * bi term
-#define bli_rrtermii( pab, ab )  PASTEMAC(pab,zero)
-#define bli_rctermii( pab, ab )  PASTEMAC(pab,zero)
-#define bli_crtermii( pab, ab )  PASTEMAC(pab,zero)
+#define bli_rrtermii( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
+#define bli_rctermii( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
+#define bli_crtermii( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
 #define bli_cctermii( pab, ab )  ab
 
 // ai * br term
-#define bli_rrtermir( pab, ab )  PASTEMAC(pab,zero)
-#define bli_rctermir( pab, ab )  PASTEMAC(pab,zero)
+#define bli_rrtermir( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
+#define bli_rctermir( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
 #define bli_crtermir( pab, ab )  ab
 #define bli_cctermir( pab, ab )  ab
 
 // ar * bi term
-#define bli_rrtermri( pab, ab )  PASTEMAC(pab,zero)
+#define bli_rrtermri( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
 #define bli_rctermri( pab, ab )  ab
-#define bli_crtermri( pab, ab )  PASTEMAC(pab,zero)
+#define bli_crtermri( pab, ab )  ( (void)(ab), PASTEMAC(pab,zero) )
 #define bli_cctermri( pab, ab )  ab
 
 

--- a/frame/include/level0/bli_declinits.h
+++ b/frame/include/level0/bli_declinits.h
@@ -45,13 +45,14 @@
 //   to the real and imaginary parts of (presumably) temporary variables.
 //   If the domain is real, only the real part is declared and initialized.
 
-#define bli_rdeclinits( pxy, xr, xi, yr, yi ) PASTEMAC(pxy,ctype) yr = xr; (void)yr;
+#define bli_rdeclinits( pxy, xr, xi, yr, yi ) PASTEMAC(pxy,ctype) yr = xr; (void)yr; \
+                                              PASTEMAC(pxy,ctype) yi;      (void)yi;
 #define bli_cdeclinits( pxy, xr, xi, yr, yi ) PASTEMAC(pxy,ctype) yr = xr; (void)yr; \
                                               PASTEMAC(pxy,ctype) yi = xi; (void)yi;
 
 // An extra definition for situations where we only need a real value declared
 // and initialized (e.g. when explicitly implementing in the complex domain).
-#define bli_rodeclinits( pxy, xr, yr ) bli_rdeclinits( pxy, xr, /*xi*/, yr, /*yi*/ )
+#define bli_rodeclinits( pxy, xr, yr ) PASTEMAC(pxy,ctype) yr = xr; (void)yr;
 
 
 #endif

--- a/frame/include/level0/bli_tsets.h
+++ b/frame/include/level0/bli_tsets.h
@@ -241,25 +241,47 @@
 #define bli_tbcastbbs_mxn( chy, m, n, y, incy, ldy ) \
 { \
 	/* Assume that the duplication factor is the row stride of y. */ \
-	const dim_t _d    = incy; \
-	const dim_t _ds_y = 1; \
+	const dim_t _d = incy; \
 \
 	for ( dim_t _j = 0; _j < (n); ++_j ) \
 	{ \
-		PASTEMAC(chy,ctype)* restrict _yj = (PASTEMAC(chy,ctype)*)(y) + _j*(ldy); \
+		PASTEMAC(chy,ctype)* _yj = (PASTEMAC(chy,ctype)*)(y) + _j*(ldy); \
 \
 		for ( dim_t _i = 0; _i < (m); ++_i ) \
 		{ \
-			PASTEMAC(chy,ctyper)* restrict _yij_r = (PASTEMAC(chy,ctyper)*)( _yj + _i*(incy) ); \
-			PASTEMAC(chy,ctyper)* restrict _yij_i = _yij_r + (incy); \
+			PASTEMAC(chy,ctype)* _yij = _yj + _i*(incy); \
+			PASTEMAC(chy,ctyper) _yij_r, _yij_i; \
 \
-			for ( dim_t _p = 1; _p < _d; ++_p ) \
+			bli_tgets( chy,chy, *_yij, _yij_r, _yij_i ); \
+\
+			for ( dim_t _p = 0; _p < _d; ++_p ) \
 			{ \
-				PASTEMAC(chy,ctyper)* restrict _yijd_r = _yij_r + _p*_ds_y; \
-				PASTEMAC(chy,ctyper)* restrict _yijd_i = _yij_i + _p*_ds_y; (void)_yijd_i; \
+				PASTEMAC(chy,ctyper)* _yijd_r = (PASTEMAC(chy,ctyper)*)_yij      + _p; \
+				PASTEMAC(chy,ctyper)* _yijd_i = (PASTEMAC(chy,ctyper)*)_yij + _d + _p; \
 \
-				bli_tcopyris( chy,chy, *_yij_r, *_yij_i, *_yijd_r, *_yijd_i ); \
+				bli_tcopyris( chy,chy, _yij_r, _yij_i, *_yijd_r, *_yijd_i ); \
 			} \
+		} \
+	} \
+}
+
+// bcastbbs_mxn
+#define bli_tcompressbbs_mxn( chy, m, n, y, incy, ldy ) \
+{ \
+	/* Assume that the duplication factor is the row stride of y. */ \
+	const dim_t _d = incy; \
+\
+	for ( dim_t _j = 0; _j < (n); ++_j ) \
+	{ \
+		PASTEMAC(chy,ctype)* _yj = (PASTEMAC(chy,ctype)*)(y) + _j*(ldy); \
+\
+		for ( dim_t _i = 0; _i < (m); ++_i ) \
+		{ \
+			PASTEMAC(chy,ctype)* _yij = _yj + _i*(incy); \
+			PASTEMAC(chy,ctyper)* _yij_r = (PASTEMAC(chy,ctyper)*)_yij; \
+			PASTEMAC(chy,ctyper)* _yij_i = (PASTEMAC(chy,ctyper)*)_yij + _d; \
+\
+			bli_tsets( chy,chy, *_yij_r, *_yij_i, *_yij ); \
 		} \
 	} \
 }

--- a/ref_kernels/1m/bli_packm_cxc_diag_1er_ref.c
+++ b/ref_kernels/1m/bli_packm_cxc_diag_1er_ref.c
@@ -159,7 +159,7 @@ void PASTEMAC(cha,chp,opname,arch,suf) \
 		bli_tset0s_mxn \
 		( \
 		  chp_r, \
-		  2*cdim_max, \
+		  2*cdim_max*cdim_bcast, \
 		  2*n_max, \
 		  ( ctypep_r* )p, 1, ldp  \
 		); \
@@ -263,7 +263,7 @@ void PASTEMAC(cha,chp,opname,arch,suf) \
 		bli_tset0s_mxn \
 		( \
 		  chp_r, \
-		  cdim_max, \
+		  cdim_max*cdim_bcast, \
 		  2*n_max, \
 		  ( ctypep_r* )p, 1, ldp  \
 		); \

--- a/ref_kernels/1m/bli_packm_cxc_diag_ref.c
+++ b/ref_kernels/1m/bli_packm_cxc_diag_ref.c
@@ -35,7 +35,98 @@
 #include "blis.h"
 
 
-#define PACKM_DIAG_BODY( ctypea, ctypep, cha, chp, mn_min, mn_max, dfac, inca, lda, op ) \
+#define PACKM_DIAG_DIAG_( ctypea, ctypep, ctypep_r, cha, chp, chp_r, dfac, inca, lda ) \
+\
+do \
+{ \
+	if ( bli_is_unit_diag( diaga ) ) \
+	{ \
+		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
+		{ \
+			ctypep_r kar, kai; \
+			bli_tgets( chp,chp, kappa_cast, kar, kai ); \
+			ctypep_r* pi1r = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ); \
+			ctypep_r* pi1i = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ) + dfac; \
+			for ( dim_t d = 0; d < dfac; ++d ) \
+				bli_tcopyris( chp,chp, kar, kai, *(pi1r + d), *(pi1i + d) ); \
+		} \
+	} \
+	else if ( bli_is_hermitian( struca ) ) \
+	{ \
+		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
+		{ \
+			ctypep alpha_cast, kappa_alpha; \
+			bli_tcopys( cha,chp, *(alpha1 + mnk*(inca + lda)), alpha_cast ); \
+			bli_tseti0s( chp, alpha_cast ); \
+			bli_tscal2s( chp,chp,chp,chp, kappa_cast, alpha_cast, kappa_alpha ); \
+			ctypep_r kar, kai; \
+			bli_tgets( chp,chp, kappa_alpha, kar, kai ); \
+			ctypep_r* pi1r = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ); \
+			ctypep_r* pi1i = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ) + dfac; \
+			for ( dim_t d = 0; d < dfac; ++d ) \
+				bli_tcopyris( chp,chp, kar, kai, *(pi1r + d), *(pi1i + d) ); \
+		} \
+	} \
+	else if ( bli_is_conj( conja )) \
+	{ \
+		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
+		{ \
+			ctypep kappa_alpha; \
+			bli_tscal2js( chp,cha,chp,chp, kappa_cast, *(alpha1 + mnk*(inca + lda)), kappa_alpha ); \
+			ctypep_r kar, kai; \
+			bli_tgets( chp,chp, kappa_alpha, kar, kai ); \
+			ctypep_r* pi1r = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ); \
+			ctypep_r* pi1i = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ) + dfac; \
+			for ( dim_t d = 0; d < dfac; ++d ) \
+				bli_tcopyris( chp,chp, kar, kai, *(pi1r + d), *(pi1i + d) ); \
+		} \
+	} \
+	else \
+	{ \
+		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
+		{ \
+			ctypep kappa_alpha; \
+			bli_tscal2s( chp,cha,chp,chp, kappa_cast, *(alpha1 + mnk*(inca + lda)), kappa_alpha ); \
+			ctypep_r kar, kai; \
+			bli_tgets( chp,chp, kappa_alpha, kar, kai ); \
+			ctypep_r* pi1r = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ); \
+			ctypep_r* pi1i = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ) + dfac; \
+			for ( dim_t d = 0; d < dfac; ++d ) \
+				bli_tcopyris( chp,chp, kar, kai, *(pi1r + d), *(pi1i + d) ); \
+		} \
+	} \
+	\
+	/* invert the diagonal if requested */ \
+	if ( invdiag ) \
+	{ \
+		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
+		{ \
+			ctypep_r* pi1r = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ); \
+			ctypep_r* pi1i = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ) + dfac; \
+			for ( dim_t d = 0; d < dfac; ++d ) \
+				bli_tinvertris( chp,chp, *(pi1r + d), *(pi1i + d) ); \
+		} \
+	} \
+	\
+	/* if this an edge case in both directions, extend the diagonal with ones */ \
+	for ( dim_t mnk = cdim; mnk < bli_min( cdim_max, n_max ); ++mnk ) \
+	{ \
+		ctypep_r* pi1r = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ); \
+		ctypep_r* pi1i = (ctypep_r*)( pi1 + mnk*(dfac + ldp) ) + dfac; \
+		ctypep_r oner, onei; \
+		bli_tset1s( chp_r, oner ); \
+		bli_tset0s( chp_r, onei ); \
+		for ( dim_t d = 0; d < dfac; ++d ) \
+			bli_tcopyris( chp,chp, oner, onei, *(pi1r + d), *(pi1i + d) ); \
+	} \
+} while (0)
+
+
+#define PACKM_DIAG_DIAG( ctypea, ctypep, cha, chp, dfac, inca, lda ) \
+PACKM_DIAG_DIAG_( ctypea, ctypep, PASTEMAC(chp,ctyper), cha, chp, PASTEMAC(chp,prec), dfac, inca, lda )
+
+
+#define PACKM_DIAG_BODY_( ctypea, ctypep, ctypep_r, cha, chp, chp_r, mn_min, mn_max, dfac, inca, lda, op ) \
 \
 do \
 { \
@@ -44,11 +135,18 @@ do \
 	{ \
 		ctypep kappa_alpha; \
 		PASTEMAC(t,op)( chp,cha,chp,chp, kappa_cast, *(alpha1 + mn*inca + k*lda), kappa_alpha ); \
+		ctypep_r kar, kai; \
+		bli_tgets( chp,chp, kappa_alpha, kar, kai ); \
+		ctypep_r* pi1r = (ctypep_r*)( pi1 + mn*dfac + k*ldp ); \
+		ctypep_r* pi1i = (ctypep_r*)( pi1 + mn*dfac + k*ldp ) + dfac; \
 		for ( dim_t d = 0; d < dfac; d++ ) \
-			bli_tcopys( chp,chp, kappa_alpha, *(pi1 + mn*dfac + d + k*ldp) ); \
+			bli_tcopyris( chp,chp, kar, kai, *(pi1r + d), *(pi1i + d) ); \
 	} \
 } while(0)
 
+
+#define PACKM_DIAG_BODY( ctypea, ctypep, cha, chp, mn_min, mn_max, dfac, inca, lda, op ) \
+PACKM_DIAG_BODY_( ctypea, ctypep, PASTEMAC(chp,ctyper), cha, chp, PASTEMAC(chp,prec), mn_min, mn_max, dfac, inca, lda, op )
 
 #define PACKM_DIAG_BODY_L( ctypea, ctypep, cha, chp, op ) \
 	PACKM_DIAG_BODY( ctypea, ctypep, cha, chp, k+1, cdim, cdim_bcast, inca_l, lda_l, op )
@@ -83,7 +181,7 @@ void PASTEMAC(cha,chp,opname,arch,suf) \
 	bli_tset0s_mxn \
 	( \
 	  chp, \
-	  cdim_max, \
+	  cdim_max*cdim_bcast, \
 	  n_max, \
 	  ( ctypep* )p, 1, ldp  \
 	); \
@@ -130,57 +228,7 @@ void PASTEMAC(cha,chp,opname,arch,suf) \
 	} \
 \
 	/* write the diagonal */ \
-	if ( bli_is_unit_diag( diaga ) ) \
-	{ \
-		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
-		for ( dim_t d = 0; d < cdim_bcast; ++d ) \
-			bli_tcopys( chp,chp, kappa_cast, *(pi1 + mnk*(cdim_bcast + ldp) + d) ); \
-	} \
-	else if ( bli_is_hermitian( struca ) ) \
-	{ \
-		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
-		{ \
-			ctypep alpha_cast, kappa_alpha; \
-			bli_tcopys( cha,chp, *(alpha1 + mnk*(inca + lda)), alpha_cast ); \
-			bli_tseti0s( chp, alpha_cast ); \
-			bli_tscal2s( chp,chp,chp,chp, kappa_cast, alpha_cast, kappa_alpha ); \
-			for ( dim_t d = 0; d < cdim_bcast; ++d ) \
-				bli_tcopys( chp,chp, kappa_alpha, *(pi1 + mnk*(cdim_bcast + ldp) + d) ); \
-		} \
-	} \
-	else if ( bli_is_conj( conja )) \
-	{ \
-		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
-		{ \
-			ctypep kappa_alpha; \
-			bli_tscal2js( chp,cha,chp,chp, kappa_cast, *(alpha1 + mnk*(inca + lda)), kappa_alpha ); \
-			for ( dim_t d = 0; d < cdim_bcast; ++d ) \
-				bli_tcopys( chp,chp, kappa_alpha, *(pi1 + mnk*(cdim_bcast + ldp) + d) ); \
-		} \
-	} \
-	else \
-	{ \
-		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
-		{ \
-			ctypep kappa_alpha; \
-			bli_tscal2s( chp,cha,chp,chp, kappa_cast, *(alpha1 + mnk*(inca + lda)), kappa_alpha ); \
-			for ( dim_t d = 0; d < cdim_bcast; ++d ) \
-				bli_tcopys( chp,chp, kappa_alpha, *(pi1 + mnk*(cdim_bcast + ldp) + d) ); \
-		} \
-	} \
-\
-	/* invert the diagonal if requested */ \
-	if ( invdiag ) \
-	{ \
-		for ( dim_t mnk = 0; mnk < cdim; ++mnk ) \
-		for ( dim_t d = 0; d < cdim_bcast; ++d ) \
-			bli_tinverts( chp,chp, *(pi1 + mnk*(cdim_bcast + ldp) + d) ); \
-	} \
-\
-	/* if this an edge case in both directions, extend the diagonal with ones */ \
-	for ( dim_t mnk = cdim; mnk < bli_min( cdim_max, n_max ); ++mnk ) \
-	for ( dim_t d = 0; d < cdim_bcast; ++d ) \
-		bli_tset1s( chp, *(pi1 + mnk*(cdim_bcast + ldp) + d) ); \
+	PACKM_DIAG_DIAG( ctypea, ctypep, cha, chp, cdim_bcast, inca, lda ); \
 }
 
 INSERT_GENTFUNC2_BASIC( packm_diag, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX )

--- a/ref_kernels/1m/bli_packm_cxk_ref.c
+++ b/ref_kernels/1m/bli_packm_cxk_ref.c
@@ -44,28 +44,7 @@
 #endif
 #endif
 
-#define PACKM_BODY_r( ctypea, ctypep, cha, chp, pragma, cdim, dfac, inca, op ) \
-\
-do \
-{ \
-	for ( dim_t k = n; k != 0; --k ) \
-	{ \
-		pragma \
-		for ( dim_t mn = 0; mn < cdim; mn++ ) \
-		{ \
-			ctypep kappa_alpha; \
-			PASTEMAC(t,op)( chp,cha,chp,chp, kappa_cast, *(alpha1 + mn*inca), kappa_alpha ); \
-			for ( dim_t d = 0; d < dfac; d++ ) \
-				bli_tcopys( chp,chp, kappa_alpha, *(pi1 + mn*dfac + d) ); \
-		} \
-\
-		alpha1 += lda; \
-		pi1    += ldp; \
-	} \
-} while(0)
-
-
-#define PACKM_BODY_c_( ctypea, ctypep, ctypep_r, cha, chp, chp_r, pragma, cdim, dfac, inca, op ) \
+#define PACKM_BODY_( ctypea, ctypep, ctypep_r, cha, chp, chp_r, pragma, cdim, dfac, inca, op ) \
 \
 do \
 { \
@@ -78,13 +57,10 @@ do \
 			PASTEMAC(t,op)( chp,cha,chp,chp, kappa_cast, *(alpha1 + mn*inca), kappa_alpha ); \
 			ctypep_r kar, kai; \
 			bli_tgets( chp,chp, kappa_alpha, kar, kai ); \
-			ctypep_r* pi1r = (ctypep_r*)pi1; \
-			ctypep_r* pi1i = (ctypep_r*)pi1 + dfac; \
+			ctypep_r* pi1r = (ctypep_r*)( pi1 + mn*dfac ); \
+			ctypep_r* pi1i = pi1r + dfac; \
 			for ( dim_t d = 0; d < dfac; d++ ) \
-			{ \
-				bli_tcopys( chp_r,chp_r, kar, *(pi1r + mn*dfac*2 + d) ); \
-				bli_tcopys( chp_r,chp_r, kai, *(pi1i + mn*dfac*2 + d) ); \
-			} \
+				bli_tcopyris( chp,chp, kar, kai, *(pi1r + d), *(pi1i + d) ); \
 		} \
 \
 		alpha1 += lda; \
@@ -93,12 +69,8 @@ do \
 } while(0)
 
 
-#define PACKM_BODY_c( ctypea, ctypep, cha, chp, pragma, cdim, dfac, inca, op ) \
-PACKM_BODY_c_( ctypea, ctypep, PASTEMAC(chp,ctyper), cha, chp, PASTEMAC(chp,prec), pragma, cdim, dfac, inca, op )
-
-
 #define PACKM_BODY( ctypea, ctypep, cha, chp, pragma, cdim, dfac, inca, op ) \
-PASTECH(PACKM_BODY_,PASTEMAC(chp,dom))( ctypea, ctypep, cha, chp, pragma, cdim, dfac, inca, op )
+PACKM_BODY_( ctypea, ctypep, PASTEMAC(chp,ctyper), cha, chp, PASTEMAC(chp,prec), pragma, cdim, dfac, inca, op )
 
 
 #undef  GENTFUNC2

--- a/ref_kernels/3/bli_gemmtrsm_ref.c
+++ b/ref_kernels/3/bli_gemmtrsm_ref.c
@@ -116,6 +116,19 @@ PASTEMAC(d,fprintm)( stdout, "gemmtrsm_ukr: b11", mr, 2*nr, \
 		cs_c_use = cs_ct; \
 	} \
 \
+	/* If b11 is stored in broacasted format, the real and imaginary components
+	   will be too widely separated (an imaginary stride > 1). Recompress b11 so
+	   that the imaginary stride is 1 as expected (the duplicated elements aren't needed
+	   here so they are left untouched). */ \
+	if ( cs_b > 1 ) \
+	bli_tcompressbbs_mxn \
+	( \
+	  ch, \
+	  n, \
+	  m, \
+	  b11, cs_b, rs_b  \
+	); \
+\
 	/* lower: b11 = alpha * b11 - a10 * b01; */ \
 	/* upper: b11 = alpha * b11 - a12 * b21; */ \
 	gemm_ukr \
@@ -138,6 +151,7 @@ PASTEMAC(d,fprintm)( stdout, "gemmtrsm_ukr: b11 after gemm", mr, 2*nr, \
 \
 	/* Broadcast the elements of the updated b11 submatrix to their
 	   duplicated neighbors. */ \
+	if ( cs_b > 1 ) \
 	bli_tbcastbbs_mxn \
 	( \
 	  ch, \
@@ -156,6 +170,7 @@ PASTEMAC(d,fprintm)( stdout, "gemmtrsm_ukr: b11 after gemm", mr, 2*nr, \
 	  data, \
 	  cntx  \
 	); \
+	\
 /*
 PASTEMAC(d,fprintm)( stdout, "gemmtrsm_ukr: b11 after trsm", mr, 2*nr, \
                      (double*)b11, rs_b, 1, "%5.2f", "" ); \

--- a/test/level0/test_tsets.cxx
+++ b/test/level0/test_tsets.cxx
@@ -318,6 +318,76 @@ UNIT_TEST(chy,PASTECH(opname,_,D)) \
 
 INSERT_GENTFUNC_MIX1( RC, set0bbs_mxn )
 
+#undef GENTFUNC0
+#define GENTFUNC0( opname, D, ctypey, chy ) \
+UNIT_TEST(chy,PASTECH(opname,_,D)) \
+( \
+	constexpr auto M = 4; \
+	constexpr auto N = 4; \
+  \
+	for ( const auto y : test_values<ctypey>() ) \
+	{ \
+		auto ymn = tile<M,D*N>( y ); \
+\
+		INFO( "column-major" ); \
+\
+		auto ymn0 = tile<M,D*N>( y ); \
+		auto& ymn0_ = reinterpret_cast<decltype(tile<M,2*D*N>(real(y)))&>( ymn0 ); \
+		for ( auto i = 0;i < M;i++ ) \
+		for ( auto j = 0;j < N;j++ ) \
+		for ( auto d = 0;d < D;d++ ) \
+		{ \
+			ymn0_[i][j*2*D     + d] = real( y ); \
+			ymn0_[i][j*2*D + D + d] = imag( y ); \
+		} \
+\
+		INFO( "y (init):\n" << ymn ); \
+\
+		bli_tbcastbbs_mxn( chy, N, M, &ymn[0][0], D, D*N ); \
+\
+		INFO( "y (C++):\n" << ymn0 ); \
+		INFO( "y (BLIS):\n" << ymn ); \
+\
+		check<ctypey>( ymn, ymn0 ); \
+	} \
+)
+
+INSERT_GENTFUNC_MIX1( RC, bcastbbs_mxn )
+
+#undef GENTFUNC0
+#define GENTFUNC0( opname, D, ctypey, chy ) \
+UNIT_TEST(chy,PASTECH(opname,_,D)) \
+( \
+	constexpr auto M = 4; \
+	constexpr auto N = 4; \
+  \
+	for ( const auto y : test_values<ctypey>() ) \
+	{ \
+		auto ymn = tile<M,D*N>( y ); \
+\
+		INFO( "column-major" ); \
+\
+		auto ymn0 = tile<M,D*N>( y ); \
+\
+		INFO( "y (init):\n" << ymn ); \
+\
+		bli_tbcastbbs_mxn( chy, N, M, &ymn[0][0], D, D*N ); \
+		bli_tcompressbbs_mxn( chy, N, M, &ymn[0][0], D, D*N ); \
+\
+		for ( auto i = 0;i < M;i++ ) \
+		for ( auto j = 0;j < N;j++ ) \
+		for ( auto d = 1;d < D;d++ ) \
+			ymn[i][j*D+d] = ymn0[i][j*D+d]; \
+\
+		INFO( "y (C++):\n" << ymn0 ); \
+		INFO( "y (BLIS):\n" << ymn ); \
+\
+		check<ctypey>( ymn, ymn0 ); \
+	} \
+)
+
+INSERT_GENTFUNC_MIX1( RC, compressbbs_mxn )
+
 #undef GENTFUNC
 #define GENTFUNC( opname, ctypey, chy ) \
 GENTFUNC0( opname, 10, 10, ctypey, chy ) \

--- a/test/level0/test_tsets.cxx
+++ b/test/level0/test_tsets.cxx
@@ -332,14 +332,25 @@ UNIT_TEST(chy,PASTECH(opname,_,D)) \
 		INFO( "column-major" ); \
 \
 		auto ymn0 = tile<M,D*N>( y ); \
-		auto& ymn0_ = reinterpret_cast<decltype(tile<M,2*D*N>(real(y)))&>( ymn0 ); \
+\
+		if constexpr ( is_complex<ctypey>::value ) \
+		{ \
+			for ( auto i = 0;i < M;i++ ) \
+			for ( auto j = 0;j < N;j++ ) \
+			{ \
+				auto ymnij = &real( ymn0[i][j*D] ); \
+				for ( auto d = 0;d < D;d++ ) \
+				{ \
+					ymnij[  d] = real( y ); \
+					ymnij[D+d] = imag( y ); \
+				} \
+			} \
+		} \
+\
 		for ( auto i = 0;i < M;i++ ) \
 		for ( auto j = 0;j < N;j++ ) \
-		for ( auto d = 0;d < D;d++ ) \
-		{ \
-			ymn0_[i][j*2*D     + d] = real( y ); \
-			ymn0_[i][j*2*D + D + d] = imag( y ); \
-		} \
+		for ( auto d = 1;d < D;d++ ) \
+			ymn[i][j*D + d] = ctypey{}; \
 \
 		INFO( "y (init):\n" << ymn ); \
 \

--- a/testsuite/src/test_gemm_ukr.c
+++ b/testsuite/src/test_gemm_ukr.c
@@ -190,8 +190,8 @@ void libblis_test_gemm_ukr_experiment
 	k = libblis_test_get_dim_from_prob_size( op->dim_spec[0], p_cur );
 
 	// Fix m and n to MR and NR, respectively.
-	m = bli_cntx_get_blksz_def_dt( datatype, BLIS_MR, cntx );
-	n = bli_cntx_get_blksz_def_dt( datatype, BLIS_NR, cntx );
+	m   = bli_cntx_get_blksz_def_dt( datatype, BLIS_MR, cntx );
+	n   = bli_cntx_get_blksz_def_dt( datatype, BLIS_NR, cntx );
 
 	// Store the register blocksizes so that the driver can retrieve the
 	// values later when printing results.
@@ -240,6 +240,7 @@ void libblis_test_gemm_ukr_experiment
 	(
 	  BLIS_MR,
 	  BLIS_KR,
+	  BLIS_BBM,
 	  BLIS_NO_INVERT_DIAG,
 	  BLIS_PACKED_PANELS,
 	  BLIS_BUFFER_FOR_A_BLOCK,
@@ -250,6 +251,7 @@ void libblis_test_gemm_ukr_experiment
 	(
 	  BLIS_NR,
 	  BLIS_KR,
+	  BLIS_BBN,
 	  BLIS_NO_INVERT_DIAG,
 	  BLIS_PACKED_PANELS,
 	  BLIS_BUFFER_FOR_B_PANEL,

--- a/testsuite/src/test_libblis.c
+++ b/testsuite/src/test_libblis.c
@@ -2418,7 +2418,7 @@ void libblis_test_mobj_create( test_params_t* params, num_t dt, trans_t trans, c
 }
 
 
-thrinfo_t* libblis_test_pobj_create( bszid_t bmult_id_m, bszid_t bmult_id_n, invdiag_t inv_diag, pack_t pack_schema, packbuf_t pack_buf, obj_t* a, obj_t* p, cntx_t* cntx )
+thrinfo_t* libblis_test_pobj_create( bszid_t bmult_id_m, bszid_t bmult_id_n, bszid_t bcast_id_m, invdiag_t inv_diag, pack_t pack_schema, packbuf_t pack_buf, obj_t* a, obj_t* p, cntx_t* cntx )
 {
 	static packm_ker_ft GENARRAY2_MIXP(packm_struc_cxk,packm_struc_cxk);
 
@@ -2441,7 +2441,7 @@ thrinfo_t* libblis_test_pobj_create( bszid_t bmult_id_m, bszid_t bmult_id_n, inv
 	  packm_struc_cxk[ dt ][ dt ],
 	  bli_cntx_get_blksz_def_dt( dt, bmult_id_m, cntx ),
 	  bli_cntx_get_blksz_max_dt( dt, bmult_id_m, cntx ),
-	  1,
+	  bli_cntx_get_blksz_def_dt( dt, bcast_id_m, cntx ),
 	  1,
 	  1,
 	  bli_cntx_get_blksz_def_dt( dt, bmult_id_n, cntx ),

--- a/testsuite/src/test_libblis.h
+++ b/testsuite/src/test_libblis.h
@@ -421,7 +421,7 @@ void fill_string_with_n_spaces( char* str, unsigned int n_spaces );
 // --- Create object ---
 
 void libblis_test_mobj_create( test_params_t* params, num_t dt, trans_t trans, char storage, dim_t m, dim_t n, obj_t* a );
-thrinfo_t* libblis_test_pobj_create( bszid_t bmult_id_m, bszid_t bmult_id_n, invdiag_t inv_diag, pack_t pack_schema, packbuf_t pack_buf, obj_t* a, obj_t* p, cntx_t* cntx );
+thrinfo_t* libblis_test_pobj_create( bszid_t bmult_id_m, bszid_t bmult_id_n, bszid_t bcast_id_m, invdiag_t inv_diag, pack_t pack_schema, packbuf_t pack_buf, obj_t* a, obj_t* p, cntx_t* cntx );
 void libblis_test_vobj_create( test_params_t* params, num_t dt, char storage, dim_t m, obj_t* x );
 
 // --- Randomize/initialize object ---

--- a/testsuite/src/test_trsm_ukr.c
+++ b/testsuite/src/test_trsm_ukr.c
@@ -238,6 +238,7 @@ void libblis_test_trsm_ukr_experiment
 	(
 	  BLIS_MR,
 	  BLIS_MR,
+	  BLIS_BBM,
 	  BLIS_INVERT_DIAG,
 	  BLIS_PACKED_PANELS,
 	  BLIS_BUFFER_FOR_A_BLOCK,
@@ -270,6 +271,7 @@ bli_printm( "ap", &ap, "%5.2f", "" );
 		(
 		  BLIS_NR,
 		  BLIS_MR,
+		  BLIS_BBN,
 		  BLIS_NO_INVERT_DIAG,
 		  BLIS_PACKED_PANELS,
 		  BLIS_BUFFER_FOR_B_PANEL,


### PR DESCRIPTION
Details:
- Add tests for the generic config (all reference kernels), including a special test which forces broadcast packing of A and B since this uses a separate reference kernel.
- When doing a fast "make check", check all enabled threading backends.
- Merge the tests for separate threading backends into the "main" test case. Also test the posix backend on macOS.