### PR TITLE
Proof-of-concept: speeding up gemm reference kernel

### DIFF
--- a/ref_kernels/3/bli_gemm_ref.c
+++ b/ref_kernels/3/bli_gemm_ref.c
@@ -157,6 +157,89 @@ INSERT_GENTFUNCR_BASIC( gemm_gen, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX )
 // instructions via constant loop bounds + #pragma omp simd directives.
 // If compile-time MR/NR are not available (indicated by BLIS_[MN]R_x = -1),
 // then the non-unrolled version (above) is used.
+// first the fastest case, 4 macros for m==mr, n==nr, k>0
+// cs_c = 1, beta != 0 (row major)
+// cs_c = 1, beta == 0
+// rs_c = 1, beta != 0 (column major)
+// rs_c = 1, beta == 0
+
+#define TAIL_NITER 5 // in units of 4x k iterations
+#define CACHELINE_SIZE 64
+#define TAXPBYS_BETA0(ch1,ch2,ch3,ch4,ch5,alpha,ab,beta,c) bli_tscal2s(ch1,ch2,ch3,ch4,alpha,ab,c)
+#undef  GENTFUNC
+#define GENTFUNC( ctype, ch, opname, arch, suf, taxpbys, i_or_j, j_or_i, mr_or_nr, nr_or_mr ) \
+\
+static void PASTEMAC(ch,ch,opname,arch,suf)  \
+     ( \
+             dim_t      k, \
+       const ctype*     alpha, \
+       const ctype*     a, \
+       const ctype*     b, \
+       const ctype*     beta, \
+             ctype*     c, inc_t s_c \
+     ) \
+{ \
+	const dim_t mr = PASTECH(BLIS_,mr_or_nr,_,ch); \
+	const dim_t nr = PASTECH(BLIS_,nr_or_mr,_,ch); \
+\
+	const inc_t cs_a   = PASTECH(BLIS_PACKMR_,ch); \
+	const inc_t rs_b   = PASTECH(BLIS_PACKNR_,ch); \
+\
+	      char   ab_[ BLIS_STACK_BUF_MAX_SIZE ] __attribute__((aligned(BLIS_STACK_BUF_ALIGN_SIZE))) = { 0 }; \
+	      ctype* ab    = (ctype*)ab_; \
+	const inc_t s_ab  = nr; \
+\
+\
+	/* Initialize the accumulator elements in ab to zero. */ \
+	PRAGMA_SIMD \
+	for ( dim_t i = 0; i < mr * nr; ++i ) \
+	{ \
+		bli_tset0s( ch, ab[ i ] ); \
+	} \
+\
+	/* Perform a series of k rank-1 updates into ab. */ \
+	dim_t l = 0; do \
+	{ \
+		dim_t i = l + TAIL_NITER*4 + mr - k; \
+		if ( i  >= 0 && i < mr ) \
+			for ( dim_t j = 0; j < nr; j += CACHELINE_SIZE/sizeof(double) ) \
+				bli_prefetch( &c[ i*s_c + j ], 0, 3 ); \
+		for ( dim_t i = 0; i < mr; ++i ) \
+		{ \
+			PRAGMA_SIMD \
+			for ( dim_t j = 0; j < nr; ++j ) \
+			{ \
+				bli_tdots \
+				( \
+				  ch,ch,ch,ch, \
+				  a[ i_or_j ], \
+				  b[ j_or_i ], \
+				  ab[ i*s_ab + j ]  \
+				); \
+			} \
+		} \
+\
+		a += cs_a; \
+		b += rs_b; \
+	} while ( ++l < k ); \
+\
+	for ( dim_t i = 0; i < mr; ++i ) \
+	PRAGMA_SIMD \
+	for ( dim_t j = 0; j < nr; ++j ) \
+	taxpbys \
+	( \
+	  ch,ch,ch,ch,ch, \
+	  *alpha, \
+	  ab[ i*s_ab + j ], \
+	  *beta, \
+	  c [ i*s_c  + j ]  \
+	); \
+}
+
+INSERT_GENTFUNC_BASIC( gemm_vect_r_beta0, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, TAXPBYS_BETA0, i, j, MR, NR )
+INSERT_GENTFUNC_BASIC( gemm_vect_r, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, bli_taxpbys, i, j, MR, NR )
+INSERT_GENTFUNC_BASIC( gemm_vect_c_beta0, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, TAXPBYS_BETA0, j, i, NR, MR )
+INSERT_GENTFUNC_BASIC( gemm_vect_c, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX, bli_taxpbys, j, i, NR, MR )
 
 #undef  GENTFUNC
 #define GENTFUNC( ctype, ch, opname, arch, suf ) \
@@ -209,6 +292,36 @@ void PASTEMAC(ch,ch,opname,arch,suf) \
 		  cntx \
 		); \
 		return; \
+	} \
+\
+	if ( m == mr && n == nr && k > 0 ) \
+	{ \
+		if ( cs_c == 1 ) \
+		{ \
+			(bli_teq0s( ch, *beta ) ? PASTEMAC(ch,ch,gemm_vect_r_beta0,arch,suf) : PASTEMAC(ch,ch,gemm_vect_r,arch,suf)) \
+			( \
+			  k, \
+			  alpha, \
+			  a, \
+			  b, \
+			  beta, \
+			  c, rs_c \
+			); \
+			return; \
+		} \
+		if ( rs_c == 1 ) \
+		{ \
+			(bli_teq0s( ch, *beta ) ? PASTEMAC(ch,ch,gemm_vect_c_beta0,arch,suf) : PASTEMAC(ch,ch,gemm_vect_c,arch,suf)) \
+			( \
+			  k, \
+			  alpha, \
+			  a, \
+			  b, \
+			  beta, \
+			  c, cs_c \
+			); \
+			return; \
+		} \
 	} \
 \
 	      char   ab_[ BLIS_STACK_BUF_MAX_SIZE ] __attribute__((aligned(BLIS_STACK_BUF_ALIGN_SIZE))) = { 0 }; \
@@ -382,5 +495,3 @@ void PASTEMAC(chab,chc,opname,arch,suf) \
 }
 
 INSERT_GENTFUNC2_MIX_P( gemm, BLIS_CNAME_INFIX, BLIS_REF_SUFFIX )
-
-


### PR DESCRIPTION
Related issue: https://github.com/flame/blis/issues/259

This proof of concept is the result of me playing around a bit with reference kernels to better understand the underlying algorithms used for GEMM by BLIS and OpenBLAS for an upcoming talk ( https://easybuild.io/eum25/#linalg ): with blislab I got close to peak performance with just a kernel written in C.

This is a proof-of-concept since I'm not quite sure how to integrate parts of it, particularly the prefetch stuff, and I may have abused the C preprocessor a bit too much, although other things may be straight forward.

So here's the idea:
via a macro, generate 4 fast kernels:
row-major/column-major and `beta==0`/`beta!=0`

Then the `for` loop for `k` was replaced by a `do`-`while` loop, so it only works with `k>0` (checked before).
Some 20 iterations before the end, much like various asm kernels, it'll prefetch relevant parts of C; I did not see any benefit prefetching A and B.
Next I also needed to fold the scaling into the c updater, replacing `bli_tcopys` with `bli_tscal2s` and `bli_txpbys` by `bli_taxpbys`.

I found that if I use a `for` loop instead of `do`-`while` or test for `beta==0` inside the kernel the compiler spills the whole C-tile from registers onto the stack, but it'll keep it in registers with this approach.

Some tests on zen4 (single socket AMD EPYC 9534 64-Core Processor, Genoa) with GCC 13.3, `CFLAGS="-march=native" ./configure generic`  on a 2400x2400 single-threaded dgemm:
* original generic: 36.13 Gflops
* generic with this PR: 44.96 Gflops
* using column-major with KC,MC,NC copied from AOCL-BLAS' zen4 config: 57.67 Gflops (*)
* AOCL-BLAS 5.0, pre-compiled GCC binary: 56.77 Gflops

(it was cool to beat AOCL-BLAS by a small amount, although of course there may be other cases where it won't!)

(*) this used
`CFLAGS="-march=native -DBLIS_MR_d=32 -DBLIS_NR_d=6" ./configure generic` and the following change:
```
--- a/ref_kernels/bli_cntx_ref.c
+++ b/ref_kernels/bli_cntx_ref.c
@@ -379,8 +379,8 @@ void GENBARNAME(cntx_init)
        bli_blksz_init     ( &blkszs[ BLIS_NR  ],     BLIS_NR_s,     BLIS_NR_d,     BLIS_NR_c,     BLIS_NR_z,
                                                  BLIS_PACKNR_s, BLIS_PACKNR_d, BLIS_PACKNR_c, BLIS_PACKNR_z );
        bli_blksz_init_easy( &blkszs[ BLIS_MC  ],           256,           128,           128,            64 );
-       bli_blksz_init_easy( &blkszs[ BLIS_KC  ],           256,           256,           256,           256 );
-       bli_blksz_init_easy( &blkszs[ BLIS_NC  ],          4096,          4096,          4096,          4096 );
+       bli_blksz_init_easy( &blkszs[ BLIS_KC  ],           256,           512,           256,           256 );
+       bli_blksz_init_easy( &blkszs[ BLIS_NC  ],          4096,          4002,          4096,          4096 );
        bli_blksz_init_easy( &blkszs[ BLIS_M2  ],          1000,          1000,          1000,          1000 );
        bli_blksz_init_easy( &blkszs[ BLIS_N2  ],          1000,          1000,          1000,          1000 );
        bli_blksz_init_easy( &blkszs[ BLIS_AF  ],             8,             8,             8,             8 );
@@ -447,7 +447,7 @@ void GENBARNAME(cntx_init)
        gen_func_init_ro( &funcs[ bli_ker_idx( BLIS_GEMMTRSM1M_U_UKR ) ], gemmtrsm1m_u_ukr_name );

        //                                                           s      d      c      z
-       bli_mbool_init( &mbools[ BLIS_GEMM_UKR_ROW_PREF ],        TRUE,  TRUE,  TRUE,  TRUE );
+       bli_mbool_init( &mbools[ BLIS_GEMM_UKR_ROW_PREF ],        TRUE, FALSE,  TRUE,  TRUE );
        bli_mbool_init( &mbools[ BLIS_GEMMTRSM_L_UKR_ROW_PREF ], FALSE, FALSE, FALSE, FALSE );
        bli_mbool_init( &mbools[ BLIS_GEMMTRSM_U_UKR_ROW_PREF ], FALSE, FALSE, FALSE, FALSE );
        bli_mbool_init( &mbools[ BLIS_TRSM_L_UKR_ROW_PREF ],     FALSE, FALSE, FALSE, FALSE );
@@ -552,4 +552,3 @@ void GENBARNAME(cntx_init)
        for ( dim_t i = 0; i < BLIS_NUM_LEVEL3_OPS; i++ )
                bli_cntx_set_l3_sup_handler( i, vfuncs[ i ], cntx );
 }
```