### PR TITLE
Allow runtime configuration selection by name.

### DIFF
--- a/ci/do_sde.sh
+++ b/ci/do_sde.sh
@@ -32,7 +32,8 @@ tar xvf $SDE_TARBALL
 make -j2 testsuite-bin blastest-bin
 
 for ARCH in penryn sandybridge haswell skx knl piledriver steamroller excavator zen generic; do
-    export BLIS_ARCH_TYPE=-1
+    # The leading space is for stress testing
+    export BLIS_ARCH_TYPE=" -1"
 
     if [ "$ARCH" = "knl" ]; then
         TESTSUITE_WRAPPER="$SDE -knl --"

--- a/ci/do_sde.sh
+++ b/ci/do_sde.sh
@@ -41,23 +41,23 @@ for ARCH in penryn sandybridge haswell skx knl piledriver steamroller excavator 
         # Instead, use the CPUID values for haswell, but force BLIS to use the
         # sandybridge configuration.
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
-        export BLIS_ARCH_TYPE=4
+        export BLIS_ARCH_TYPE="sandybridge"
     elif [ "$ARCH" = "piledriver" ]; then
         # We used to "patch" ld.so and libm to remove CPUID checks so that glibc
         # wouldn't try to use instructions not supported by SDE (FMA4). That no
         # longer works, so test Piledriver/Steamroller/Excavator as haswell
         # but with the configuration forced via environment variable.
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
-        export BLIS_ARCH_TYPE=11
+        export BLIS_ARCH_TYPE="piledriver"
     elif [ "$ARCH" = "steamroller" ]; then
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
-        export BLIS_ARCH_TYPE=10
+        export BLIS_ARCH_TYPE="steamroller"
     elif [ "$ARCH" = "excavator" ]; then
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
-        export BLIS_ARCH_TYPE=9
+        export BLIS_ARCH_TYPE="excavator"
     elif [ "$ARCH" = "generic" ]; then
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/haswell.def --"
-        export BLIS_ARCH_TYPE=33
+        export BLIS_ARCH_TYPE="generic"
     else
         TESTSUITE_WRAPPER="$SDE -cpuid_in $DIST_PATH/ci/cpuid/$ARCH.def --"
     fi

--- a/docs/BuildSystem.md
+++ b/docs/BuildSystem.md
@@ -65,12 +65,14 @@ Configurations are described in detail in the [Configuration Guide](Configuratio
 Generally speaking, a configuration consists of several files that reside in a sub-directory of the `config` directory. To see a list of the available configurations, you may inspect this directory, or run `configure` with no arguments. Here are the current (as of this writing) contents of the `config` directory:
 ```
 $ ls config
-amd64      cortexa15  excavator  intel64  old         power7       template
-bgq        cortexa57  generic    knc      penryn      sandybridge  zen
-bulldozer  cortexa9   haswell    knl      piledriver  steamroller
+a64fx        arm32        cortexa15    firestorm    knl          power10      rv64i        skx          zen
+altra        arm64        cortexa53    generic      old          power7       rv64iv       steamroller  zen2
+altramax     armsve       cortexa57    haswell      penryn       power9       sandybridge  template     zen3
+amd64        bgq          cortexa9     intel64      piledriver   rv32i        sifive_rvv   thunderx2
+amd64_legacy bulldozer    excavator    knc          power        rv32iv       sifive_x280  x86_64
 ```
 There is one additional configuration available that is not present in the `config` directory, and that is `auto`.
-By targeting the `auto` configuration (i.e., `./configure auto`), the user is requesting that `configure` select a configuration automatically based on the detected features of the processor.
+By targeting the `auto` configuration (i.e., `./configure auto`), the user is requesting that `configure` select a configuration automatically based on the detected features of the processor. Many of the configurations cover multiple hardware types, e.g. `x86_64` covers all Intel and AMD architectures. While the appropriate member of the configuration family is detected at runtime based on your hardware, this choice can be overridden by exporting the `BLIS_ARCH_TYPE` environment variable, e.g. `export BLIS_ARCH_TYPE=haswell`.
 
 Another special configuration (one that, unlike `auto`, _is_ present in `config`) is the `generic` configuration. This configuration, like its name suggests, is architecture-agnostic and may be targeted in virtually any environment that supports the minimum build requirements of BLIS. The `generic` configuration uses a set of built-in, portable reference kernels (written in C99) that should work without modification on most, if not all, architectures. These reference kernels, however, should be expected to yield relatively low performance since they do not employ any architecture-specific optimizations beyond those the compiler provides automatically. (Historical note: The `generic` configuration corresponds to the `reference` configuration of previous releases of BLIS.)
 

--- a/frame/base/bli_arch.c
+++ b/frame/base/bli_arch.c
@@ -130,6 +130,20 @@ arch_t bli_arch_query_id_impl( void )
 	dim_t req_id = bli_env_get_var( "BLIS_ARCH_TYPE", -1 );
 	const char* req_env = bli_env_get_str( "BLIS_ARCH_TYPE" );
 
+	// If the user specifically goes out of their way to define
+	// BLIS_ARCH_TYPE=-1, then we have to handle that specially.
+	if ( req_env )
+	{
+		// strtol allows leading whitespace
+		const char* p = req_env;
+		while ( isspace( *p ) ) p++;
+
+		if ( strcmp( p, "-1" ) == 0 )
+		{
+			req_env = NULL;
+		}
+	}
+
 	// When this file is being compiled as part of the configure script's
 	// hardware auto-detection driver, we avoid calling the bli_check APIs
 	// so that we aren't required to include those symbols in the executable.

--- a/frame/base/bli_arch.c
+++ b/frame/base/bli_arch.c
@@ -128,14 +128,28 @@ arch_t bli_arch_query_id_impl( void )
 	// Check the environment variable BLIS_ARCH_TYPE to see if the user
 	// requested that we use a specific subconfiguration.
 	dim_t req_id = bli_env_get_var( "BLIS_ARCH_TYPE", -1 );
+	const char* req_env = bli_env_get_str( "BLIS_ARCH_TYPE" );
 
 	// When this file is being compiled as part of the configure script's
 	// hardware auto-detection driver, we avoid calling the bli_check APIs
 	// so that we aren't required to include those symbols in the executable.
 #ifndef BLIS_CONFIGURETIME_CPUID
-	if ( req_id != -1 )
+	if ( req_env )
 	{
 		// BLIS_ARCH_TYPE was set. Cautiously check whether its value is usable.
+
+		// A non-numerical value was supplied. Check if it matches one of the
+		// configuration names.
+		if ( req_id == -1 )
+		{
+			for ( arch_t i = 0; i < BLIS_NUM_ARCHS; i++ )
+			{
+				if ( strcasecmp( req_env, bli_arch_string( i ) ) == 0 )
+				{
+					req_id = i;
+				}
+			}
+		}
 
 		// If req_id was set to an invalid arch_t value (ie: outside the range
 		// [0,BLIS_NUM_ARCHS-1]), output an error message and abort.

--- a/frame/base/bli_env.c
+++ b/frame/base/bli_env.c
@@ -78,7 +78,15 @@ gint_t bli_env_get_var( const char* env, gint_t fallback )
 	{
 		// If there was no error, convert the string to an integer and
 		// prepare to return that integer.
-		r_val = ( gint_t )strtol( str, NULL, 10 );
+		char* end;
+		r_val = ( gint_t )strtol( str, &end, 10 );
+
+		// If no characters were read, or if there are additional character
+		// after any digits, revert to the fallback value.
+		if ( str == end || *end != '\0' )
+		{
+			r_val = fallback;
+		}
 	}
 	else
 	{

--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -50,7 +50,13 @@
 #include <float.h>
 #include <errno.h>
 #include <ctype.h>
-#include <strings.h>
+
+#ifdef _MSC_VER
+  #define strncasecmp _strnicmp
+  #define strcasecmp _stricmp
+#else
+  #include <strings.h>
+#endif
 
 // Determine the compiler (hopefully) and define conveniently named macros
 // accordingly.

--- a/frame/include/bli_system.h
+++ b/frame/include/bli_system.h
@@ -50,6 +50,7 @@
 #include <float.h>
 #include <errno.h>
 #include <ctype.h>
+#include <strings.h>
 
 // Determine the compiler (hopefully) and define conveniently named macros
 // accordingly.


### PR DESCRIPTION
Details:
- The `BLIS_ARCH_TYPE` environment variable currently only allows numerical values, which requires reading the source to select the appropriate value (and these values can change over time).
- Implement selection by name (case insensitive), based on the names returned by `blis_arch_string` (typically the same as the folder name in the `config` directory).