### PR TITLE
Apply temporary fix for gcc 15.

### DIFF
--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8m.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8m.c
@@ -33,6 +33,13 @@
 
 */
 
+// This avoids a known issue with GCC15 ("error: bp cannot be used in asm here", #845).
+// Only check for version 15 since this may be fixed in 16 (**fingers crossed**), and also
+// make sure the compiler isn't clang since it also confusingly defines __GNUC__
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 15
+#pragma GCC optimize("-fno-tree-slp-vectorize")
+#endif
+
 #include "blis.h"
 
 #define BLIS_ASM_SYNTAX_ATT

--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8n.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8n.c
@@ -33,6 +33,13 @@
 
 */
 
+// This avoids a known issue with GCC15 ("error: bp cannot be used in asm here", #845).
+// Only check for version 15 since this may be fixed in 16 (**fingers crossed**), and also
+// make sure the compiler isn't clang since it also confusingly defines __GNUC__
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 15
+#pragma GCC optimize("-fno-tree-slp-vectorize")
+#endif
+
 #include "blis.h"
 
 #define BLIS_ASM_SYNTAX_ATT

--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_s6x16m.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_s6x16m.c
@@ -33,6 +33,13 @@
 
 */
 
+// This avoids a known issue with GCC15 ("error: bp cannot be used in asm here", #845).
+// Only check for version 15 since this may be fixed in 16 (**fingers crossed**), and also
+// make sure the compiler isn't clang since it also confusingly defines __GNUC__
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 15
+#pragma GCC optimize("-fno-tree-slp-vectorize")
+#endif
+
 #include "blis.h"
 
 #define BLIS_ASM_SYNTAX_ATT

--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_s6x16n.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_s6x16n.c
@@ -33,6 +33,13 @@
 
 */
 
+// This avoids a known issue with GCC15 ("error: bp cannot be used in asm here", #845).
+// Only check for version 15 since this may be fixed in 16 (**fingers crossed**), and also
+// make sure the compiler isn't clang since it also confusingly defines __GNUC__
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 15
+#pragma GCC optimize("-fno-tree-slp-vectorize")
+#endif
+
 #include "blis.h"
 
 #define BLIS_ASM_SYNTAX_ATT


### PR DESCRIPTION
Details:
- As reported in #845, gcc 15 fails to build the haswell gemmsup kernels due to the use of rbp.
- As a temporary fix, disable slp-tree-vectorization in just the affected files.
- Thanks @loveshack for reporting and @chillenb for the suggested fix.
- Eventually, the kernels should be rewritten to avoid using rbp.