### PR TITLE
Fix to prevent is_win flag setting with clang on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -2739,14 +2739,8 @@ check_build_tools()
 	                  "C compiler" "yes" found_cc
 
 	# Also check the compiler to see if we are (cross-)compiling for Windows
-	if [ "${os_name}" == "Darwin" ] && "${found_cc}" --version 2> /dev/null | grep -q clang; then
-		if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep TARGET_OS_WIN32 | grep -q 1; then
-			is_win=yes
-		fi
-	else
-		if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep -q _WIN32; then
-			is_win=yes
-		fi
+	if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep -qE "#define\s+_WIN32"; then
+		is_win=yes
 	fi
 	is_msvc=no
 	if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep -q _MSC_VER; then

--- a/configure
+++ b/configure
@@ -2739,8 +2739,14 @@ check_build_tools()
 	                  "C compiler" "yes" found_cc
 
 	# Also check the compiler to see if we are (cross-)compiling for Windows
-	if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep -q _WIN32; then
-		is_win=yes
+	if [ "${os_name}" == "Darwin" ] && "${found_cc}" --version 2> /dev/null | grep -q clang; then
+		if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep TARGET_OS_WIN32 | grep -q 1; then
+			is_win=yes
+		fi
+	else
+		if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep -q _WIN32; then
+			is_win=yes
+		fi
 	fi
 	is_msvc=no
 	if "${found_cc}" -dM -E - < /dev/null 2> /dev/null | grep -q _MSC_VER; then


### PR DESCRIPTION
This pull request fixes an issue where `libblis.dylib` is not created when built with clang on macOS. My execution environment and the observed problem are as follows:

```
$ gcc --version
Apple clang version 17.0.0 (clang-1700.0.13.3)
Target: arm64-apple-darwin24.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
$ ~/blis
$ ./configure auto
$ cat config.mk | grep IS_WIN
IS_WIN            := yes
$ make
$ ls -1 lib/firestorm/
libblis.4.dylib
libblis.a
```

The cause of the problem is that the `is_win` flag is incorrectly set to `yes` in the configure script, leading to an incorrect filename being used. On macOS with clang, whether the environment is Windows or not is indicated by the value of the `TARGET_OS_WIN32` macro:

```
$ gcc -dM -E - < /dev/null 2> /dev/null | grep "WIN32"
#define TARGET_OS_WIN32 0
```

The configure script determines the `is_win` flag by checking for the presence of the string `"WIN32"`. This caused a false positive in the case of clang on macOS. This pull request modifies it so that the determination is made based on the value of `TARGET_OS_WIN32`.