### PR TITLE
Fix an issue with 1m and negative strides.

### DIFF
--- a/ref_kernels/ind/bli_gemm1m_ref.c
+++ b/ref_kernels/ind/bli_gemm1m_ref.c
@@ -92,6 +92,7 @@ void PASTEMAC(chabr,chcr,opname,arch,suf) \
 \
 	if ( !bli_teq0s( chabr, *alpha_i ) || \
 	     !bli_teq0s( chcr, *beta_i ) || \
+	     rs_c <= 0 || cs_c <= 0 || \
 	     !bli_is_preferentially_stored( rs_c, cs_c, row_pref ) || \
 	     !PASTEMAC(chabr,chcr,same) ) \
 	{ \

--- a/ref_kernels/ind/bli_gemm_ccr_ref.c
+++ b/ref_kernels/ind/bli_gemm_ccr_ref.c
@@ -91,6 +91,7 @@ void PASTEMAC(chabr,chcr,opname,arch,suf) \
 \
 	if ( !bli_teq0s( chabr, *alpha_i ) || \
 	     !bli_teq0s( chcr, *beta_i ) || \
+	     rs_c <= 0 || cs_c <= 0 || \
 	     !bli_is_preferentially_stored( rs_c, cs_c, row_pref ) || \
 	     !PASTEMAC(chab,chc,same) ) \
 	{ \


### PR DESCRIPTION
Details:
- In the reference `gemm1m` kernel, the code checks if the matrix is "preferentially stored", meaning columns (rows) are contiguous if the real-domain microkernel is column- (row-)preferential.
- However, `bli_is_preferentially_stored` checks for contiguity based on the *absolute value* of the row and column strides, such that a row or column stride of -1 is indicated as preferentially stored.
- Passing the stride of -1 to the real-domain kernel then essentially causes elements along each row or column to be written in opposite order. This causes problems for 1m because a) imaginary elements are written before real elements, and b) the provided pointer points to the last *complex* element, which is one real element too low and can then cause an out-of-bounds error when the last real-domain element is written to an address preceding the row or column storage.
- This commit adds a check for positivity of `rs_c` and `cs_c` in `bli_gemm1m_ref` and `bli_gemm_ccr_ref` in order to pass through directly to the real-domain microkernel. Technically, only a -1 stride along the preferential storage direction will lead to the errors noted above, but who know what other bad things might happen for other negative strides (and god forbid you put in a stride of 0...).