### PR TITLE
examples: replace all 4.1f printm format by 4.3f

### DIFF
--- a/examples/oapi/00obj_basic.c
+++ b/examples/oapi/00obj_basic.c
@@ -187,7 +187,7 @@ int main( int argc, char** argv )
 	// still need to make sure that the specifier makes sense for the data
 	// being printed. For example, you shouldn't use "%d" when printing
 	// elements of type 'float'.
-	bli_printm( "matrix 'a9' contents:", &a9, "%4.1f", "" );
+	bli_printm( "matrix 'a9' contents:", &a9, "% 4.3f", "" );
 
 
 	//
@@ -200,7 +200,7 @@ int main( int argc, char** argv )
 	// When printing complex matrices, the same format specifier gets used
 	// for both the real and imaginary parts.
 	bli_randm( &a11 );
-	bli_printm( "matrix 'a11' contents (complex):", &a11, "%4.1f", "" );
+	bli_printm( "matrix 'a11' contents (complex):", &a11, "% 4.3f", "" );
 
 
 	//

--- a/examples/oapi/04level0.c
+++ b/examples/oapi/04level0.c
@@ -105,10 +105,10 @@ int main( int argc, char** argv )
 
 	// BLIS does not have a special print function for scalars, but since a
 	// 1x1 is also a vector and a matrix, we can use printv or printm.
-	bli_printm( "alpha:", &alpha, "%4.1f", "" );
-	bli_printm( "beta:", &beta, "%4.1f", "" );
-	bli_printm( "kappa:", &kappa, "%4.1f", "" );
-	bli_printm( "gamma:", &gamma, "%4.1f", "" );
+	bli_printm( "alpha:", &alpha, "% 4.3f", "" );
+	bli_printm( "beta:", &beta, "% 4.3f", "" );
+	bli_printm( "kappa:", &kappa, "% 4.3f", "" );
+	bli_printm( "gamma:", &gamma, "% 4.3f", "" );
 
 
 	//
@@ -121,7 +121,7 @@ int main( int argc, char** argv )
 	// can be used.
 	bli_obj_create_1x1( BLIS_DCOMPLEX, &zeta );
 	bli_setsc( 3.3, -4.4, &zeta );
-	bli_printm( "zeta (complex):", &zeta, "%4.1f", "" );
+	bli_printm( "zeta (complex):", &zeta, "% 4.3f", "" );
 
 
 	//
@@ -133,10 +133,10 @@ int main( int argc, char** argv )
 	// We can copy scalars amongst one another, and we can use the global
 	// scalar constants for input operands.
 	bli_copysc( &beta, &gamma );
-	bli_printm( "gamma (overwritten with beta):", &gamma, "%4.1f", "" );
+	bli_printm( "gamma (overwritten with beta):", &gamma, "% 4.3f", "" );
 
 	bli_copysc( &BLIS_ONE, &gamma );
-	bli_printm( "gamma (overwritten with BLIS_ONE):", &gamma, "%4.1f", "" );
+	bli_printm( "gamma (overwritten with BLIS_ONE):", &gamma, "% 4.3f", "" );
 
 
 	//
@@ -147,24 +147,24 @@ int main( int argc, char** argv )
 
 	// BLIS defines a range of basic floating-point operations on scalars.
 	bli_addsc( &beta, &gamma );
-	bli_printm( "gamma := gamma + beta", &gamma, "%4.1f", "" );
+	bli_printm( "gamma := gamma + beta", &gamma, "% 4.3f", "" );
 
 	bli_subsc( &alpha, &gamma );
-	bli_printm( "gamma := gamma - alpha", &gamma, "%4.1f", "" );
+	bli_printm( "gamma := gamma - alpha", &gamma, "% 4.3f", "" );
 
 	bli_divsc( &kappa, &gamma );
-	bli_printm( "gamma := gamma / kappa", &gamma, "%4.1f", "" );
+	bli_printm( "gamma := gamma / kappa", &gamma, "% 4.3f", "" );
 
 	bli_sqrtsc( &gamma, &gamma );
-	bli_printm( "gamma := sqrt( gamma )", &gamma, "%4.1f", "" );
+	bli_printm( "gamma := sqrt( gamma )", &gamma, "% 4.3f", "" );
 
 	bli_normfsc( &alpha, &alpha );
-	bli_printm( "alpha := normf( alpha ) # normf() = abs() in real domain.", &alpha, "%4.1f", "" );
+	bli_printm( "alpha := normf( alpha ) # normf() = abs() in real domain.", &alpha, "% 4.3f", "" );
 
 	// Note that normfsc() allows complex input objects, but requires that the
 	// output operand (the second operand) be a real object.
 	bli_normfsc( &zeta, &alpha );
-	bli_printm( "alpha := normf( zeta )  # normf() = complex modulus in complex domain.", &alpha, "%4.1f", "" );
+	bli_printm( "alpha := normf( zeta )  # normf() = complex modulus in complex domain.", &alpha, "% 4.3f", "" );
 
 	bli_invertsc( &gamma, &gamma );
 	bli_printm( "gamma := 1.0 / gamma", &gamma, "%4.2f", "" );

--- a/examples/oapi/05level1v.c
+++ b/examples/oapi/05level1v.c
@@ -79,9 +79,9 @@ int main( int argc, char** argv )
 	bli_setsc( 0.2, 0.0, &beta );
 	bli_setsc( 3.0, 0.0, &gamma );
 
-	bli_printm( "alpha:", &alpha, "%4.1f", "" );
-	bli_printm( "beta:", &beta, "%4.1f", "" );
-	bli_printm( "gamma:", &gamma, "%4.1f", "" );
+	bli_printm( "alpha:", &alpha, "% 4.3f", "" );
+	bli_printm( "beta:", &beta, "% 4.3f", "" );
+	bli_printm( "gamma:", &gamma, "% 4.3f", "" );
 
 	// Vectors can set by "broadcasting" a constant to every element.
 	bli_setv( &BLIS_ONE, &x );
@@ -93,9 +93,9 @@ int main( int argc, char** argv )
 	// orientation of the vector (row or column) when printing, whereas
 	// printv always prints vectors as column vectors regardless of their
 	// they are 1 x n or n x 1.
-	bli_printm( "x := 1.0", &x, "%4.1f", "" );
-	bli_printm( "y := alpha", &y, "%4.1f", "" );
-	bli_printm( "z := 0.0", &z, "%4.1f", "" );
+	bli_printm( "x := 1.0", &x, "% 4.3f", "" );
+	bli_printm( "y := alpha", &y, "% 4.3f", "" );
+	bli_printm( "z := 0.0", &z, "% 4.3f", "" );
 
 
 	//
@@ -107,7 +107,7 @@ int main( int argc, char** argv )
 	// Set a vector to random values.
 	bli_randv( &w );
 
-	bli_printm( "w := randv()", &w, "%4.1f", "" );
+	bli_printm( "w := randv()", &w, "% 4.3f", "" );
 
 
 	//
@@ -118,38 +118,38 @@ int main( int argc, char** argv )
 
 	// Copy a vector.
 	bli_copyv( &w, &a );
-	bli_printm( "a := w", &a, "%4.1f", "" );
+	bli_printm( "a := w", &a, "% 4.3f", "" );
 
 	// Add and subtract vectors.
 	bli_addv( &y, &a );
-	bli_printm( "a := a + y", &a, "%4.1f", "" );
+	bli_printm( "a := a + y", &a, "% 4.3f", "" );
 
 	bli_subv( &w, &a );
-	bli_printm( "a := a - w", &a, "%4.1f", "" );
+	bli_printm( "a := a - w", &a, "% 4.3f", "" );
 
 	// Scale a vector (destructive).
 	bli_scalv( &beta, &a );
-	bli_printm( "a := beta * a", &a, "%4.1f", "" );
+	bli_printm( "a := beta * a", &a, "% 4.3f", "" );
 
 	// Scale a vector (non-destructive).
 	bli_scal2v( &gamma, &a, &z );
-	bli_printm( "z := gamma * a", &z, "%4.1f", "" );
+	bli_printm( "z := gamma * a", &z, "% 4.3f", "" );
 
 	// Scale and accumulate between vectors.
 	bli_axpyv( &alpha, &w, &x );
-	bli_printm( "x := x + alpha * w", &x, "%4.1f", "" );
+	bli_printm( "x := x + alpha * w", &x, "% 4.3f", "" );
 
 	bli_xpbyv( &w, &BLIS_MINUS_ONE, &x );
-	bli_printm( "x := -1.0 * x + w", &x, "%4.1f", "" );
+	bli_printm( "x := -1.0 * x + w", &x, "% 4.3f", "" );
 
 	// Invert a vector element-wise.
 	bli_invertv( &y );
-	bli_printm( "y := 1 / y", &y, "%4.1f", "" );
+	bli_printm( "y := 1 / y", &y, "% 4.3f", "" );
 
 	// Swap two vectors.
 	bli_swapv( &x, &y );
-	bli_printm( "x (after swapping with y)", &x, "%4.1f", "" );
-	bli_printm( "y (after swapping with x)", &y, "%4.1f", "" );
+	bli_printm( "x (after swapping with y)", &x, "% 4.3f", "" );
+	bli_printm( "y (after swapping with x)", &y, "% 4.3f", "" );
 
 
 	//

--- a/examples/oapi/06level1m.c
+++ b/examples/oapi/06level1m.c
@@ -76,9 +76,9 @@ int main( int argc, char** argv )
 	bli_setsc( 0.2, 0.0, &beta );
 	bli_setsc( 3.0, 0.0, &gamma );
 
-	bli_printm( "alpha:", &alpha, "%4.1f", "" );
-	bli_printm( "beta:", &beta, "%4.1f", "" );
-	bli_printm( "gamma:", &gamma, "%4.1f", "" );
+	bli_printm( "alpha:", &alpha, "% 4.3f", "" );
+	bli_printm( "beta:", &beta, "% 4.3f", "" );
+	bli_printm( "gamma:", &gamma, "% 4.3f", "" );
 
 	// Matrices, like vectors, can set by "broadcasting" a constant to every
 	// element.
@@ -86,9 +86,9 @@ int main( int argc, char** argv )
 	bli_setm( &alpha, &b );
 	bli_setm( &BLIS_ZERO, &c );
 
-	bli_printm( "a := 1.0", &a, "%4.1f", "" );
-	bli_printm( "b := alpha", &b, "%4.1f", "" );
-	bli_printm( "c := 0.0", &c, "%4.1f", "" );
+	bli_printm( "a := 1.0", &a, "% 4.3f", "" );
+	bli_printm( "b := alpha", &b, "% 4.3f", "" );
+	bli_printm( "c := 0.0", &c, "% 4.3f", "" );
 
 
 	//
@@ -100,7 +100,7 @@ int main( int argc, char** argv )
 	// Set a matrix to random values.
 	bli_randm( &e );
 
-	bli_printm( "e (randomized):", &e, "%4.1f", "" );
+	bli_printm( "e (randomized):", &e, "% 4.3f", "" );
 
 
 	//
@@ -111,26 +111,26 @@ int main( int argc, char** argv )
 
 	// Copy a matrix.
 	bli_copym( &e, &d );
-	bli_printm( "d := e", &d, "%4.1f", "" );
+	bli_printm( "d := e", &d, "% 4.3f", "" );
 
 	// Add and subtract vectors.
 	bli_addm( &a, &d );
-	bli_printm( "d := d + a", &d, "%4.1f", "" );
+	bli_printm( "d := d + a", &d, "% 4.3f", "" );
 
 	bli_subm( &a, &e );
-	bli_printm( "e := e - a", &e, "%4.1f", "" );
+	bli_printm( "e := e - a", &e, "% 4.3f", "" );
 
 	// Scale a matrix (destructive).
 	bli_scalm( &alpha, &e );
-	bli_printm( "e := alpha * e", &e, "%4.1f", "" );
+	bli_printm( "e := alpha * e", &e, "% 4.3f", "" );
 
 	// Scale a matrix (non-destructive).
 	bli_scal2m( &beta, &e, &c );
-	bli_printm( "c := beta * e", &c, "%4.1f", "" );
+	bli_printm( "c := beta * e", &c, "% 4.3f", "" );
 
 	// Scale and accumulate between matrices.
 	bli_axpym( &alpha, &a, &c );
-	bli_printm( "c := c + alpha * a", &c, "%4.1f", "" );
+	bli_printm( "c := c + alpha * a", &c, "% 4.3f", "" );
 
 
 	//
@@ -146,8 +146,8 @@ int main( int argc, char** argv )
 	// Initialize all of 'f' to -1.0 to simulate junk values.
 	bli_setm( &BLIS_MINUS_ONE, &f );
 
-	bli_printm( "e:", &e, "%4.1f", "" );
-	bli_printm( "f (initial value):", &f, "%4.1f", "" );
+	bli_printm( "e:", &e, "% 4.3f", "" );
+	bli_printm( "f (initial value):", &f, "% 4.3f", "" );
 
 	// Since we are going to copy 'e' to 'f', we need to indicate a transpose
 	// on 'e', the input operand. Transposition can be indicated by setting a
@@ -173,7 +173,7 @@ int main( int argc, char** argv )
 	// when marking an operand for transposition, not the destination.
 	bli_copym( &e, &f );
 
-	bli_printm( "f (copied value):", &f, "%4.1f", "" );
+	bli_printm( "f (copied value):", &f, "% 4.3f", "" );
 
 
 	//
@@ -194,8 +194,8 @@ int main( int argc, char** argv )
 	// Initialize all of 'h' to -1.0 to simulate junk values.
 	bli_setm( &BLIS_MINUS_ONE, &h );
 
-	bli_printm( "g:", &g, "%4.1f", "" );
-	bli_printm( "h (initial value):", &h, "%4.1f", "" );
+	bli_printm( "g:", &g, "% 4.3f", "" );
+	bli_printm( "h (initial value):", &h, "% 4.3f", "" );
 
 	// Set both the transpose and conjugation bits.
 	bli_obj_toggle_trans( &g );
@@ -206,7 +206,7 @@ int main( int argc, char** argv )
 	// conjugation.
 	bli_copym( &g, &h );
 
-	bli_printm( "h (copied value):", &h, "%4.1f", "" );
+	bli_printm( "h (copied value):", &h, "% 4.3f", "" );
 
 
 	// Free the objects.

--- a/examples/oapi/07level1m_diag.c
+++ b/examples/oapi/07level1m_diag.c
@@ -73,7 +73,7 @@ int main( int argc, char** argv )
 	// Now set the upper triangle to random values.
 	bli_randm( &a );
 
-	bli_printm( "a: randomize upper part (lower part may contain garbage)", &a, "%4.1f", "" );
+	bli_printm( "a: randomize upper part (lower part may contain garbage)", &a, "% 4.3f", "" );
 
 
 	//
@@ -125,14 +125,14 @@ int main( int argc, char** argv )
 	// triangle of 'bl' to zero).
 	bli_setm( &BLIS_ZERO, &bl );
 
-	bli_printm( "b: randomize upper part; set strictly lower part to 0.0", &b, "%4.1f", "" );
+	bli_printm( "b: randomize upper part; set strictly lower part to 0.0", &b, "% 4.3f", "" );
 
 	// You may not see the effect of setting the strictly lower part to zero,
 	// since those values may already be zero (instead of random junk). So
 	// let's set it to something you'll notice, like -1.0.
 	bli_setm( &BLIS_MINUS_ONE, &bl );
 
-	bli_printm( "b: randomize upper part; set strictly lower part to -1.0", &b, "%4.1f", "" );
+	bli_printm( "b: randomize upper part; set strictly lower part to -1.0", &b, "% 4.3f", "" );
 
 
 	//
@@ -158,7 +158,7 @@ int main( int argc, char** argv )
 	// uninitialized, the strictly upper part could contain junk.
 	bli_copym( &bl, &c );
 
-	bli_printm( "c: copy lower part of b (upper part may contain garbage)", &c, "%4.1f", "" );
+	bli_printm( "c: copy lower part of b (upper part may contain garbage)", &c, "% 4.3f", "" );
 
 	// Notice that the structure and uplo properties of 'c' were set to their
 	// default values, BLIS_GENERAL and BLIS_DENSE, respectively. Thus, it is
@@ -178,7 +178,7 @@ int main( int argc, char** argv )
 	// ignore the "unstored" regions of input operands because they are assumed
 	// to be zero).
 
-	bli_printm( "a: copy lower triangular bl to upper triangular a", &a, "%4.1f", "" );
+	bli_printm( "a: copy lower triangular bl to upper triangular a", &a, "% 4.3f", "" );
 
 
 	//
@@ -198,7 +198,7 @@ int main( int argc, char** argv )
 	// Let's start by setting entire destination matrix to zero.
 	bli_setm( &BLIS_ZERO, &d );
 
-	bli_printm( "d: initial value (all zeros)", &d, "%4.1f", "" );
+	bli_printm( "d: initial value (all zeros)", &d, "% 4.3f", "" );
 
 	// Recall that 'bl' is marked as lower triangular with a diagonal offset
 	// of 0. Also recall that 'bl' is an alias of 'b', which is now fully
@@ -210,7 +210,7 @@ int main( int argc, char** argv )
 	bli_setijm( 3.1, 0.0, 3, 1, &bl );
 	bli_setijm( 3.2, 0.0, 3, 2, &bl );
 
-	bli_printm( "bl: lower triangular bl is aliased to b", &bl, "%4.1f", "" );
+	bli_printm( "bl: lower triangular bl is aliased to b", &bl, "% 4.3f", "" );
 
 	// We want to pluck out the lower triangle and transpose it into the upper
 	// triangle of 'd'.
@@ -221,7 +221,7 @@ int main( int argc, char** argv )
 	// 'd'. It's the source operand that matters, not the destination!)
 	bli_copym( &bl, &d );
 
-	bli_printm( "d: transpose of lower triangular of bl copied to d", &d, "%4.1f", "" );
+	bli_printm( "d: transpose of lower triangular of bl copied to d", &d, "% 4.3f", "" );
 
 
 	//
@@ -242,7 +242,7 @@ int main( int argc, char** argv )
 	// Initialize the entire matrix to -1.0 to simulate junk values.
 	bli_setm( &BLIS_MINUS_ONE, &e );
 
-	bli_printm( "e: initial value (all -1.0)", &e, "%4.1f", "" );
+	bli_printm( "e: initial value (all -1.0)", &e, "% 4.3f", "" );
 
 	// Create an alias to work with.
 	bli_obj_alias_to( &e, &el );
@@ -258,7 +258,7 @@ int main( int argc, char** argv )
 	// Randomize the lower trapezoid.
 	bli_randm( &el );
 
-	bli_printm( "e: after lower trapezoid randomized", &e, "%4.1f", "" );
+	bli_printm( "e: after lower trapezoid randomized", &e, "% 4.3f", "" );
 
 	// Move the diagonal offset of 'el' to 1 and flip the uplo field to
 	// "upper".
@@ -268,7 +268,7 @@ int main( int argc, char** argv )
 	// Set the upper triangle to zero.
 	bli_setm( &BLIS_ZERO, &el );
 
-	bli_printm( "e: after upper triangle set to zero", &e, "%4.1f", "" );
+	bli_printm( "e: after upper triangle set to zero", &e, "% 4.3f", "" );
 
 
 	//
@@ -288,7 +288,7 @@ int main( int argc, char** argv )
 	// Initialize the entire matrix to -1.0 to simulate junk values.
 	bli_setm( &BLIS_MINUS_ONE, &h );
 
-	bli_printm( "h: initial value (all -1.0)", &h, "%4.1f", "" );
+	bli_printm( "h: initial value (all -1.0)", &h, "% 4.3f", "" );
 
 	// Set the diagonal offset of 'h' to -1.
 	bli_obj_set_diag_offset( -1, &h );
@@ -300,7 +300,7 @@ int main( int argc, char** argv )
 	// Randomize the elements on and above the first subdiagonal.
 	bli_randm( &h );
 
-	bli_printm( "h: after randomizing above first subdiagonal", &h, "%4.1f", "" );
+	bli_printm( "h: after randomizing above first subdiagonal", &h, "% 4.3f", "" );
 
 	// Create an alias to work with.
 	bli_obj_alias_to( &h, &hl );
@@ -313,7 +313,7 @@ int main( int argc, char** argv )
 	// the second subdiagonal) to zero.
 	bli_setm( &BLIS_ZERO, &hl );
 
-	bli_printm( "h: after setting elements below first subdiagonal to zero", &h, "%4.1f", "" );
+	bli_printm( "h: after setting elements below first subdiagonal to zero", &h, "% 4.3f", "" );
 
 
 	// Free the objects.

--- a/examples/oapi/08level2.c
+++ b/examples/oapi/08level2.c
@@ -74,14 +74,14 @@ int main( int argc, char** argv )
 	// Initialize 'a' to 1.0.
 	bli_setm( &BLIS_ONE, &a );
 
-	bli_printm( "x: set to random values", &x, "%4.1f", "" );
-	bli_printm( "y: set to -1.0", &y, "%4.1f", "" );
-	bli_printm( "a: initial value", &a, "%4.1f", "" );
+	bli_printm( "x: set to random values", &x, "% 4.3f", "" );
+	bli_printm( "y: set to -1.0", &y, "% 4.3f", "" );
+	bli_printm( "a: initial value", &a, "% 4.3f", "" );
 
 	// a := a + alpha * x * y, where 'a' is general.
 	bli_ger( alpha, &x, &y, &a );
 
-	bli_printm( "a: after ger", &a, "%4.1f", "" );
+	bli_printm( "a: after ger", &a, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -122,14 +122,14 @@ int main( int argc, char** argv )
 	// Randomize 'a'.
 	bli_randm( &a );
 
-	bli_printm( "a: randomized", &a, "%4.1f", "" );
-	bli_printm( "x: set to 1.0", &x, "%4.1f", "" );
-	bli_printm( "y: initial value", &y, "%4.1f", "" );
+	bli_printm( "a: randomized", &a, "% 4.3f", "" );
+	bli_printm( "x: set to 1.0", &x, "% 4.3f", "" );
+	bli_printm( "y: initial value", &y, "% 4.3f", "" );
 
 	// y := beta * y + alpha * a * x, where 'a' is general.
 	bli_gemv( alpha, &a, &x, beta, &y );
 
-	bli_printm( "y: after gemv", &y, "%4.1f", "" );
+	bli_printm( "y: after gemv", &y, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -165,13 +165,13 @@ int main( int argc, char** argv )
 	bli_obj_set_uplo( BLIS_LOWER, &a );
 	bli_randm( &a );
 
-	bli_printm( "x: set to random values", &x, "%4.1f", "" );
-	bli_printm( "a: initial value (zeros in upper triangle)", &a, "%4.1f", "" );
+	bli_printm( "x: set to random values", &x, "% 4.3f", "" );
+	bli_printm( "a: initial value (zeros in upper triangle)", &a, "% 4.3f", "" );
 
 	// a := a + alpha * x * x^T, where 'a' is symmetric and lower-stored.
 	bli_syr( alpha, &x, &a );
 
-	bli_printm( "a: after syr", &a, "%4.1f", "" );
+	bli_printm( "a: after syr", &a, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -209,14 +209,14 @@ int main( int argc, char** argv )
 	bli_obj_set_uplo( BLIS_UPPER, &a );
 	bli_randm( &a );
 
-	bli_printm( "a: randomized (zeros in lower triangle)", &a, "%4.1f", "" );
-	bli_printm( "x: set to 1.0", &x, "%4.1f", "" );
-	bli_printm( "y: initial value", &y, "%4.1f", "" );
+	bli_printm( "a: randomized (zeros in lower triangle)", &a, "% 4.3f", "" );
+	bli_printm( "x: set to 1.0", &x, "% 4.3f", "" );
+	bli_printm( "y: initial value", &y, "% 4.3f", "" );
 
 	// y := beta * y + alpha * a * x, where 'a' is symmetric and upper-stored.
 	bli_symv( alpha, &a, &x, beta, &y );
 
-	bli_printm( "y: after symv", &y, "%4.1f", "" );
+	bli_printm( "y: after symv", &y, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -253,13 +253,13 @@ int main( int argc, char** argv )
 	bli_obj_set_diag( BLIS_NONUNIT_DIAG, &a );
 	bli_randm( &a );
 
-	bli_printm( "a: randomized (zeros in upper triangle)", &a, "%4.1f", "" );
-	bli_printm( "x: initial value", &x, "%4.1f", "" );
+	bli_printm( "a: randomized (zeros in upper triangle)", &a, "% 4.3f", "" );
+	bli_printm( "x: initial value", &x, "% 4.3f", "" );
 
 	// x := alpha * a * x, where 'a' is triangular and lower-stored.
 	bli_trmv( alpha, &a, &x );
 
-	bli_printm( "x: after trmv", &x, "%4.1f", "" );
+	bli_printm( "x: after trmv", &x, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -301,21 +301,21 @@ int main( int argc, char** argv )
 	// that the matrix is not singular (singular matrices have no inverse).
 	bli_shiftd( &BLIS_TWO, &a );
 
-	bli_printm( "a: randomized (zeros in upper triangle)", &a, "%4.1f", "" );
-	bli_printm( "b: initial value", &b, "%4.1f", "" );
+	bli_printm( "a: randomized (zeros in upper triangle)", &a, "% 4.3f", "" );
+	bli_printm( "b: initial value", &b, "% 4.3f", "" );
 
 	// solve a * x = alpha * b, where 'a' is triangular and lower-stored, and
 	// overwrite b with the solution vector x.
 	bli_trsv( alpha, &a, &b );
 
-	bli_printm( "b: after trsv", &b, "%4.1f", "" );
+	bli_printm( "b: after trsv", &b, "% 4.3f", "" );
 
 	// We can confirm the solution by comparing the product of a and x to the
 	// original value of b.
 	bli_copyv( &b, &y );
 	bli_trmv( alpha, &a, &y );
 
-	bli_printm( "y: should equal initial value of b", &y, "%4.1f", "" );
+	bli_printm( "y: should equal initial value of b", &y, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );

--- a/examples/oapi/09level3.c
+++ b/examples/oapi/09level3.c
@@ -74,14 +74,14 @@ int main( int argc, char** argv )
 	bli_setm( &BLIS_ONE, &b );
 	bli_setm( &BLIS_ZERO, &c );
 
-	bli_printm( "a: randomized", &a, "%4.1f", "" );
-	bli_printm( "b: set to 1.0", &b, "%4.1f", "" );
-	bli_printm( "c: initial value", &c, "%4.1f", "" );
+	bli_printm( "a: randomized", &a, "% 4.3f", "" );
+	bli_printm( "b: set to 1.0", &b, "% 4.3f", "" );
+	bli_printm( "c: initial value", &c, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a', 'b', and 'c' are general.
 	bli_gemm( alpha, &a, &b, beta, &c );
 
-	bli_printm( "c: after gemm", &c, "%4.1f", "" );
+	bli_printm( "c: after gemm", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -115,14 +115,14 @@ int main( int argc, char** argv )
 	// Set the transpose bit in 'a'.
 	bli_obj_toggle_trans( &a );
 
-	bli_printm( "a: randomized", &a, "%4.1f", "" );
-	bli_printm( "b: set to 1.0", &b, "%4.1f", "" );
-	bli_printm( "c: initial value", &c, "%4.1f", "" );
+	bli_printm( "a: randomized", &a, "% 4.3f", "" );
+	bli_printm( "b: set to 1.0", &b, "% 4.3f", "" );
+	bli_printm( "c: initial value", &c, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a^T * b, where 'a', 'b', and 'c' are general.
 	bli_gemm( alpha, &a, &b, beta, &c );
 
-	bli_printm( "c: after gemm", &c, "%4.1f", "" );
+	bli_printm( "c: after gemm", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -155,13 +155,13 @@ int main( int argc, char** argv )
 	bli_obj_set_uplo( BLIS_LOWER, &c );
 	bli_randm( &c );
 
-	bli_printm( "a: set to random values", &a, "%4.1f", "" );
-	bli_printm( "c: initial value (zeros in upper triangle)", &c, "%4.1f", "" );
+	bli_printm( "a: set to random values", &a, "% 4.3f", "" );
+	bli_printm( "c: initial value (zeros in upper triangle)", &c, "% 4.3f", "" );
 
 	// c := c + alpha * a * a^T, where 'c' is symmetric and lower-stored.
 	bli_syrk( alpha, &a, beta, &c );
 
-	bli_printm( "c: after syrk", &c, "%4.1f", "" );
+	bli_printm( "c: after syrk", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &c );
@@ -202,16 +202,16 @@ int main( int argc, char** argv )
 	bli_obj_set_uplo( BLIS_UPPER, &a );
 	bli_randm( &a );
 
-	bli_printm( "a: randomized (zeros in lower triangle)", &a, "%4.1f", "" );
-	bli_printm( "b: set to 1.0", &b, "%4.1f", "" );
-	bli_printm( "c: initial value", &c, "%4.1f", "" );
+	bli_printm( "a: randomized (zeros in lower triangle)", &a, "% 4.3f", "" );
+	bli_printm( "b: set to 1.0", &b, "% 4.3f", "" );
+	bli_printm( "c: initial value", &c, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a' is symmetric and upper-stored.
 	// Note that the first 'side' operand indicates the side from which matrix
 	// 'a' is multiplied into 'b'.
 	bli_symm( side, alpha, &a, &b, beta, &c );
 
-	bli_printm( "c: after symm", &c, "%4.1f", "" );
+	bli_printm( "c: after symm", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -251,13 +251,13 @@ int main( int argc, char** argv )
 	bli_obj_set_diag( BLIS_NONUNIT_DIAG, &a );
 	bli_randm( &a );
 
-	bli_printm( "a: randomized (zeros in upper triangle)", &a, "%4.1f", "" );
-	bli_printm( "b: initial value", &b, "%4.1f", "" );
+	bli_printm( "a: randomized (zeros in upper triangle)", &a, "% 4.3f", "" );
+	bli_printm( "b: initial value", &b, "% 4.3f", "" );
 
 	// b := alpha * a * b, where 'a' is triangular and lower-stored.
 	bli_trmm( side, alpha, &a, &b );
 
-	bli_printm( "x: after trmm", &b, "%4.1f", "" );
+	bli_printm( "x: after trmm", &b, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -303,21 +303,21 @@ int main( int argc, char** argv )
 	// that the matrix is not singular (singular matrices have no inverse).
 	bli_shiftd( &BLIS_TWO, &a );
 
-	bli_printm( "a: randomized (zeros in upper triangle)", &a, "%4.1f", "" );
-	bli_printm( "b: initial value", &b, "%4.1f", "" );
+	bli_printm( "a: randomized (zeros in upper triangle)", &a, "% 4.3f", "" );
+	bli_printm( "b: initial value", &b, "% 4.3f", "" );
 
 	// solve a * x = alpha * b, where 'a' is triangular and lower-stored, and
 	// overwrite b with the solution matrix x.
 	bli_trsm( side, alpha, &a, &b );
 
-	bli_printm( "b: after trsm", &b, "%4.1f", "" );
+	bli_printm( "b: after trsm", &b, "% 4.3f", "" );
 
 	// We can confirm the solution by comparing the product of a and x to the
 	// original value of b.
 	bli_copym( &b, &c );
 	bli_trmm( side, alpha, &a, &c );
 
-	bli_printm( "c: should equal initial value of b", &c, "%4.1f", "" );
+	bli_printm( "c: should equal initial value of b", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );

--- a/examples/oapi/10util.c
+++ b/examples/oapi/10util.c
@@ -73,18 +73,18 @@ int main( int argc, char** argv )
 	bli_randv( &x );
 	bli_randv( &y );
 
-	bli_printm( "x:", &x, "%4.1f", "" );
+	bli_printm( "x:", &x, "% 4.3f", "" );
 
 	// Compute the one, infinity, and frobenius norms of 'x'.
 	bli_norm1v( &x, &norm1 );
 	bli_normiv( &x, &normi );
 	bli_normfv( &x, &normf );
 
-	bli_printm( "x: 1-norm:", &norm1, "%4.1f", "" );
-	bli_printm( "x: infinity norm:", &normi, "%4.1f", "" );
-	bli_printm( "x: frobenius norm:", &normf, "%4.1f", "" );
+	bli_printm( "x: 1-norm:", &norm1, "% 4.3f", "" );
+	bli_printm( "x: infinity norm:", &normi, "% 4.3f", "" );
+	bli_printm( "x: frobenius norm:", &normf, "% 4.3f", "" );
 
-	bli_printm( "y:", &y, "%4.1f", "" );
+	bli_printm( "y:", &y, "% 4.3f", "" );
 
 	// Compute the one, infinity, and frobenius norms of 'y'. Note that we
 	// can reuse the same scalars from before for computing norms of
@@ -93,9 +93,9 @@ int main( int argc, char** argv )
 	bli_normiv( &y, &normi );
 	bli_normfv( &y, &normf );
 
-	bli_printm( "y: 1-norm:", &norm1, "%4.1f", "" );
-	bli_printm( "y: infinity norm:", &normi, "%4.1f", "" );
-	bli_printm( "y: frobenius norm:", &normf, "%4.1f", "" );
+	bli_printm( "y: 1-norm:", &norm1, "% 4.3f", "" );
+	bli_printm( "y: infinity norm:", &normi, "% 4.3f", "" );
+	bli_printm( "y: frobenius norm:", &normf, "% 4.3f", "" );
 
 
 	//
@@ -113,27 +113,27 @@ int main( int argc, char** argv )
 	bli_randm( &a );
 	bli_randm( &b );
 
-	bli_printm( "a:", &a, "%4.1f", "" );
+	bli_printm( "a:", &a, "% 4.3f", "" );
 
 	// Compute the one, infinity, and frobenius norms of 'a'.
 	bli_norm1m( &a, &norm1 );
 	bli_normim( &a, &normi );
 	bli_normfm( &a, &normf );
 
-	bli_printm( "a: 1-norm:", &norm1, "%4.1f", "" );
-	bli_printm( "a: infinity norm:", &normi, "%4.1f", "" );
-	bli_printm( "a: frobenius norm:", &normf, "%4.1f", "" );
+	bli_printm( "a: 1-norm:", &norm1, "% 4.3f", "" );
+	bli_printm( "a: infinity norm:", &normi, "% 4.3f", "" );
+	bli_printm( "a: frobenius norm:", &normf, "% 4.3f", "" );
 
-	bli_printm( "b:", &b, "%4.1f", "" );
+	bli_printm( "b:", &b, "% 4.3f", "" );
 
 	// Compute the one-norm of 'b'.
 	bli_norm1m( &b, &norm1 );
 	bli_normim( &b, &normi );
 	bli_normfm( &b, &normf );
 
-	bli_printm( "b: 1-norm:", &norm1, "%4.1f", "" );
-	bli_printm( "b: infinity norm:", &normi, "%4.1f", "" );
-	bli_printm( "b: frobenius norm:", &normf, "%4.1f", "" );
+	bli_printm( "b: 1-norm:", &norm1, "% 4.3f", "" );
+	bli_printm( "b: infinity norm:", &normi, "% 4.3f", "" );
+	bli_printm( "b: frobenius norm:", &normf, "% 4.3f", "" );
 
 
 	//
@@ -157,13 +157,13 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'c'.
 	bli_randm( &c );
 
-	bli_printm( "c (initial state):", &c, "%4.1f", "" );
+	bli_printm( "c (initial state):", &c, "% 4.3f", "" );
 
 	// mksymm on a real matrix transposes the stored triangle into the
 	// unstored triangle, making the matrix densely symmetric.
 	bli_mksymm( &c );
 
-	bli_printm( "c (after mksymm on lower triangle):", &c, "%4.1f", "" );
+	bli_printm( "c (after mksymm on lower triangle):", &c, "% 4.3f", "" );
 
 	// Digression: Most people think only of complex matrices as being able
 	// to be complex. However, in BLIS, we define Hermitian operations on
@@ -180,13 +180,13 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'd'.
 	bli_randm( &d );
 
-	bli_printm( "d (initial state):", &d, "%4.1f", "" );
+	bli_printm( "d (initial state):", &d, "% 4.3f", "" );
 
 	// mkherm on a real matrix behaves the same as mksymm, as there are no
 	// imaginary elements to conjugate.
 	bli_mkherm( &d );
 
-	bli_printm( "d (after mkherm on lower triangle):", &d, "%4.1f", "" );
+	bli_printm( "d (after mkherm on lower triangle):", &d, "% 4.3f", "" );
 
 
 	//
@@ -210,13 +210,13 @@ int main( int argc, char** argv )
 	// Randomize the upper triangle of 'e'.
 	bli_randm( &e );
 
-	bli_printm( "e (initial state):", &e, "%4.1f", "" );
+	bli_printm( "e (initial state):", &e, "% 4.3f", "" );
 
 	// mksymm on a complex matrix transposes the stored triangle into the
 	// unstored triangle.
 	bli_mksymm( &e );
 
-	bli_printm( "e (after mksymm):", &e, "%4.1f", "" );
+	bli_printm( "e (after mksymm):", &e, "% 4.3f", "" );
 
 	// Initialize all of 'f' to -1.0 to simulate junk values.
 	bli_setm( &BLIS_MINUS_ONE, &f );
@@ -228,13 +228,13 @@ int main( int argc, char** argv )
 	// Randomize the upper triangle of 'f'.
 	bli_randm( &f );
 
-	bli_printm( "f (initial state):", &f, "%4.1f", "" );
+	bli_printm( "f (initial state):", &f, "% 4.3f", "" );
 
 	// mkherm on a complex matrix transposes and conjugates the stored
 	// triangle into the unstored triangle.
 	bli_mkherm( &f );
 
-	bli_printm( "f (after mkherm):", &f, "%4.1f", "" );
+	bli_printm( "f (after mkherm):", &f, "% 4.3f", "" );
 
 
 	//
@@ -257,14 +257,14 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'g'.
 	bli_randm( &g );
 
-	bli_printm( "g (initial state):", &g, "%4.1f", "" );
+	bli_printm( "g (initial state):", &g, "% 4.3f", "" );
 
 	// mktrim does not explicitly copy any data, since presumably the stored
 	// triangle already contains the data of interest. However, mktrim does
 	// explicitly writes zeros to the unstored region.
 	bli_mktrim( &g );
 
-	bli_printm( "g (after mktrim):", &g, "%4.1f", "" );
+	bli_printm( "g (after mktrim):", &g, "% 4.3f", "" );
 
 
 	// Free the objects.

--- a/examples/oapi/11gemm_md.c
+++ b/examples/oapi/11gemm_md.c
@@ -80,15 +80,15 @@ int main( int argc, char** argv )
 	bli_randm( &b );
 	bli_setm( &BLIS_ZERO, &c );
 
-	bli_printm( "a (double real):    randomized", &a, "%4.1f", "" );
-	bli_printm( "b (double complex): randomized", &b, "%4.1f", "" );
-	bli_printm( "c (double complex): initial value", &c, "%4.1f", "" );
+	bli_printm( "a (double real):    randomized", &a, "% 4.3f", "" );
+	bli_printm( "b (double complex): randomized", &b, "% 4.3f", "" );
+	bli_printm( "c (double complex): initial value", &c, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a' is real, and 'b' and 'c' are
 	// complex.
 	bli_gemm( alpha, &a, &b, beta, &c );
 
-	bli_printm( "c (double complex): after gemm", &c, "%4.1f", "" );
+	bli_printm( "c (double complex): after gemm", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -129,16 +129,16 @@ int main( int argc, char** argv )
 	bli_randm( &b );
 	bli_setm( &BLIS_ZERO, &c );
 
-	bli_printm( "a (single real): randomized", &a, "%4.1f", "" );
-	bli_printm( "b (single real): randomized", &b, "%4.1f", "" );
-	bli_printm( "c (double real): initial value", &c, "%4.1f", "" );
+	bli_printm( "a (single real): randomized", &a, "% 4.3f", "" );
+	bli_printm( "b (single real): randomized", &b, "% 4.3f", "" );
+	bli_printm( "c (double real): initial value", &c, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a' and 'b' are single-precision
 	// real, 'c' is double-precision real, and the matrix product is performed
 	// in double-precision arithmetic.
 	bli_gemm( alpha, &a, &b, beta, &c );
 
-	bli_printm( "c (double real): after gemm (exec prec = double precision)", &c, "%4.1f", "" );
+	bli_printm( "c (double real): after gemm (exec prec = double precision)", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -172,16 +172,16 @@ int main( int argc, char** argv )
 	bli_randm( &b );
 	bli_setm( &BLIS_ZERO, &c );
 
-	bli_printm( "a (single real): randomized", &a, "%4.1f", "" );
-	bli_printm( "b (double complex): randomized", &b, "%4.1f", "" );
-	bli_printm( "c (single complex): initial value", &c, "%4.1f", "" );
+	bli_printm( "a (single real): randomized", &a, "% 4.3f", "" );
+	bli_printm( "b (double complex): randomized", &b, "% 4.3f", "" );
+	bli_printm( "c (single complex): initial value", &c, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a' is single-precision real, 'b'
 	// is double-precision complex, 'c' is single-precision complex, and the
 	// matrix product is performed in single-precision arithmetic.
 	bli_gemm( alpha, &a, &b, beta, &c );
 
-	bli_printm( "c (single complex): after gemm (exec prec = single precision)", &c, "%4.1f", "" );
+	bli_printm( "c (single complex): after gemm (exec prec = single precision)", &c, "% 4.3f", "" );
 
 	// Free the objects.
 	bli_obj_free( &a );
@@ -204,12 +204,12 @@ int main( int argc, char** argv )
 	// Initialize a real matrix A.
 	bli_randm( &a );
 
-	bli_printm( "a (double real): randomized", &a, "%4.1f", "" );
+	bli_printm( "a (double real): randomized", &a, "% 4.3f", "" );
 
 	// Project real matrix A to the complex domain (in B).
 	bli_projm( &a, &b );
 
-	bli_printm( "b (double complex): projected from 'a'", &b, "%4.1f", "" );
+	bli_printm( "b (double complex): projected from 'a'", &b, "% 4.3f", "" );
 
 	// Notice how the imaginary components in B are zero since any real
 	// matrix implicitly has imaginary values that are equal to zero.
@@ -219,12 +219,12 @@ int main( int argc, char** argv )
 	// Initialize the complex matrix B.
 	bli_randm( &b );
 
-	bli_printm( "b (double complex): randomized", &b, "%4.1f", "" );
+	bli_printm( "b (double complex): randomized", &b, "% 4.3f", "" );
 
 	// Project complex matrix B to the real domain (in A).
 	bli_projm( &b, &a );
 
-	bli_printm( "a (double real): projected from 'b'", &a, "%4.1f", "" );
+	bli_printm( "a (double real): projected from 'b'", &a, "% 4.3f", "" );
 
 	// Notice how the imaginary components are lost in the projection from
 	// the complex domain to the real domain.

--- a/examples/tapi/00level1v.c
+++ b/examples/tapi/00level1v.c
@@ -82,9 +82,9 @@ int main( int argc, char** argv )
 	beta  = 0.2;
 	gamma = 3.0;
 
-	printf( "alpha:\n%4.1f\n\n", alpha );
-	printf( "beta:\n%4.1f\n\n", beta );
-	printf( "gamma:\n%4.1f\n\n", gamma );
+	printf( "alpha:\n% 4.3f\n\n", alpha );
+	printf( "beta:\n% 4.3f\n\n", beta );
+	printf( "gamma:\n% 4.3f\n\n", gamma );
 	printf( "\n" );
 
 	bli_dsetv( BLIS_NO_CONJUGATE, n, &one, x, 1 );
@@ -96,9 +96,9 @@ int main( int argc, char** argv )
 	// orientation of the vector (row or column) when printing, whereas
 	// printv always prints vectors as column vectors regardless of their
 	// they are 1 x n or n x 1.
-	bli_dprintm( "x := 1.0", m, n, x, rs, cs, "%4.1f", "" );
-	bli_dprintm( "y := alpha", m, n, y, rs, cs, "%4.1f", "" );
-	bli_dprintm( "z := 0.0", m, n, z, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x := 1.0", m, n, x, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "y := alpha", m, n, y, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "z := 0.0", m, n, z, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -110,7 +110,7 @@ int main( int argc, char** argv )
 	// Set a vector to random values.
 	bli_drandv( n, w, 1 );
 
-	bli_dprintm( "x := randv()", m, n, w, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x := randv()", m, n, w, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -121,38 +121,38 @@ int main( int argc, char** argv )
 
 	// Copy a vector.
 	bli_dcopyv( BLIS_NO_CONJUGATE, n, w, 1, a, 1 );
-	bli_dprintm( "a := w", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a := w", m, n, a, rs, cs, "% 4.3f", "" );
 
 	// Add and subtract vectors.
 	bli_daddv( BLIS_NO_CONJUGATE, n, y, 1, a, 1 );
-	bli_dprintm( "a := a + y", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a := a + y", m, n, a, rs, cs, "% 4.3f", "" );
 
 	bli_dsubv( BLIS_NO_CONJUGATE, n, w, 1, a, 1 );
-	bli_dprintm( "a := a + w", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a := a + w", m, n, a, rs, cs, "% 4.3f", "" );
 
 	// Scale a vector (destructive).
 	bli_dscalv( BLIS_NO_CONJUGATE, n, &beta, a, 1 );
-	bli_dprintm( "a := beta * a", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a := beta * a", m, n, a, rs, cs, "% 4.3f", "" );
 
 	// Scale a vector (non-destructive).
 	bli_dscal2v( BLIS_NO_CONJUGATE, n, &gamma, a, 1, z, 1 );
-	bli_dprintm( "z := gamma * a", m, n, z, rs, cs, "%4.1f", "" );
+	bli_dprintm( "z := gamma * a", m, n, z, rs, cs, "% 4.3f", "" );
 
 	// Scale and accumulate between vectors.
 	bli_daxpyv( BLIS_NO_CONJUGATE, n, &alpha, w, 1, x, 1 );
-	bli_dprintm( "x := x + alpha * w", m, n, x, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x := x + alpha * w", m, n, x, rs, cs, "% 4.3f", "" );
 
 	bli_dxpbyv( BLIS_NO_CONJUGATE, n, w, 1, &minus_one, x, 1 );
-	bli_dprintm( "x := -1.0 * x + w", m, n, x, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x := -1.0 * x + w", m, n, x, rs, cs, "% 4.3f", "" );
 
 	// Invert a vector element-wise.
 	bli_dinvertv( n, y, 1 );
-	bli_dprintm( "y := 1 / y", m, n, y, rs, cs, "%4.1f", "" );
+	bli_dprintm( "y := 1 / y", m, n, y, rs, cs, "% 4.3f", "" );
 
 	// Swap two vectors.
 	bli_dswapv( n, x, 1, y, 1 );
-	bli_dprintm( "x (after swapping with y)", m, n, x, rs, cs, "%4.1f", "" );
-	bli_dprintm( "y (after swapping with x)", m, n, y, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x (after swapping with y)", m, n, x, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "y (after swapping with x)", m, n, y, rs, cs, "% 4.3f", "" );
 
 
 	//

--- a/examples/tapi/01level1m.c
+++ b/examples/tapi/01level1m.c
@@ -83,9 +83,9 @@ int main( int argc, char** argv )
 	beta  = 0.2;
 	gamma = 3.0;
 
-	printf( "alpha:\n%4.1f\n\n", alpha );
-	printf( "beta:\n%4.1f\n\n", beta );
-	printf( "gamma:\n%4.1f\n\n", gamma );
+	printf( "alpha:\n% 4.3f\n\n", alpha );
+	printf( "beta:\n% 4.3f\n\n", beta );
+	printf( "gamma:\n% 4.3f\n\n", gamma );
 	printf( "\n" );
 
 	// Matrices, like vectors, can set by "broadcasting" a constant to every
@@ -99,9 +99,9 @@ int main( int argc, char** argv )
 	bli_dsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	           m, n, &zero, c, rs, cs );
 
-	bli_dprintm( "a := 1.0", m, n, a, rs, cs, "%4.1f", "" );
-	bli_dprintm( "b := alpha", m, n, b, rs, cs, "%4.1f", "" );
-	bli_dprintm( "c := 0.0", m, n, c, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a := 1.0", m, n, a, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "b := alpha", m, n, b, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "c := 0.0", m, n, c, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -112,7 +112,7 @@ int main( int argc, char** argv )
 
 	bli_drandm( 0, BLIS_DENSE, m, n, e, rs, cs );
 
-	bli_dprintm( "e (randomized):", m, n, e, rs, cs, "%4.1f", "" );
+	bli_dprintm( "e (randomized):", m, n, e, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -124,31 +124,31 @@ int main( int argc, char** argv )
 	// Copy a matrix.
 	bli_dcopym( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_NO_TRANSPOSE,
 	            m, n, e, rs, cs, d, rs, cs );
-	bli_dprintm( "d := e", m, n, d, rs, cs, "%4.1f", "" );
+	bli_dprintm( "d := e", m, n, d, rs, cs, "% 4.3f", "" );
 
 	// Add and subtract vectors.
 	bli_daddm( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_NO_TRANSPOSE,
 	           m, n, a, rs, cs, d, rs, cs );
-	bli_dprintm( "d := d + a", m, n, d, rs, cs, "%4.1f", "" );
+	bli_dprintm( "d := d + a", m, n, d, rs, cs, "% 4.3f", "" );
 
 	bli_dsubm( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_NO_TRANSPOSE,
 	           m, n, a, rs, cs, e, rs, cs );
-	bli_dprintm( "e := e - a", m, n, e, rs, cs, "%4.1f", "" );
+	bli_dprintm( "e := e - a", m, n, e, rs, cs, "% 4.3f", "" );
 
 	// Scale a matrix (destructive).
 	bli_dscalm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	            m, n, &alpha, e, rs, cs );
-	bli_dprintm( "e := alpha * e", m, n, e, rs, cs, "%4.1f", "" );
+	bli_dprintm( "e := alpha * e", m, n, e, rs, cs, "% 4.3f", "" );
 
 	// Scale a matrix (non-destructive).
 	bli_dscal2m( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_NO_TRANSPOSE,
 	             m, n, &beta, e, rs, cs, c, rs, cs );
-	bli_dprintm( "c := beta * e", m, n, c, rs, cs, "%4.1f", "" );
+	bli_dprintm( "c := beta * e", m, n, c, rs, cs, "% 4.3f", "" );
 
 	// Scale and accumulate between matrices.
 	bli_daxpym( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_NO_TRANSPOSE,
 	            m, n, &alpha, a, rs, cs, c, rs, cs );
-	bli_dprintm( "c := alpha * a", m, n, c, rs, cs, "%4.1f", "" );
+	bli_dprintm( "c := alpha * a", m, n, c, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -166,8 +166,8 @@ int main( int argc, char** argv )
 	bli_dsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	           n, m, &minus_one, f, rsf, csf );
 
-	bli_dprintm( "e:", m, n, e, rs, cs, "%4.1f", "" );
-	bli_dprintm( "f (initial value):", n, m, f, rsf, csf, "%4.1f", "" );
+	bli_dprintm( "e:", m, n, e, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "f (initial value):", n, m, f, rsf, csf, "% 4.3f", "" );
 
 
 	// Copy 'e' to 'f', transposing 'e' in the process. Notice that we haven't
@@ -176,7 +176,7 @@ int main( int argc, char** argv )
 	bli_dcopym( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_TRANSPOSE,
 	            n, m, e, rs, cs, f, rsf, csf );
 
-	bli_dprintm( "f (copied value):", n, m, f, rsf, csf, "%4.1f", "" );
+	bli_dprintm( "f (copied value):", n, m, f, rsf, csf, "% 4.3f", "" );
 
 
 	//
@@ -193,13 +193,13 @@ int main( int argc, char** argv )
 	bli_zsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	           n, m, &minus_one_z, h, rsf, csf );
 
-	bli_zprintm( "g:", m, n, g, rs, cs, "%4.1f", "" );
-	bli_zprintm( "h (initial value):", n, m, h, rsf, csf, "%4.1f", "" );
+	bli_zprintm( "g:", m, n, g, rs, cs, "% 4.3f", "" );
+	bli_zprintm( "h (initial value):", n, m, h, rsf, csf, "% 4.3f", "" );
 
 	bli_zcopym( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE, BLIS_CONJ_TRANSPOSE,
 	            n, m, g, rs, cs, h, rsf, csf );
 
-	bli_zprintm( "h (copied value):", n, m, h, rsf, csf, "%4.1f", "" );
+	bli_zprintm( "h (copied value):", n, m, h, rsf, csf, "% 4.3f", "" );
 
 
 	// Free the memory obtained via malloc().

--- a/examples/tapi/02level1m_diag.c
+++ b/examples/tapi/02level1m_diag.c
@@ -70,7 +70,7 @@ int main( int argc, char** argv )
 	bli_drandm( 0, BLIS_UPPER, m, n, a, rs, cs );
 
 	bli_dprintm( "a: randomize upper part (lower part may contain garbage)",
-	             m, n, a, rs, cs, "%4.1f", "" );
+	             m, n, a, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -93,7 +93,7 @@ int main( int argc, char** argv )
 	           m, n, &zero, b, rs, cs );
 
 	bli_dprintm( "b: randomize upper part; set strictly lower part to 0.0)",
-	             m, n, b, rs, cs, "%4.1f", "" );
+	             m, n, b, rs, cs, "% 4.3f", "" );
 
 	// You may not see the effect of setting the strictly lower part to zero,
 	// since those values may already be zero (instead of random junk). So
@@ -102,7 +102,7 @@ int main( int argc, char** argv )
 	           m, n, &minus_one, b, rs, cs );
 
 	bli_dprintm( "b: randomize upper part; set strictly lower part to -1.0)",
-	             m, n, b, rs, cs, "%4.1f", "" );
+	             m, n, b, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -120,13 +120,13 @@ int main( int argc, char** argv )
 	            m, n, b, rs, cs, c, rs, cs );
 
 	bli_dprintm( "c: copy lower part of b (upper part may contain garbage)",
-	             m, n, c, rs, cs, "%4.1f", "" );
+	             m, n, c, rs, cs, "% 4.3f", "" );
 
 	bli_dcopym( 0, BLIS_NONUNIT_DIAG, BLIS_LOWER, BLIS_NO_TRANSPOSE,
 	            m, n, b, rs, cs, a, rs, cs );
 
 	bli_dprintm( "a: copy lower triangle of b to upper triangular a",
-	             m, n, a, rs, cs, "%4.1f", "" );
+	             m, n, a, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -145,7 +145,7 @@ int main( int argc, char** argv )
 	           m, n, &zero, d, rs, cs );
 
 	bli_dprintm( "d: initial value (all zeros)",
-	             m, n, d, rs, cs, "%4.1f", "" );
+	             m, n, d, rs, cs, "% 4.3f", "" );
 
 	// Let's change a few values of b manually so we can later see the full
 	// effect of the transposition.
@@ -156,13 +156,13 @@ int main( int argc, char** argv )
 	bli_dsetijm( 3.2, 0.0, 3, 2, b, rs, cs );
 
 	bli_dprintm( "b:",
-	             m, n, b, rs, cs, "%4.1f", "" );
+	             m, n, b, rs, cs, "% 4.3f", "" );
 
 	bli_dcopym( 0, BLIS_NONUNIT_DIAG, BLIS_LOWER, BLIS_TRANSPOSE,
 	            m, n, b, rs, cs, d, rs, cs );
 
 	bli_dprintm( "d: transpose of lower triangle of b copied to d",
-	             m, n, d, rs, cs, "%4.1f", "" );
+	             m, n, d, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -182,20 +182,20 @@ int main( int argc, char** argv )
 	           m, n, &minus_one, e, rs, cs );
 
 	bli_dprintm( "e: initial value (all -1.0)",
-	             m, n, e, rs, cs, "%4.1f", "" );
+	             m, n, e, rs, cs, "% 4.3f", "" );
 
 	// Randomize the lower trapezoid.
 	bli_drandm( 0, BLIS_LOWER, m, n, e, rs, cs );
 
 	bli_dprintm( "e: after lower trapezoid randomized",
-	             m, n, e, rs, cs, "%4.1f", "" );
+	             m, n, e, rs, cs, "% 4.3f", "" );
 
 	// Set the upper triangle to zero.
 	bli_dsetm( BLIS_NO_CONJUGATE, 1, BLIS_NONUNIT_DIAG, BLIS_UPPER,
 	           m, n, &zero, e, rs, cs );
 
 	bli_dprintm( "e: after upper triangle set to zero",
-	             m, n, e, rs, cs, "%4.1f", "" );
+	             m, n, e, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -214,13 +214,13 @@ int main( int argc, char** argv )
 	           m, n, &minus_one, h, rs, cs );
 
 	bli_dprintm( "h: initial value (all -1.0)",
-	             m, n, h, rs, cs, "%4.1f", "" );
+	             m, n, h, rs, cs, "% 4.3f", "" );
 
 	// Randomize the elements on and above the first subdiagonal.
 	bli_drandm( -1, BLIS_UPPER, m, n, h, rs, cs );
 
 	bli_dprintm( "h: after randomizing above first subdiagonal",
-	             m, n, h, rs, cs, "%4.1f", "" );
+	             m, n, h, rs, cs, "% 4.3f", "" );
 
 	// Set the region strictly below the first subdiagonal (on or below
 	// the second subdiagonal) to zero.
@@ -228,7 +228,7 @@ int main( int argc, char** argv )
 	           m, n, &zero, h, rs, cs );
 
 	bli_dprintm( "h: after setting elements below first subdiagonal to zero",
-	             m, n, h, rs, cs, "%4.1f", "" );
+	             m, n, h, rs, cs, "% 4.3f", "" );
 
 
 	// Free the memory obtained via malloc().

--- a/examples/tapi/03level2.c
+++ b/examples/tapi/03level2.c
@@ -80,15 +80,15 @@ int main( int argc, char** argv )
 	bli_dsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	           m, n, &one, a, rs, cs );
 
-	bli_dprintm( "x: set to random values", m, 1, x, 1, m, "%4.1f", "" );
-	bli_dprintm( "y: set to -1.0", 1, n, y, n, 1, "%4.1f", "" );
-	bli_dprintm( "a: intial value", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x: set to random values", m, 1, x, 1, m, "% 4.3f", "" );
+	bli_dprintm( "y: set to -1.0", 1, n, y, n, 1, "% 4.3f", "" );
+	bli_dprintm( "a: intial value", m, n, a, rs, cs, "% 4.3f", "" );
 
 	// a := a + alpha * x * y, where 'a' is general.
 	bli_dger( BLIS_NO_CONJUGATE, BLIS_NO_CONJUGATE,
 	          m, n, &alpha, x, 1, y, 1, a, rs, cs );
 
-	bli_dprintm( "a: after ger", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a: after ger", m, n, a, rs, cs, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -119,15 +119,15 @@ int main( int argc, char** argv )
 	// Randomize 'a'.
 	bli_drandm( 0, BLIS_DENSE, m, n, a, rs, cs );
 
-	bli_dprintm( "a: randomized", m, n, a, rs, cs, "%4.1f", "" );
-	bli_dprintm( "x: set to 1.0", 1, n, x, n, 1, "%4.1f", "" );
-	bli_dprintm( "y: intial value", 1, m, y, m, 1, "%4.1f", "" );
+	bli_dprintm( "a: randomized", m, n, a, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "x: set to 1.0", 1, n, x, n, 1, "% 4.3f", "" );
+	bli_dprintm( "y: intial value", 1, m, y, m, 1, "% 4.3f", "" );
 
 	// y := beta * y + alpha * a * x, where 'a' is general.
 	bli_dgemv( BLIS_NO_TRANSPOSE, BLIS_NO_CONJUGATE,
 	           m, n, &alpha, a, rs, cs, x, 1, &beta, y, 1 );
 
-	bli_dprintm( "y: after gemv", 1, m, y, m, 1, "%4.1f", "" );
+	bli_dprintm( "y: after gemv", 1, m, y, m, 1, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -160,13 +160,13 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'a'.
 	bli_drandm( 0, BLIS_LOWER, m, m, a, rs, cs );
 
-	bli_dprintm( "x: set to random values", 1, m, x, m, 1, "%4.1f", "" );
-	bli_dprintm( "a: initial value (zeros in upper triangle)", m, m, a, 1, m, "%4.1f", "" );
+	bli_dprintm( "x: set to random values", 1, m, x, m, 1, "% 4.3f", "" );
+	bli_dprintm( "a: initial value (zeros in upper triangle)", m, m, a, 1, m, "% 4.3f", "" );
 
 	// a := a + alpha * x * x^T, where 'a' is symmetric and lower-stored.
 	bli_dsyr( BLIS_LOWER, BLIS_NO_CONJUGATE, m, &alpha, x, 1, a, rs, cs );
 
-	bli_dprintm( "a: after syr", m, m, a, 1, m, "%4.1f", "" );
+	bli_dprintm( "a: after syr", m, m, a, 1, m, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -201,15 +201,15 @@ int main( int argc, char** argv )
 	// Randomize 'a'.
 	bli_drandm( 0, BLIS_UPPER, m, m, a, rs, cs );
 
-	bli_dprintm( "a: randomized (zeros in lower triangle)", m, m, a, rs, cs, "%4.1f", "" );
-	bli_dprintm( "x: set to 1.0", 1, m, x, m, 1, "%4.1f", "" );
-	bli_dprintm( "y: intial value", 1, m, y, m, 1, "%4.1f", "" );
+	bli_dprintm( "a: randomized (zeros in lower triangle)", m, m, a, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "x: set to 1.0", 1, m, x, m, 1, "% 4.3f", "" );
+	bli_dprintm( "y: intial value", 1, m, y, m, 1, "% 4.3f", "" );
 
 	// y := beta * y + alpha * a * x, where 'a' is symmetric and upper-stored.
 	bli_dsymv( BLIS_UPPER, BLIS_NO_TRANSPOSE, BLIS_NO_CONJUGATE,
 	           m, &alpha, a, rs, cs, x, 1, &beta, y, 1 );
 
-	bli_dprintm( "y: after symv", 1, m, y, m, 1, "%4.1f", "" );
+	bli_dprintm( "y: after symv", 1, m, y, m, 1, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -242,14 +242,14 @@ int main( int argc, char** argv )
 	// Randomize 'a'.
 	bli_drandm( 0, BLIS_LOWER, m, m, a, rs, cs );
 
-	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rs, cs, "%4.1f", "" );
-	bli_dprintm( "x: intial value", 1, m, x, m, 1, "%4.1f", "" );
+	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "x: intial value", 1, m, x, m, 1, "% 4.3f", "" );
 
 	// x := alpha * a * x, where 'a' is triangular and lower-stored.
 	bli_dtrmv( BLIS_LOWER, BLIS_NO_TRANSPOSE, BLIS_NONUNIT_DIAG,
 	           m, &alpha, a, rs, cs, x, 1 );
 
-	bli_dprintm( "x: after trmv", 1, m, x, m, 1, "%4.1f", "" );
+	bli_dprintm( "x: after trmv", 1, m, x, m, 1, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -287,14 +287,14 @@ int main( int argc, char** argv )
 	// that the matrix is not singular (singular matrices have no inverse).
 	bli_dshiftd( 0, m, m, &two, a, rs, cs );
 
-	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rs, cs, "%4.1f", "" );
-	bli_dprintm( "b: intial value", 1, m, b, m, 1, "%4.1f", "" );
+	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "b: intial value", 1, m, b, m, 1, "% 4.3f", "" );
 
 	// x := alpha * a * x, where 'a' is triangular and lower-stored.
 	bli_dtrsv( BLIS_LOWER, BLIS_NO_TRANSPOSE, BLIS_NONUNIT_DIAG,
 	           m, &alpha, a, rs, cs, x, 1 );
 
-	bli_dprintm( "b: after trsv", 1, m, b, m, 1, "%4.1f", "" );
+	bli_dprintm( "b: after trsv", 1, m, b, m, 1, "% 4.3f", "" );
 
 	// We can confirm the solution by comparing the product of a and x to the
 	// original value of b.
@@ -302,7 +302,7 @@ int main( int argc, char** argv )
 	bli_dtrmv( BLIS_LOWER, BLIS_NO_TRANSPOSE, BLIS_NONUNIT_DIAG,
 	           m, &alpha, a, rs, cs, y, 1 );
 
-	bli_dprintm( "y: should equal initial value of b", 1, m, y, m, 1, "%4.1f", "" );
+	bli_dprintm( "y: should equal initial value of b", 1, m, y, m, 1, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );

--- a/examples/tapi/04level3.c
+++ b/examples/tapi/04level3.c
@@ -84,16 +84,16 @@ int main( int argc, char** argv )
 	bli_dsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
                m, n, &zero, c, rsc, csc );
 
-	bli_dprintm( "a: randomized", m, k, a, rsa, csa, "%4.1f", "" );
-	bli_dprintm( "b: set to 1.0", k, n, b, rsb, csb, "%4.1f", "" );
-	bli_dprintm( "c: initial value", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "a: randomized", m, k, a, rsa, csa, "% 4.3f", "" );
+	bli_dprintm( "b: set to 1.0", k, n, b, rsb, csb, "% 4.3f", "" );
+	bli_dprintm( "c: initial value", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a', 'b', and 'c' are general.
 	bli_dgemm( BLIS_NO_TRANSPOSE, BLIS_NO_TRANSPOSE,
 	           m, n, k, &alpha, a, rsa, csa, b, rsb, csb,
 	                     &beta, c, rsc, csc );
 
-	bli_dprintm( "c: after gemm", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "c: after gemm", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -128,16 +128,16 @@ int main( int argc, char** argv )
 	bli_dsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
                m, n, &zero, c, rsc, csc );
 
-	bli_dprintm( "a: randomized", k, m, a, rsa, csa, "%4.1f", "" );
-	bli_dprintm( "b: set to 1.0", k, n, b, rsb, csb, "%4.1f", "" );
-	bli_dprintm( "c: initial value", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "a: randomized", k, m, a, rsa, csa, "% 4.3f", "" );
+	bli_dprintm( "b: set to 1.0", k, n, b, rsb, csb, "% 4.3f", "" );
+	bli_dprintm( "c: initial value", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a^T * b, where 'a', 'b', and 'c' are general.
 	bli_dgemm( BLIS_TRANSPOSE, BLIS_NO_TRANSPOSE,
 	           m, n, k, &alpha, a, rsa, csa, b, rsb, csb,
 	                     &beta, c, rsc, csc );
 
-	bli_dprintm( "c: after gemm", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "c: after gemm", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -169,15 +169,15 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'c'.
 	bli_drandm( 0, BLIS_LOWER, m, n, c, rsc, csc );
 
-	bli_dprintm( "a: set to random values", m, k, a, rsa, csa, "%4.1f", "" );
-	bli_dprintm( "c: initial value (zeros in upper triangle)", m, m, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "a: set to random values", m, k, a, rsa, csa, "% 4.3f", "" );
+	bli_dprintm( "c: initial value (zeros in upper triangle)", m, m, c, rsc, csc, "% 4.3f", "" );
 
 	// c := c + alpha * a * a^T, where 'c' is symmetric and lower-stored.
 	bli_dsyrk( BLIS_LOWER, BLIS_NO_TRANSPOSE,
 	           m, k, &alpha, a, rsa, csa,
 	                  &beta, c, rsc, csc );
 
-	bli_dprintm( "c: after syrk", m, m, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "c: after syrk", m, m, c, rsc, csc, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -217,16 +217,16 @@ int main( int argc, char** argv )
 	// Randomize the upper triangle of 'a'.
 	bli_drandm( 0, BLIS_UPPER, m, m, a, rsa, csa );
 
-	bli_dprintm( "a: randomized (zeros in lower triangle)", m, m, a, rsa, csa, "%4.1f", "" );
-	bli_dprintm( "b: set to 1.0", m, n, b, rsb, csb, "%4.1f", "" );
-	bli_dprintm( "c: initial value", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "a: randomized (zeros in lower triangle)", m, m, a, rsa, csa, "% 4.3f", "" );
+	bli_dprintm( "b: set to 1.0", m, n, b, rsb, csb, "% 4.3f", "" );
+	bli_dprintm( "c: initial value", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// c := beta * c + alpha * a * b, where 'a' is symmetric and upper-stored.
 	bli_dsymm( BLIS_LEFT, BLIS_UPPER, BLIS_NO_CONJUGATE, BLIS_NO_TRANSPOSE,
 	           m, n, &alpha, a, rsa, csa, b, rsb, csb,
 	                  &beta, c, rsc, csc );
 
-	bli_dprintm( "c: after symm", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "c: after symm", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -262,14 +262,14 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'a'.
 	bli_drandm( 0, BLIS_LOWER, m, m, a, rsa, csa );
 
-	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rsa, csa, "%4.1f", "" );
-	bli_dprintm( "b: initial value", m, n, b, rsb, csb, "%4.1f", "" );
+	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rsa, csa, "% 4.3f", "" );
+	bli_dprintm( "b: initial value", m, n, b, rsb, csb, "% 4.3f", "" );
 
 	// b := alpha * a * b, where 'a' is triangular and lower-stored.
 	bli_dtrmm( BLIS_LEFT, BLIS_LOWER, BLIS_NONUNIT_DIAG, BLIS_NO_TRANSPOSE,
 	           m, n, &alpha, a, rsa, csa, b, rsb, csb );
 
-	bli_dprintm( "b: after trmm", m, n, b, rsb, csb, "%4.1f", "" );
+	bli_dprintm( "b: after trmm", m, n, b, rsb, csb, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );
@@ -312,15 +312,15 @@ int main( int argc, char** argv )
 	// that the matrix is not singular (singular matrices have no inverse).
 	bli_dshiftd( 0, m, m, &two, a, rsa, csa );
 
-	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rsa, csa, "%4.1f", "" );
-	bli_dprintm( "b: initial value", m, n, b, rsb, csb, "%4.1f", "" );
+	bli_dprintm( "a: randomized (zeros in upper triangle)", m, m, a, rsa, csa, "% 4.3f", "" );
+	bli_dprintm( "b: initial value", m, n, b, rsb, csb, "% 4.3f", "" );
 
 	// solve a * x = alpha * b, where 'a' is triangular and lower-stored, and
 	// overwrite b with the solution matrix x.
 	bli_dtrsm( BLIS_LEFT, BLIS_LOWER, BLIS_NONUNIT_DIAG, BLIS_NO_TRANSPOSE,
 	           m, n, &alpha, a, rsa, csa, b, rsb, csb );
 
-	bli_dprintm( "b: after trmm", m, n, b, rsb, csb, "%4.1f", "" );
+	bli_dprintm( "b: after trmm", m, n, b, rsb, csb, "% 4.3f", "" );
 
 	// We can confirm the solution by comparing the product of a and x to the
 	// original value of b.
@@ -329,7 +329,7 @@ int main( int argc, char** argv )
 	bli_dtrmm( BLIS_LEFT, BLIS_LOWER, BLIS_NONUNIT_DIAG, BLIS_NO_TRANSPOSE,
 	           m, n, &alpha, a, rsa, csa, c, rsc, csc );
 
-	bli_dprintm( "c: should equal initial value of b", m, n, c, rsc, csc, "%4.1f", "" );
+	bli_dprintm( "c: should equal initial value of b", m, n, c, rsc, csc, "% 4.3f", "" );
 
 	// Free the memory obtained via malloc().
 	free( a );

--- a/examples/tapi/05util.c
+++ b/examples/tapi/05util.c
@@ -76,7 +76,7 @@ int main( int argc, char** argv )
 	bli_drandv( n, x, 1 );
 	bli_zrandv( n, y, 1 );
 
-	bli_dprintm( "x", m, n, x, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x", m, n, x, rs, cs, "% 4.3f", "" );
 
 	// Compute the one, infinity, and frobenius norms of 'x'. Note that when
 	// computing the norm alpha of a vector 'x', the datatype of alpha must be
@@ -85,11 +85,11 @@ int main( int argc, char** argv )
 	bli_dnormiv( n, x, 1, &normi );
 	bli_dnormfv( n, x, 1, &normf );
 
-	bli_dprintm( "x: 1-norm:", 1, 1, &norm1, rs, cs, "%4.1f", "" );
-	bli_dprintm( "x: infinity norm:", 1, 1, &normi, rs, cs, "%4.1f", "" );
-	bli_dprintm( "x: frobenius norm:", 1, 1, &normf, rs, cs, "%4.1f", "" );
+	bli_dprintm( "x: 1-norm:", 1, 1, &norm1, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "x: infinity norm:", 1, 1, &normi, rs, cs, "% 4.3f", "" );
+	bli_dprintm( "x: frobenius norm:", 1, 1, &normf, rs, cs, "% 4.3f", "" );
 
-	bli_zprintm( "y", m, n, y, rs, cs, "%4.1f", "" );
+	bli_zprintm( "y", m, n, y, rs, cs, "% 4.3f", "" );
 
 	// Compute the one, infinity, and frobenius norms of 'y'. Note that we
 	// can reuse the same scalars from before for computing norms of
@@ -98,9 +98,9 @@ int main( int argc, char** argv )
 	bli_znormiv( n, y, 1, &normi );
 	bli_znormfv( n, y, 1, &normf );
 
-	bli_dprintm( "y: 1-norm:", 1, 1, &norm1, 1, 1, "%4.1f", "" );
-	bli_dprintm( "y: infinity norm:", 1, 1, &normi, 1, 1, "%4.1f", "" );
-	bli_dprintm( "y: frobenius norm:", 1, 1, &normf, 1, 1, "%4.1f", "" );
+	bli_dprintm( "y: 1-norm:", 1, 1, &norm1, 1, 1, "% 4.3f", "" );
+	bli_dprintm( "y: infinity norm:", 1, 1, &normi, 1, 1, "% 4.3f", "" );
+	bli_dprintm( "y: frobenius norm:", 1, 1, &normf, 1, 1, "% 4.3f", "" );
 
 
 	//
@@ -118,7 +118,7 @@ int main( int argc, char** argv )
 	bli_drandm( 0, BLIS_DENSE, m, n, a, rs, cs );
 	bli_zrandm( 0, BLIS_DENSE, m, n, b, rs, cs );
 
-	bli_dprintm( "a:", m, n, a, rs, cs, "%4.1f", "" );
+	bli_dprintm( "a:", m, n, a, rs, cs, "% 4.3f", "" );
 
 	// Compute the one-norm of 'a'.
 	bli_dnorm1m( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
@@ -128,11 +128,11 @@ int main( int argc, char** argv )
 	bli_dnormfm( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	             m, n, a, rs, cs, &normf );
 
-	bli_dprintm( "a: 1-norm:", 1, 1, &norm1, 1, 1, "%4.1f", "" );
-	bli_dprintm( "a: infinity norm:", 1, 1, &normi, 1, 1, "%4.1f", "" );
-	bli_dprintm( "a: frobenius norm:", 1, 1, &normf, 1, 1, "%4.1f", "" );
+	bli_dprintm( "a: 1-norm:", 1, 1, &norm1, 1, 1, "% 4.3f", "" );
+	bli_dprintm( "a: infinity norm:", 1, 1, &normi, 1, 1, "% 4.3f", "" );
+	bli_dprintm( "a: frobenius norm:", 1, 1, &normf, 1, 1, "% 4.3f", "" );
 
-	bli_zprintm( "b:", m, n, b, rs, cs, "%4.1f", "" );
+	bli_zprintm( "b:", m, n, b, rs, cs, "% 4.3f", "" );
 
 	// Compute the one-norm of 'b'.
 	bli_znorm1m( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
@@ -142,9 +142,9 @@ int main( int argc, char** argv )
 	bli_znormfm( 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
 	             m, n, b, rs, cs, &normf );
 
-	bli_dprintm( "a: 1-norm:", 1, 1, &norm1, 1, 1, "%4.1f", "" );
-	bli_dprintm( "a: infinity norm:", 1, 1, &normi, 1, 1, "%4.1f", "" );
-	bli_dprintm( "a: frobenius norm:", 1, 1, &normf, 1, 1, "%4.1f", "" );
+	bli_dprintm( "a: 1-norm:", 1, 1, &norm1, 1, 1, "% 4.3f", "" );
+	bli_dprintm( "a: infinity norm:", 1, 1, &normi, 1, 1, "% 4.3f", "" );
+	bli_dprintm( "a: frobenius norm:", 1, 1, &normf, 1, 1, "% 4.3f", "" );
 
 
 	//
@@ -165,13 +165,13 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'c'.
 	bli_drandm( 0, BLIS_LOWER, m, m, c, rs, cs );
 
-	bli_dprintm( "c (initial state):", m, m, c, rs, cs, "%4.1f", "" );
+	bli_dprintm( "c (initial state):", m, m, c, rs, cs, "% 4.3f", "" );
 
 	// mksymm on a real matrix transposes the stored triangle into the
 	// unstored triangle, making the matrix densely symmetric.
 	bli_dmksymm( BLIS_LOWER, m, c, rs, cs );
 
-	bli_dprintm( "c (after mksymm on lower triangle):", m, m, c, rs, cs, "%4.1f", "" );
+	bli_dprintm( "c (after mksymm on lower triangle):", m, m, c, rs, cs, "% 4.3f", "" );
 
 	// Digression: Most people think only of complex matrices as being able
 	// to be complex. However, in BLIS, we define Hermitian operations on
@@ -186,13 +186,13 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'd'.
 	bli_drandm( 0, BLIS_LOWER, m, m, d, rs, cs );
 
-	bli_dprintm( "d (initial state):", m, m, d, rs, cs, "%4.1f", "" );
+	bli_dprintm( "d (initial state):", m, m, d, rs, cs, "% 4.3f", "" );
 
 	// mkherm on a real matrix behaves the same as mksymm, as there are no
 	// imaginary elements to conjugate.
 	bli_dmkherm( BLIS_LOWER, m, d, rs, cs );
 
-	bli_dprintm( "c (after mkherm on lower triangle):", m, m, d, rs, cs, "%4.1f", "" );
+	bli_dprintm( "c (after mkherm on lower triangle):", m, m, d, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -213,13 +213,13 @@ int main( int argc, char** argv )
 	// Randomize the upper triangle of 'e'.
 	bli_zrandm( 0, BLIS_UPPER, m, m, e, rs, cs );
 
-	bli_zprintm( "e (initial state):", m, m, e, rs, cs, "%4.1f", "" );
+	bli_zprintm( "e (initial state):", m, m, e, rs, cs, "% 4.3f", "" );
 
 	// mksymm on a complex matrix transposes the stored triangle into the
 	// unstored triangle.
 	bli_zmksymm( BLIS_UPPER, m, e, rs, cs );
 
-	bli_zprintm( "e (after mksymm on lower triangle):", m, m, e, rs, cs, "%4.1f", "" );
+	bli_zprintm( "e (after mksymm on lower triangle):", m, m, e, rs, cs, "% 4.3f", "" );
 
 	// Initialize all of 'f' to -1.0 to simulate junk values.
 	bli_zsetm( BLIS_NO_CONJUGATE, 0, BLIS_NONUNIT_DIAG, BLIS_DENSE,
@@ -228,13 +228,13 @@ int main( int argc, char** argv )
 	// Randomize the upper triangle of 'd'.
 	bli_zrandm( 0, BLIS_UPPER, m, m, f, rs, cs );
 
-	bli_zprintm( "f (initial state):", m, m, f, rs, cs, "%4.1f", "" );
+	bli_zprintm( "f (initial state):", m, m, f, rs, cs, "% 4.3f", "" );
 
 	// mkherm on a real matrix behaves the same as mksymm, as there are no
 	// imaginary elements to conjugate.
 	bli_zmkherm( BLIS_UPPER, m, f, rs, cs );
 
-	bli_zprintm( "f (after mkherm on lower triangle):", m, m, f, rs, cs, "%4.1f", "" );
+	bli_zprintm( "f (after mkherm on lower triangle):", m, m, f, rs, cs, "% 4.3f", "" );
 
 
 	//
@@ -254,14 +254,14 @@ int main( int argc, char** argv )
 	// Randomize the lower triangle of 'g'.
 	bli_drandm( 0, BLIS_LOWER, m, m, g, rs, cs );
 
-	bli_dprintm( "g (initial state):", m, m, g, rs, cs, "%4.1f", "" );
+	bli_dprintm( "g (initial state):", m, m, g, rs, cs, "% 4.3f", "" );
 
 	// mktrim does not explicitly copy any data, since presumably the stored
 	// triangle already contains the data of interest. However, mktrim does
 	// explicitly writes zeros to the unstored region.
 	bli_dmktrim( BLIS_LOWER, m, g, rs, cs );
 
-	bli_dprintm( "g (after mktrim):", m, m, g, rs, cs, "%4.1f", "" );
+	bli_dprintm( "g (after mktrim):", m, m, g, rs, cs, "% 4.3f", "" );
 
 
 	// Free the memory obtained via malloc().


### PR DESCRIPTION
- This avoids possible mis-interpretation of computation results printed on stdout (thanks Mason McBride for reporting it in #864)