### PR TITLE
Remove unnecessary OpenMP include.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -109,6 +109,7 @@ but many others have contributed code, ideas, and feedback, including
   Pradeep Rao              @pradeeptrgit              (AMD)
   Aleksei Rechinskii
   Leick Robinson           @LeickR                    (Oracle)
+  Melven Roehrig-Zoellner  @melven
   Karl Rupp                @karlrupp
   Martin Schatz                                       (The University of Texas at Austin)
   Nico Schlömer            @nschloe

--- a/frame/3/bli_l3_decor.c
+++ b/frame/3/bli_l3_decor.c
@@ -35,6 +35,10 @@
 
 #include "blis.h"
 
+#if BLIS_ENABLE_OPENMP
+#include <omp.h>
+#endif
+
 struct l3_decor_params_s
 {
 	const obj_t*   a;

--- a/frame/thread/bli_thrcomm_openmp.c
+++ b/frame/thread/bli_thrcomm_openmp.c
@@ -146,10 +146,10 @@ barrier_t* bli_thrcomm_tree_barrier_create( int num_threads, int arity, barrier_
 			kid->dad = me;
 
 			leaf_index += threads_this_kid;
-		}  
+		}
 		me->count = arity;
 		me->arity = arity;
-	}  
+	}
 
 	return me;
 }

--- a/frame/thread/bli_thrcomm_openmp.h
+++ b/frame/thread/bli_thrcomm_openmp.h
@@ -40,8 +40,6 @@
 // enabled.
 #ifdef BLIS_ENABLE_OPENMP
 
-#include <omp.h>
-
 // OpenMP-specific function prototypes.
 void bli_thrcomm_init_openmp( dim_t nt, thrcomm_t* comm );
 void bli_thrcomm_cleanup_openmp( thrcomm_t* comm );

--- a/frame/thread/bli_thread_openmp.c
+++ b/frame/thread/bli_thread_openmp.c
@@ -36,6 +36,8 @@
 
 #ifdef BLIS_ENABLE_OPENMP
 
+#include <omp.h>
+
 void bli_thread_launch_openmp( dim_t n_threads, thread_func_t func, const void* params )
 {
 	const timpl_t ti = BLIS_OPENMP;

--- a/kernels/bgq/1/bli_dotv_bgq_int.c
+++ b/kernels/bgq/1/bli_dotv_bgq_int.c
@@ -34,6 +34,8 @@
 
 #include "blis.h"
 
+#include <omp.h>
+
 void bli_ddotv_bgq_int
      (
              conj_t  conjx,


### PR DESCRIPTION
Details:
- Previously, `<omp.h>` was included in `bli_thrcomm_openmp.h` so that the framework could access the necessary OpenMP functions.
- As @melven reported (#873), this causes issues when `blis.h` is included in C++ code since the `<omp.h>` include happens with `extern "C"`.
- Move the include from the header to the necessary .c files so that it does not "pollute" `blis.h`.