### PR TITLE
Make configure/make/make install work with spaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ config.mk
 bli_config.h
 bli_addon.h
 blis.pc
+.dist_path
+.install_libdir
+.install_incdir
+.install_sharedir
 
 # -- monolithic headers --
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@
         check checkblas \
         checkblis checkblis-fast checkblis-md checkblis-salt \
         install-headers install-helper-headers install-libs install-lib-symlinks \
+        make-symlinks make-install-symlinks \
         showconfig \
         clean cleanmk cleanh cleanlib distclean \
         cleantest cleanblastest cleanblistest \
@@ -524,7 +525,7 @@ clean: cleanh cleanlib
 
 # --- Environment check rules ---
 
-check-env: check-env-make-defs check-env-fragments check-env-mk
+check-env: check-env-make-defs check-env-fragments check-env-mk make-symlinks
 
 check-env-mk:
 ifeq ($(CONFIG_MK_PRESENT),no)
@@ -540,6 +541,23 @@ check-env-make-defs: check-env-fragments
 ifeq ($(ALL_MAKE_DEFS_MK_PRESENT),no)
 	$(error Cannot proceed: Some make_defs.mk files not found or mislabeled!)
 endif
+
+make-symlinks:
+	@rm -f .dist_path
+	@ln -s "$(DIST_PATH_REAL)" .dist_path
+
+make-install-symlinks:
+	@rm -f .install_libdir
+	@rm -f .install_incdir
+	@rm -f .install_sharedir
+	@ln -s "$(INSTALL_LIBDIR_REAL)" .install_libdir
+	@ln -s "$(INSTALL_INCDIR_REAL)" .install_incdir
+	@ln -s "$(INSTALL_SHAREDIR_REAL)" .install_sharedir
+	@mkdir -p "$(INSTALL_LIBDIR_REAL)"
+	@mkdir -p "$(INSTALL_INCDIR_REAL)"
+	@mkdir -p "$(INSTALL_SHAREDIR_REAL)"
+
+$(CONFIG_MK_FILE) $(ALL_H99_FILES): check-env
 
 
 # --- Shared/dynamic libblis symbol file creation/refresh ---
@@ -1085,23 +1103,23 @@ endif
 install-headers: check-env $(HEADERS_INSTALLED) install-helper-headers
 
 # Rule for installing main headers.
-$(MK_INCL_DIR_INST)/%.h: $(BASE_INC_PATH)/%.h $(CONFIG_MK_FILE)
+$(MK_INCL_DIR_INST)/%.h: $(BASE_INC_PATH)/%.h $(CONFIG_MK_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(dir $(@))
 	$(INSTALL) -m 0644 $(<) $(dir $(@))
 else
 	@$(MKDIR) $(dir $(@))
-	@echo "Installing $(notdir $(<)) into $(dir $(@))/"
+	@echo "Installing $(notdir $(<)) into $(subst .install_incdir,$(INSTALL_INCDIR_REAL),$(dir $(@)))"
 	@$(INSTALL) -m 0644 $(<) $(dir $(@))
 endif
 
-$(MK_INCL_DIR_INST)/%.hh: $(VEND_CPP_PATH)/%.hh $(CONFIG_MK_FILE)
+$(MK_INCL_DIR_INST)/%.hh: $(VEND_CPP_PATH)/%.hh $(CONFIG_MK_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(dir $(@))
 	$(INSTALL) -m 0644 $(<) $(dir $(@))
 else
 	@$(MKDIR) $(dir $(@))
-	@echo "Installing $(notdir $(<)) into $(dir $(@))/"
+	@echo "Installing $(notdir $(<)) into $(subst .install_incdir,$(INSTALL_INCDIR_REAL),$(dir $(@)))"
 	@$(INSTALL) -m 0644 $(<) $(dir $(@))
 endif
 
@@ -1109,13 +1127,11 @@ install-helper-headers: check-env $(HELP_HEADERS_INSTALLED)
 
 # A rule to install a helper header file.
 define make-helper-header-rule
-$(INSTALL_INCDIR)/$(notdir $(1)): $(BUILD_PATH)/$(notdir $(1)) $(CONFIG_MK_FILE)
+$(INSTALL_INCDIR)/$(notdir $(1)): $(BUILD_PATH)/$(notdir $(1)) $(CONFIG_MK_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
-	$(MKDIR) $(INSTALL_INCDIR)
 	$(INSTALL) -m 0644 $$(<) $$(@)
 else
-	@$(MKDIR) $(INSTALL_INCDIR)
-	@echo "Installing $$(@F) helper header into $(INSTALL_INCDIR)/"
+	@echo "Installing $$(@F) helper header into $(INSTALL_INCDIR_REAL)/"
 	@$(INSTALL) -m 0644 $$(<) $$(@)
 endif
 endef
@@ -1127,7 +1143,7 @@ $(foreach h, $(HELP_HEADERS_TO_INSTALL), $(eval $(call make-helper-header-rule,$
 
 install-share: check-env $(MK_SHARE_DIR_INST) $(PC_SHARE_DIR_INST)
 
-$(MK_SHARE_DIR_INST): $(CONFIGURE_FILE) $(FRAGS_TO_INSTALL) $(PLUGIN_FRAGS_TO_INSTALL) $(CONFIG_DIR)/$(CONFIG_NAME)/$(MAKE_DEFS_FILE)
+$(MK_SHARE_DIR_INST): $(CONFIGURE_FILE) $(FRAGS_TO_INSTALL) $(PLUGIN_FRAGS_TO_INSTALL) $(CONFIG_DIR)/$(CONFIG_NAME)/$(MAKE_DEFS_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(@)
 	$(MKDIR) $(@)/plugin
@@ -1148,12 +1164,12 @@ ifeq ($(ENABLE_VERBOSE),yes)
 else
 	@$(MKDIR) $(@)
 	@$(MKDIR) $(@)/plugin
-	@echo "Installing $(notdir $(FRAGS_TO_INSTALL)) into $(@)/"
+	@echo "Installing $(notdir $(FRAGS_TO_INSTALL)) into $(INSTALL_SHAREDIR_REAL)/"
 	@$(INSTALL) -m 0755 $(filter %.sh,$(FRAGS_TO_INSTALL)) $(@)
 	@$(INSTALL) -m 0644 $(filter-out %.sh,$(FRAGS_TO_INSTALL)) $(@)
-	@echo "Installing $(notdir $(PLUGIN_FRAGS_TO_INSTALL)) into $(@)/plugin/"
+	@echo "Installing $(notdir $(PLUGIN_FRAGS_TO_INSTALL)) into $(INSTALL_SHAREDIR_REAL)/plugin/"
 	@$(INSTALL) -m 0644 $(PLUGIN_FRAGS_TO_INSTALL) $(@)/plugin
-	@echo "Installing $(CONFIGURE_FILE) into $(@)/configure-plugin"
+	@echo "Installing $(CONFIGURE_FILE) into $(INSTALL_SHAREDIR_REAL)/configure-plugin"
 	@$(INSTALL) -m 0755 $(CONFIGURE_FILE) $(@)/configure-plugin
 #	@$(MKDIR) -p $(@)/$(CONFIG_DIR)/$(CONFIG_NAME)#\
 #	@echo "Installing $(CONFIG_DIR)/$(CONFIG_NAME)/$(MAKE_DEFS_FILE) into $(@)/$(CONFIG_DIR)/$(CONFIG_NAME)"
@@ -1161,16 +1177,16 @@ else
 #	               $(@)/$(CONFIG_DIR)/$(CONFIG_NAME)/
 	@for THIS_CONFIG in $(FULL_CONFIG_LIST); do \
 		$(MKDIR) -p $(@)/$(CONFIG_DIR)/$$THIS_CONFIG; \
-		echo "Installing $(CONFIG_DIR)/$$THIS_CONFIG/$(MAKE_DEFS_FILE) into $(@)/$(CONFIG_DIR)/$$THIS_CONFIG"; \
+		echo "Installing $(CONFIG_DIR)/$$THIS_CONFIG/$(MAKE_DEFS_FILE) into $(INSTALL_SHAREDIR_REAL)/$(CONFIG_DIR)/$$THIS_CONFIG"; \
 		$(INSTALL) -m 0644 $(CONFIG_DIR)/$$THIS_CONFIG/$(MAKE_DEFS_FILE) \
 		              $(@)/$(CONFIG_DIR)/$$THIS_CONFIG; \
-		echo "Installing $(CONFIG_DIR)/$$THIS_CONFIG/bli_kernel_defs_$$THIS_CONFIG.h into $(@)/$(CONFIG_DIR)/$$THIS_CONFIG"; \
+		echo "Installing $(CONFIG_DIR)/$$THIS_CONFIG/bli_kernel_defs_$$THIS_CONFIG.h into $(INSTALL_SHAREDIR_REAL)/$(CONFIG_DIR)/$$THIS_CONFIG"; \
 		$(INSTALL) -m 0644 $(CONFIG_DIR)/$$THIS_CONFIG/bli_kernel_defs_$$THIS_CONFIG.h \
 		              $(@)/$(CONFIG_DIR)/$$THIS_CONFIG; \
 	done
 endif
 
-$(PC_SHARE_DIR_INST): $(PC_IN_FILE)
+$(PC_SHARE_DIR_INST): $(PC_IN_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
 	$(MKDIR) $(@)
 	$(shell cat "$(PC_IN_FILE)" \
@@ -1184,7 +1200,7 @@ ifeq ($(ENABLE_VERBOSE),yes)
 	$(INSTALL) -m 0644 $(PC_OUT_FILE) $(@)
 else
 	@$(MKDIR) $(@)
-	@echo "Installing $(PC_OUT_FILE) into $(@)/"
+	@echo "Installing $(PC_OUT_FILE) into $(subst .install_sharedir,$(INSTALL_SHAREDIR_REAL),$(@))"
 	@$(shell cat "$(PC_IN_FILE)" \
 	| sed -e "s#@PACKAGE_VERSION@#$(VERSION)#g" \
 	| sed -e "s#@prefix@#$(prefix)#g" \
@@ -1201,13 +1217,11 @@ endif
 install-libs: check-env $(MK_LIBS_INST)
 
 # Install static library.
-$(INSTALL_LIBDIR)/%.a: $(BASE_LIB_PATH)/%.a $(CONFIG_MK_FILE)
+$(INSTALL_LIBDIR)/%.a: $(BASE_LIB_PATH)/%.a $(CONFIG_MK_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
-	$(MKDIR) $(@D)
 	$(INSTALL) -m 0644 $< $@
 else
-	@echo "Installing $(@F) into $(INSTALL_LIBDIR)/"
-	@$(MKDIR) $(@D)
+	@echo "Installing $(@F) into $(INSTALL_LIBDIR_REAL)/"
 	@$(INSTALL) -m 0644 $< $@
 endif
 
@@ -1217,36 +1231,30 @@ endif
 ifeq ($(IS_WIN),no)
 
 # Linux/OSX library (.so OR .dylib) installation rules.
-$(INSTALL_LIBDIR)/%.$(LIBBLIS_SO_MMB_EXT): $(BASE_LIB_PATH)/%.$(SHLIB_EXT) $(CONFIG_MK_FILE)
+$(INSTALL_LIBDIR)/%.$(LIBBLIS_SO_MMB_EXT): $(BASE_LIB_PATH)/%.$(SHLIB_EXT) $(CONFIG_MK_FILE) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
-	$(MKDIR) $(@D)
 	$(INSTALL) -m 0755 $< $@
 else
-	@echo "Installing $(@F) into $(INSTALL_LIBDIR)/"
-	@$(MKDIR) $(@D)
+	@echo "Installing $(@F) into $(INSTALL_LIBDIR_REAL)/"
 	@$(INSTALL) -m 0755 $< $@
 endif
 
 else # ifeq ($(IS_WIN),yes)
 
 # Windows library (.dll and .lib) installation rules.
-$(INSTALL_LIBDIR)/%.$(SHLIB_EXT): $(BASE_LIB_PATH)/%.$(SHLIB_EXT)
+$(INSTALL_LIBDIR)/%.$(SHLIB_EXT): $(BASE_LIB_PATH)/%.$(SHLIB_EXT) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
-	@$(MKDIR) $(@D)
 	@$(INSTALL) -m 0644 $(BASE_LIB_PATH)/$(@F) $@
 else
-	@echo "Installing $(@F) into $(INSTALL_LIBDIR)/"
-	@$(MKDIR) $(@D)
+	@echo "Installing $(@F) into $(INSTALL_LIBDIR_REAL)/"
 	@$(INSTALL) -m 0644 $(BASE_LIB_PATH)/$(@F) $@
 endif
 
-$(INSTALL_LIBDIR)/%.$(LIBBLIS_SO_MAJ_EXT): $(BASE_LIB_PATH)/%.$(LIBBLIS_SO_MAJ_EXT)
+$(INSTALL_LIBDIR)/%.$(LIBBLIS_SO_MAJ_EXT): $(BASE_LIB_PATH)/%.$(LIBBLIS_SO_MAJ_EXT) make-install-symlinks
 ifeq ($(ENABLE_VERBOSE),yes)
-	@$(MKDIR) $(@D)
 	@$(INSTALL) -m 0644 $(BASE_LIB_PATH)/$(@F) $@
 else
-	@echo "Installing $(@F) into $(INSTALL_LIBDIR)/"
-	@$(MKDIR) $(@D)
+	@echo "Installing $(@F) into $(INSTALL_LIBDIR_REAL)/"
 	@$(INSTALL) -m 0644 $(BASE_LIB_PATH)/$(@F) $@
 endif
 
@@ -1265,7 +1273,7 @@ ifeq ($(ENABLE_VERBOSE),yes)
 	$(SYMLINK) $(<F) $(@F)
 	$(MV) $(@F) $(INSTALL_LIBDIR)/
 else
-	@echo "Installing symlink $(@F) into $(INSTALL_LIBDIR)/"
+	@echo "Installing symlink $(@F) into $(INSTALL_LIBDIR_REAL)/"
 	@$(SYMLINK) $(<F) $(@F)
 	@$(MV) $(@F) $(INSTALL_LIBDIR)/
 endif
@@ -1276,7 +1284,7 @@ ifeq ($(ENABLE_VERBOSE),yes)
 	$(SYMLINK) $(<F) $(@F)
 	$(MV) $(@F) $(INSTALL_LIBDIR)/
 else
-	@echo "Installing symlink $(@F) into $(INSTALL_LIBDIR)/"
+	@echo "Installing symlink $(@F) into $(INSTALL_LIBDIR_REAL)/"
 	@$(SYMLINK) $(<F) $(@F)
 	@$(MV) $(@F) $(INSTALL_LIBDIR)/
 endif
@@ -1312,6 +1320,7 @@ showconfig: check-env
 cleanmk:
 ifeq ($(IS_CONFIGURED),yes)
 ifeq ($(ENABLE_VERBOSE),yes)
+	- $(RM_F) .dist_path .install_libdir .install_incdir .install_sharedir
 	- $(FIND) $(CONFIG_FRAG_PATH) -name "$(FRAGMENT_MK)" | $(XARGS) $(RM_F)
 	- $(FIND) $(FRAME_FRAG_PATH) -name "$(FRAGMENT_MK)" | $(XARGS) $(RM_F)
 	- $(FIND) $(REFKERN_FRAG_PATH) -name "$(FRAGMENT_MK)" | $(XARGS) $(RM_F)
@@ -1323,6 +1332,8 @@ ifneq ($(SANDBOX),)
 	- $(FIND) $(SANDBOX_FRAG_PATH) -name "$(FRAGMENT_MK)" | $(XARGS) $(RM_F)
 endif
 else
+	@echo "Removing helper symlinks"
+	@- $(RM_F) .dist_path .install_libdir .install_incdir .install_sharedir
 	@echo "Removing makefile fragments from $(CONFIG_FRAG_PATH)"
 	@- $(FIND) $(CONFIG_FRAG_PATH) -name "$(FRAGMENT_MK)" | $(XARGS) $(RM_F)
 	@echo "Removing makefile fragments from $(FRAME_FRAG_PATH)"

--- a/Makefile
+++ b/Makefile
@@ -543,16 +543,16 @@ ifeq ($(ALL_MAKE_DEFS_MK_PRESENT),no)
 endif
 
 make-symlinks:
-	@rm -f .dist_path
-	@ln -s "$(DIST_PATH_REAL)" .dist_path
+#	@rm -f .dist_path
+#	@ln -s "$(DIST_PATH_REAL)" .dist_path
 
 make-install-symlinks:
-	@rm -f .install_libdir
-	@rm -f .install_incdir
-	@rm -f .install_sharedir
-	@ln -s "$(INSTALL_LIBDIR_REAL)" .install_libdir
-	@ln -s "$(INSTALL_INCDIR_REAL)" .install_incdir
-	@ln -s "$(INSTALL_SHAREDIR_REAL)" .install_sharedir
+#	@rm -f .install_libdir
+#	@rm -f .install_incdir
+#	@rm -f .install_shredir
+#	@ln -s "$(INSTALL_LIBDIR_REAL)" .install_libdir
+#	@ln -s "$(INSTALL_INCDIR_REAL)" .install_incdir
+#	@ln -s "$(INSTALL_SHAREDIR_REAL)" .install_sharedir
 	@mkdir -p "$(INSTALL_LIBDIR_REAL)"
 	@mkdir -p "$(INSTALL_INCDIR_REAL)"
 	@mkdir -p "$(INSTALL_SHAREDIR_REAL)"

--- a/blastest/src/fortran/run-f2c.sh
+++ b/blastest/src/fortran/run-f2c.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # This script converts netlib [sdcz]blat[123].f files from Fortran to C.
-# 
+#
 
-# Start by converting to C with f2c. 
+# Start by converting to C with f2c.
 # Options used:
 #  -A  Produce ANSI C (instead of old-style C).
 #  -R  Do  not promote REAL functions and operations to DOUBLE PRECISION.
 #  -a  Make local variables automatic rather than static (unless they
 #      appear in a DATA, EQUIVALENCE, NAMELIST, or SAVE statement).
-f2c -A -R -a *.f
+f2c -A -R -a ./*.f
 
 # Add 'const' qualifier to certain function delcarations so they match
 # the prototypes taken from libf2c.
@@ -27,7 +27,7 @@ recursive-sed.sh -c "s/VOID/void/g" -p "*.c"
 # Add prefix to calls to epsilon_() based on the file in which the
 # function is called. [sd]_epsilon_() are not libf2c functions, but
 # they are present in the local subset of libf2c used to link the
-# BLAS testsuite drivers. 
+# BLAS testsuite drivers.
 recursive-sed.sh -c "s/epsilon_/s_epsilon_/g" -p "[sc]*.c"
 recursive-sed.sh -c "s/epsilon_/d_epsilon_/g" -p "[dz]*.c"
 
@@ -61,4 +61,3 @@ recursive-sed.sh -c "s/ void zdotc_(doublecomplex \*,/${subst1}doublecomplex zdo
 recursive-sed.sh -c "s/ void zdotu_(doublecomplex \*,/${subst1}doublecomplex zdotu_(${subst2}/g" -p "z*1.c"
 recursive-sed.sh -c "s/\(.*\)zdotc_(\&z__1,/${subst1}\1z__1 = zdotc_(${subst2}\1/g" -p "z*1.c"
 recursive-sed.sh -c "s/\(.*\)zdotu_(\&z__1,/${subst1}\1z__1 = zdotu_(${subst2}\1/g" -p "z*1.c"
-

--- a/build/bump-version.sh
+++ b/build/bump-version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -42,13 +42,13 @@
 print_usage()
 {
 	#local script_name
-	
+
 	# Get the script name
 	#script_name=${0##*/}
-	
+
 	# Echo usage info
 	echo " "
-	echo " "$script_name
+	echo " $script_name"
 	echo " "
 	echo " Field G. Van Zee"
 	echo " "
@@ -79,7 +79,7 @@ print_usage()
 	echo "   -f VERSFILE  version file name"
 	echo "                  Update VERSFILE with new version string instead of default"
 	echo "                  'version' file."
-	
+
 	# Exit with non-zero exit status
 	exit 1
 }
@@ -113,9 +113,9 @@ main()
 
 	# The git directory.
 	gitdir='.git'
-	
+
 	# Whether we are performing a dry run or not.
-	dry_run_flag=""	
+	dry_run_flag=""
 
 	# -- END GLOBAL VARIABLE DECLARATIONS --
 
@@ -165,12 +165,12 @@ main()
 
 		echo "${script_name}: updating version file '${version_file}'."
 		if [ -z "$dry_run_flag" ]; then
-			echo "${new_version_str}" > ${version_file}
+			echo "${new_version_str}" > "${version_file}"
 		fi
 
 		echo "${script_name}: executing: git commit -m \"Version file update (${new_version_str})\" ${version_file}."
 		if [ -z "$dry_run_flag" ]; then
-			git commit -m "Version file update (${new_version_str})" ${version_file}
+			git commit -m "Version file update (${new_version_str})" "${version_file}"
 		fi
 
 		git_commit_str=$(git describe --always)
@@ -178,7 +178,7 @@ main()
 
 		echo "${script_name}: executing: git tag ${new_version_str} ${git_commit_str}."
 		if [ -z "$dry_run_flag" ]; then
-			git tag ${new_version_str} ${git_commit_str}
+			git tag "${new_version_str}" "${git_commit_str}"
 		fi
 
 		echo "${script_name}: updating ${changelog_file}."

--- a/build/detect/config/old/auto-detect.sh
+++ b/build/detect/config/old/auto-detect.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -41,7 +41,7 @@
 
 main()
 {
-	if [ clang -v > /dev/null 2>&1 ]; then
+	if clang -v > /dev/null 2>&1; then
 	    CC=clang
 	else
 	    CC=gcc
@@ -56,7 +56,7 @@ main()
 	# The path to the script. We need this to find the top-level directory
 	# of the source distribution in the event that the user has chosen to
 	# build elsewhere.
-	dist_path=${0%/${script_name}}
+	dist_path=${0%/"${script_name}"}
 
 	# The path to the directory in which we are building. We do this to
 	# make explicit that we distinguish between the top-level directory
@@ -67,17 +67,17 @@ main()
 	# Detect architecture by predefined macros
 	#
 
-	out1=`$CC -E ${dist_path}/arch_detect.c`
+	out1=`$CC -E "${dist_path}"/arch_detect.c`
 
-	ARCH=`echo $out1 | grep -o "ARCH_[a-zA-Z0-9_]*" | head -n1`
+	ARCH=`echo "$out1" | grep -o "ARCH_[a-zA-Z0-9_]*" | head -n1`
 
-	if [ $ARCH = "ARCH_X86_64" ]; then
+	if [ "$ARCH" = "ARCH_X86_64" ]; then
 		CPUID_SRC=cpuid_x86.c
-	elif [ $ARCH = "ARCH_X86" ]; then
+	elif [ "$ARCH" = "ARCH_X86" ]; then
 		CPUID_SRC=cpuid_x86.c
-	elif [ $ARCH = "ARCH_ARM" ]; then
+	elif [ "$ARCH" = "ARCH_ARM" ]; then
 		CPUID_SRC=cpuid_arm.c
-	elif [ $ARCH = "ARCH_AARCH64" ]; then
+	elif [ "$ARCH" = "ARCH_AARCH64" ]; then
 		# Only support armv8 now
 		echo "armv8a"
 		return 0
@@ -90,9 +90,9 @@ main()
 	# Detect CPU cores
 	#
 
-	$CC -o ${cur_dirpath}/$CPUID_BIN ${dist_path}/$CPUID_SRC
-	${cur_dirpath}/$CPUID_BIN
-	rm -rf ${cur_dirpath}/$CPUID_BIN
+	$CC -o "${cur_dirpath:?}/${CPUID_BIN:?}" "${dist_path}/$CPUID_SRC"
+	"${cur_dirpath:?}/${CPUID_BIN:?}"
+	rm -rf ${cur_dirpath:?}/${CPUID_BIN:?}
 
 	# Exit peacefully.
 	return 0

--- a/build/do-release.sh
+++ b/build/do-release.sh
@@ -41,7 +41,7 @@
 
 print_usage()
 {
-	echo <<- EOF
+	cat <<-EOF
 
 	$script_name
 
@@ -177,12 +177,12 @@ main()
 
 		echo "${script_name}: updating version file '${version_file}'."
 		if [ -z "$dry_run_flag" ]; then
-			echo "${new_version_str}" > ${version_file}
+			echo "${new_version_str}" > "${version_file}"
 		fi
 
 		echo "${script_name}: executing: git commit -m \"Version file update (${new_version_str})\" ${version_file}."
 		if [ -z "$dry_run_flag" ]; then
-			git commit -m "Version file update (${new_version_str})" ${version_file}
+			git commit -m "Version file update (${new_version_str})" "${version_file}"
 		fi
 
 		git_commit_str=$(git describe --always)
@@ -190,12 +190,12 @@ main()
 
 		echo "${script_name}: updating '${changelog_file}'."
 		if [ -z "$dry_run_flag" ]; then
-			git log --no-decorate > ${changelog_file}
+			git log --no-decorate > "${changelog_file}"
 		fi
 
 		echo "${script_name}: executing: git commit -m \"CHANGELOG update (${new_version_str})\" ${changelog_file}."
 		if [ -z "$dry_run_flag" ]; then
-			git commit -m "CHANGELOG update (${new_version_str})" ${changelog_file}
+			git commit -m "CHANGELOG update (${new_version_str})" "${changelog_file}"
 		fi
 
 		git_commit_str=$(git describe --always)

--- a/build/gen-libblis-symbols.sh
+++ b/build/gen-libblis-symbols.sh
@@ -3,7 +3,7 @@
 get_config_var()
 {
 	# Parse the compiler assigned to the CC variable within the config.mk file.
-	echo "$(grep "^ *$1 *:=" config.mk | sed 's/'$1' *:= *//')"
+	grep "^ *$1 *:=" config.mk | sed 's/'"$1"' *:= *//'
 }
 
 main()
@@ -17,7 +17,7 @@ main()
 	CONFIG_NAME=$(get_config_var CONFIG_NAME)
 	BLIS_H_FLAT="include/${CONFIG_NAME}/blis.h"
 
-	if [ ! -e ${BLIS_H_FLAT} ]; then
+	if [ ! -e "${BLIS_H_FLAT}" ]; then
 		echo "No monolithic blis.h file detected at ${BLIS_H_FLAT}; have you run 'make'?"
 		exit 1
 	fi
@@ -42,7 +42,7 @@ main()
 	#	| sort
 	#	| uniq
 	#
-	${CC} -DBLIS_ENABLE_CBLAS=1 -DBLIS_ENABLE_BLAS=1 -E ${BLIS_H_FLAT} \
+	${CC} -DBLIS_ENABLE_CBLAS=1 -DBLIS_ENABLE_BLAS=1 -E "${BLIS_H_FLAT}" \
 		| tr ';' '\n' \
 		| grep visibility \
 		| sed -E \

--- a/build/gen-make-frags/gen-make-frag.sh
+++ b/build/gen-make-frags/gen-make-frag.sh
@@ -145,7 +145,7 @@ gen_mkfile()
 
 
 	# Make sure the target directory exists
-	mkdir -p $this_frag_dir
+	mkdir -p "$this_frag_dir"
 
 
 	# Strip the leading path from the template makefile path to get its
@@ -168,7 +168,7 @@ gen_mkfile()
 	local_src_files=""
 
 	# Get a listing of the items in $this_dir
-	sub_items=$(ls $this_dir)
+	sub_items=$(ls "$this_dir")
 
 	# Generate a list of the source files we've chosen
 	for item in $sub_items; do
@@ -194,7 +194,7 @@ gen_mkfile()
 	cur_frag_sub_dirs=""
 
 	# Capture the relative path listing of items in $this_dir.
-	sub_items=$(ls $this_dir)
+	sub_items=$(ls "$this_dir")
 
 	# Determine the fragment's subdirectory names, if any exist
 	for item in $sub_items; do
@@ -204,8 +204,8 @@ gen_mkfile()
 
 		# If item is a directory, and it's not in the ignore list, descend into it.
 		#if [ -d $item_path ] && ! should_ignore $item; then
-		if [ "$recursive_flag" = "1" ] && [ -d $item_path ] && ! is_in_list $item "$ignore_dirs" ; then
-			cur_frag_sub_dirs=$cur_frag_sub_dirs" "$item
+		if [ "$recursive_flag" = "1" ] && [ -d "$item_path" ] && ! is_in_list $item "$ignore_dirs" ; then
+			cur_frag_sub_dirs="$cur_frag_sub_dirs $item"
 		fi
 	done
 
@@ -230,11 +230,11 @@ gen_mkfile()
 	# Copy the template makefile to the directory given, using the new
 	# makefile name we just created above.
 	if [ -z "$dry_run_flag" ]; then
-		cat $mkfile_frag_tmpl_path | sed -e s/"$mkfile_fragment_cur_dir_name_anchor"/"$cur_frag_dir"/g \
-		                           | sed -e s/"$mkfile_fragment_sub_dir_names_anchor"/"$cur_frag_sub_dirs"/g \
-		                           | sed -e s/"$mkfile_fragment_local_src_files_anchor"/"$local_src_files"/g \
-		                           | sed -e s/"$mkfile_fragment_src_var_name_anchor"/"$mkfile_frag_var_name"/g \
-		                           > $mkfile_frag_path
+		cat "$mkfile_frag_tmpl_path" | sed -e s/"$mkfile_fragment_cur_dir_name_anchor"/"$cur_frag_dir"/g \
+		                             | sed -e s/"$mkfile_fragment_sub_dir_names_anchor"/"$cur_frag_sub_dirs"/g \
+		                             | sed -e s/"$mkfile_fragment_local_src_files_anchor"/"$local_src_files"/g \
+		                             | sed -e s/"$mkfile_fragment_src_var_name_anchor"/"$mkfile_frag_var_name"/g \
+		                             > "$mkfile_frag_path"
 	fi
 
 
@@ -275,11 +275,11 @@ gen_mkfiles()
 
 
 	# Call our function to generate a makefile in the directory given.
-	gen_mkfile "${src_var_name}_$SRC" $cur_dir $this_frag_dir
+	gen_mkfile "${src_var_name}_$SRC" "$cur_dir" "$this_frag_dir"
 
 
 	# Get a listing of the directories in $directory
-	sub_items=$(ls $cur_dir)
+	sub_items=$(ls "$cur_dir")
 
 	# Descend into the contents of root_dir to generate the subdirectories'
 	# makefile fragments.
@@ -288,7 +288,7 @@ gen_mkfiles()
 		# If item is a directory, and it's not in the ignore list, descend into it.
 		#if [ -d "$cur_dir/$item" ] && ! should_ignore $item; then
 		if [ -d "$cur_dir/$item" ] && ! is_in_list $item "$ignore_dirs" ; then
-			gen_mkfiles $cur_dir/$item $this_frag_dir/$item
+			gen_mkfiles "$cur_dir/$item" "$this_frag_dir/$item"
 		fi
 	done
 
@@ -533,7 +533,7 @@ main()
 
 
 	# Call our function to generate a makefile in the root directory given.
-	gen_mkfile "${src_var_name}_$SRC" $root_dir $frag_dir
+	gen_mkfile "${src_var_name}_$SRC" "$root_dir" "$frag_dir"
 
 
 	# If we were asked to act recursively, then continue processing
@@ -541,7 +541,7 @@ main()
 	if [ -n "$recursive_flag" ]; then
 
 		# Get a listing of the directories in $directory.
-		sub_items=$(ls $root_dir)
+		sub_items=$(ls "$root_dir")
 
 		# Descend into the contents of root_dir to generate the makefile
 		# fragments.
@@ -551,7 +551,7 @@ main()
 			#if [ -d "$root_dir/$item" ] && ! should_ignore $item ; then
 			if [ -d "$root_dir/$item" ] && ! is_in_list $item "$ignore_dirs" ; then
 
-				gen_mkfiles $root_dir/$item $frag_dir/$item
+				gen_mkfiles "$root_dir/$item" "$frag_dir/$item"
 			fi
 		done
 	fi

--- a/build/gen-make-frags/gen-make-frag.sh
+++ b/build/gen-make-frags/gen-make-frag.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  BLIS
 #  An object-based framework for developing high-performance BLAS-like
@@ -41,68 +41,63 @@
 
 print_usage()
 {
-	#local script_name
-
-	# Get the script name
-	#script_name=${0##*/}
-
 	# Echo usage info
-	echo " "
-	echo " "$script_name
-	echo " "
-	echo " Field G. Van Zee"
-	echo " "
-	echo " Automatically generates makefile fragments for a specified directory"
-	echo " tree. "
-	echo " "
-	echo " Usage:"
-	echo "   ${script_name} [options] root_dir frag_dir templ.mk suff_list ign_list"
-	echo " "
-	echo " Arguments (mandatory):"
-	echo " "
-	echo "   root_dir    The root directory to scan when generating makefile"
-	echo "               fragments."
-	echo " "
-	echo "   frag_dir    The root directory in which makefile fragments will be"
-	echo "               generated."
-	echo " "
-	echo "   templ.mk    The template makefile fragment used to generate the actual"
-	echo "               fragments."
-	echo " "
-	echo "   suff_list   File containing a newline-separated list of file suffixes"
-	echo "               of source files to that the top-level makefile expects to"
-	echo "               access."
-	echo " "
-	echo "   ign_list    File containing a newline-separated list of directory names"
-	echo "               to ignore when descending recursively into "
-	echo " "
-	echo " The following options are accepted:"
-	echo " "
-	echo "   -d          dry-run"
-	echo "                 Go through all the motions, but don't actually generate any"
-	echo "                 makefile fragments."
-	echo "   -r          recursive"
-	echo "                 Also generate makefile fragments for subdirectories of"
-	echo "                 root_dir."
-	echo "   -h          hide"
-	echo "                 Hide the makefile fragments by prepending filenames with '.'."
-	echo "   -i LIST     ignore"
-	echo "                 Augment the list of directory names contained in ign_list"
-	echo "                 with the directory names in LIST."
-	echo "   -p PREFIX   prefix name"
-	echo "                 Use PREFIX instead of uppercased root_dir in the makefile"
-	echo "                 variable name. If the root_dir were 'stuff' and -p was not"
-	echo "                 used, then source would be accumulated into a makefile"
-	echo "                 variable named 'MK_STUFF', but if -p JUNK were given, then"
-	echo "                 the variable name would instead be MK_JUNK."
-	echo "   -o SCRIPT   output script name"
-	echo "                 Use SCRIPT when outputting messages instead of the script's"
-	echo "                 actual name."
-	echo "   -v [0|1|2]  verboseness level"
-	echo "                 level 0: silent  (no output)"
-	echo "                 level 1: default (one line per directory)"
-	echo "                 level 2: verbose (several lines per directory)."
-	echo " "
+    cat <<EOF
+
+$script_name
+
+Field G. Van Zee
+
+Automatically generates makefile fragments for a specified directory tree.
+
+Usage:
+  ${script_name} [options] root_dir frag_dir templ.mk suff_list ign_list
+
+Arguments (mandatory):
+
+  root_dir    The root directory to scan when generating makefile
+              fragments.
+
+  frag_dir    The root directory in which makefile fragments will be
+              generated.
+
+  templ.mk    The template makefile fragment used to generate the actual
+              fragments.
+
+  suff_list   File containing a newline-separated list of file suffixes
+              of source files to that the top-level makefile expects to
+              access.
+
+  ign_list    File containing a newline-separated list of directory names
+              to ignore when descending recursively into
+
+The following options are accepted:
+
+  -d          dry-run
+                Go through all the motions, but don't actually generate any
+                makefile fragments.
+  -r          recursive
+                Also generate makefile fragments for subdirectories of
+                root_dir.
+  -h          hide
+                Hide the makefile fragments by prepending filenames with '.'.
+  -i LIST     ignore
+                Augment the list of directory names contained in ign_list
+                with the directory names in LIST.
+  -p PREFIX   prefix name
+                Use PREFIX instead of uppercased root_dir in the makefile
+                variable name. If the root_dir were 'stuff' and -p was not
+                used, then source would be accumulated into a makefile
+                variable named 'MK_STUFF', but if -p JUNK were given, then
+                the variable name would instead be MK_JUNK.
+  -o SCRIPT   output script name
+                Use SCRIPT when outputting messages instead of the script's
+                actual name.
+  -v [0|1|2]  verboseness level
+                level 0: silent  (no output)
+                level 1: default (one line per directory)
+                level 2: verbose (several lines per directory).
+EOF
 
 	# Exit with non-zero exit status
 	exit 1
@@ -180,7 +175,7 @@ gen_mkfile()
 		item_suffix=${item_path##*.}
 
 		# If the suffix matches, then add it to our list
-		if is_in_list $item_suffix "$src_file_suffixes"
+		if is_in_list "$item_suffix" "$src_file_suffixes"
 		then
 			local_src_files="$local_src_files $item"
 		fi
@@ -204,7 +199,7 @@ gen_mkfile()
 
 		# If item is a directory, and it's not in the ignore list, descend into it.
 		#if [ -d $item_path ] && ! should_ignore $item; then
-		if [ "$recursive_flag" = "1" ] && [ -d "$item_path" ] && ! is_in_list $item "$ignore_dirs" ; then
+		if [ "$recursive_flag" = "1" ] && [ -d "$item_path" ] && ! is_in_list "$item" "$ignore_dirs" ; then
 			cur_frag_sub_dirs="$cur_frag_sub_dirs $item"
 		fi
 	done
@@ -230,11 +225,11 @@ gen_mkfile()
 	# Copy the template makefile to the directory given, using the new
 	# makefile name we just created above.
 	if [ -z "$dry_run_flag" ]; then
-		cat "$mkfile_frag_tmpl_path" | sed -e s/"$mkfile_fragment_cur_dir_name_anchor"/"$cur_frag_dir"/g \
-		                             | sed -e s/"$mkfile_fragment_sub_dir_names_anchor"/"$cur_frag_sub_dirs"/g \
-		                             | sed -e s/"$mkfile_fragment_local_src_files_anchor"/"$local_src_files"/g \
-		                             | sed -e s/"$mkfile_fragment_src_var_name_anchor"/"$mkfile_frag_var_name"/g \
-		                             > "$mkfile_frag_path"
+		< "$mkfile_frag_tmpl_path" sed -e s/"$mkfile_fragment_cur_dir_name_anchor"/"$cur_frag_dir"/g \
+		                         | sed -e s/"$mkfile_fragment_sub_dir_names_anchor"/"$cur_frag_sub_dirs"/g \
+		                         | sed -e s/"$mkfile_fragment_local_src_files_anchor"/"$local_src_files"/g \
+		                         | sed -e s/"$mkfile_fragment_src_var_name_anchor"/"$mkfile_frag_var_name"/g \
+		                         > "$mkfile_frag_path"
 	fi
 
 
@@ -268,7 +263,7 @@ gen_mkfiles()
 
 	# Be verbose if level 2 was requested
 	if   [ "$verbose_flag" = "2" ]; then
-		echo ">>>" $script_name ${src_var_name}_$SRC $cur_dir $this_frag_dir
+		echo ">>> $script_name ${src_var_name}_$SRC $cur_dir $this_frag_dir"
 	elif [ "$verbose_flag" = "1" ]; then
 		echo "$script_name: creating makefile fragment in $this_frag_dir from $cur_dir"
 	fi
@@ -287,7 +282,7 @@ gen_mkfiles()
 
 		# If item is a directory, and it's not in the ignore list, descend into it.
 		#if [ -d "$cur_dir/$item" ] && ! should_ignore $item; then
-		if [ -d "$cur_dir/$item" ] && ! is_in_list $item "$ignore_dirs" ; then
+		if [ -d "$cur_dir/$item" ] && ! is_in_list "$item" "$ignore_dirs" ; then
 			gen_mkfiles "$cur_dir/$item" "$this_frag_dir/$item"
 		fi
 	done
@@ -388,8 +383,8 @@ read_mkfile_config()
 
 	# Change newlines into spaces. This is optional, but helps when
 	# printing these values out (so they appear on one line).
-	src_file_suffixes=$(echo ${src_file_suffixes} | sed "s/\n/ /g")
-	ignore_dirs=$(echo ${ignore_dirs} | sed "s/\n/ /g")
+	src_file_suffixes=$(echo "${src_file_suffixes}" | sed "s/\n/ /g")
+	ignore_dirs=$(echo "${ignore_dirs}" | sed "s/\n/ /g")
 
 }
 
@@ -526,7 +521,7 @@ main()
 
 	# Be verbose if level 2 was requested.
 	if   [ "$verbose_flag" = "2" ]; then
-		echo ">>>" $script_name ${src_var_name}_$SRC $root_dir $frag_dir
+		echo ">>> $script_name ${src_var_name}_$SRC $root_dir $frag_dir"
 	elif [ "$verbose_flag" = "1" ]; then
 		echo "$script_name: creating makefile fragment in $frag_dir from $root_dir"
 	fi
@@ -549,7 +544,7 @@ main()
 
 			# If item is a directory, and it's not in the ignore list, descend into it.
 			#if [ -d "$root_dir/$item" ] && ! should_ignore $item ; then
-			if [ -d "$root_dir/$item" ] && ! is_in_list $item "$ignore_dirs" ; then
+			if [ -d "$root_dir/$item" ] && ! is_in_list "$item" "$ignore_dirs" ; then
 
 				gen_mkfiles "$root_dir/$item" "$frag_dir/$item"
 			fi
@@ -563,8 +558,6 @@ main()
 
 is_in_list()
 {
-	local cur_item the_item item_list
-
 	# Extract argument.
 	the_item="$1"
 	item_list="$2"

--- a/build/mirror-tree.sh
+++ b/build/mirror-tree.sh
@@ -36,14 +36,12 @@ set -e
 
 print_usage()
 {
-	local script_name
-	
 	# Get the script name
 	script_name=${0##*/}
-	
+
 	# Echo usage info
 	echo " "
-	echo " "${script_name}
+	echo " ${script_name}"
 	echo " "
 	echo " Field G. Van Zee"
 	echo " "
@@ -72,7 +70,6 @@ main()
 		case $opt in
 			v  ) verbose_flag=1 ;;
 			\? ) print_usage
-			     exit 1
 		esac
 	done
 	shift $(($OPTIND - 1))
@@ -146,8 +143,8 @@ mirror_tree()
 			
 			# Make the new subdirectory, but only if it doesn't
 			# already exist.
-			if [ ! -d $cur_n_dir ]; then
-				mkdir $cur_n_dir
+			if [ ! -d "$cur_n_dir" ]; then
+				mkdir "$cur_n_dir"
 			fi
 			
 			

--- a/build/mirror-tree.sh
+++ b/build/mirror-tree.sh
@@ -32,6 +32,8 @@
 #
 #
 
+set -e
+
 print_usage()
 {
 	local script_name
@@ -88,7 +90,7 @@ main()
 	
 	
 	# If the root new directory does not exist, then create it.
-	if [ ! -d $n_dir ]; then
+	if [ ! -d "$n_dir" ]; then
 		
 		# Be verbose, if -v was one of the command line options.
 		if [ -n "$verbose_flag" ]; then
@@ -98,7 +100,7 @@ main()
 		
 		# Make the root new directory. Create the parent directories if
 		# they do not exist with the -p option.
-		mkdir -p $n_dir
+		mkdir -p "$n_dir"
 	fi
 	
 	
@@ -111,7 +113,7 @@ main()
 	
 	# Begin recursion, starting with the contents of the existing
 	# directory.
-	mirror_tree "$(ls $e_dir)"
+	mirror_tree "$(ls "$e_dir")"
 	
 	
 	# Exit peacefully.
@@ -134,7 +136,7 @@ mirror_tree()
 		
 		# If the current existing directory exists, then create a
 		# corresponding subdirectory in new directory.
-		if [ -d ${cur_e_dir} ]; then
+		if [ -d "${cur_e_dir}" ]; then
 			
 			# Be verbose, if -v was one of the command line options.
 			if [ -n "$verbose_flag" ]; then
@@ -150,7 +152,7 @@ mirror_tree()
 			
 			
 			# Continue recursively on the contents of cur_e_dir.
-			mirror_tree "$(ls $cur_e_dir)"
+			mirror_tree "$(ls "$cur_e_dir")"
 		fi
 		
 		# Delete the end of the path, up to the first / character to

--- a/build/old/flatten-headers-pass.sh
+++ b/build/old/flatten-headers-pass.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -175,12 +175,12 @@ find_header_dirs()
 	echoninfo "scanning contents of ${cur_dirpath}"
 
 	# Acquire a list of the directory's contents.
-	sub_items=$(ls ${cur_dirpath})
+	sub_items=$(ls "${cur_dirpath}")
 
 	# If there is at least one header present, add the current directory to
 	# the list header of directories. Otherwise, the current directory does
 	# not contribute to the list returned to the caller.
-	result=$(echo ${sub_items} | grep "\.h")
+	result=$(echo "${sub_items}" | grep "\.h")
 
 	if [ -n "${result}" ]; then
 		cur_list="${cur_dirpath}"
@@ -274,14 +274,14 @@ replace_pass()
 
 		# Check whether the line begins with a #include directive, but ignore
 		# the line if it contains the skip string.
-		result=$(echo ${curline} | grep '^[[:space:]]*#include ' | grep -v "${skipstr}")
+		result=$(echo "${curline}" | grep '^[[:space:]]*#include ' | grep -v "${skipstr}")
 
 		# If the #include directive was found...
 		if [ -n "${result}" ]; then
 
 			# Isolate the header filename. We must take care to include all
 			# characters that might appear between the "" or <>.
-			header=$(echo ${curline} | sed -e "s/#include [\"<]\([a-zA-Z0-9\_\.\/\-]*\)[\">].*/\1/g")
+			header=$(echo "${curline}" | sed -e "s/#include [\"<]\([a-zA-Z0-9\_\.\/\-]*\)[\">].*/\1/g")
 
 			# Add the header file to a list.
 			headerlist=$(canonicalize_ws "${headerlist} ${header}")
@@ -298,7 +298,7 @@ replace_pass()
 	for header in ${headerlist}; do
 
 		# Find the path to the header.
-		header_filepath=$(get_header_path ${header} "${dirpaths}")
+		header_filepath=$(get_header_path "${header}" "${dirpaths}")
 
 		# If the header has a slash, escape it so that sed doesn't get confused
 		# (since we use '/' as our search-and-replace delimiter).
@@ -316,12 +316,12 @@ replace_pass()
 			# later. Notice that we mimic the quotes or angle brackets
 			# around the header name, whichever pair was used in the input.
 
-			cat ${filename} \
-			    | sed -e "s/^[[:space:]]*#include \([\"<]\)\(${header_esc}\)\([\">]\).*/#include \1\2\3 ${skipstr}/" \
+			< "${filename}" \
+			    sed -e "s/^[[:space:]]*#include \([\"<]\)\(${header_esc}\)\([\">]\).*/#include \1\2\3 ${skipstr}/" \
 			    > "${filename}.tmp"
 
 			# Overwrite the original file with the updated copy.
-			mv "${filename}.tmp" ${filename}
+			mv "${filename}.tmp" "${filename}"
 
 		else
 
@@ -335,8 +335,8 @@ replace_pass()
 				# Make a temporary copy of ${header_filepath} stripped of its
 				# C-style comments. This leaves behind a single blank line,
 				# which is then deleted.
-				cat ${header_filepath} \
-				    | perl -0777 -pe "s/\/\*.*?\*\//${commstr}/gs" \
+				< "${header_filepath}" \
+				    perl -0777 -pe "s/\/\*.*?\*\//${commstr}/gs" \
 				    | sed -e "/${commstr}/d" \
 				    > "${header_filename}.tmp"
 
@@ -348,8 +348,8 @@ replace_pass()
 			# Replace the #include directive for the current header file with the
 			# contents of that header file, saving the result to a temporary file.
 			# We also insert begin and end markers to allow for more readability.
-			cat ${filename} \
-			    | sed -e "/^[[:space:]]*#include \"${header_esc}\"/ {" \
+			< "${filename}" \
+			      sed -e "/^[[:space:]]*#include \"${header_esc}\"/ {" \
 			          -e "i // begin ${header}" \
 			          -e "r ${header_to_insert}" \
 			          -e "a // end ${header}" \
@@ -358,7 +358,7 @@ replace_pass()
 			    > "${filename}.tmp"
 
 			# Overwrite the original header file with the updated copy.
-			mv "${filename}.tmp" ${filename}
+			mv "${filename}.tmp" "${filename}"
 
 			# If C-style comments were stripped, remove the temporary file.
 			if [ -n "${strip_comments}" ]; then
@@ -378,11 +378,11 @@ replace_pass()
 	# Search the updated file for #include directives, but ignore any
 	# hits that also contain the skip string (indicating that the header
 	# file referenced by that #include could not be found).
-	result=$(cat ${filename} | grep '^[[:space:]]*#include ' | grep -v "${skipstr}")
+	result=$(< "${filename}" grep '^[[:space:]]*#include ' | grep -v "${skipstr}")
 
 	# Return the result so the caller knows if we need to proceed with
 	# another pass.
-	echo ${result}
+	echo "${result}"
 }
 
 #
@@ -448,7 +448,7 @@ main()
 
 		echoninfo "checking ${item} "
 
-		if [ -d ${item} ]; then
+		if [ -d "${item}" ]; then
 			echon2info " ...directory exists."
 			dir_list2="${dir_list2} ${item}"
 		else
@@ -477,7 +477,7 @@ main()
 		dirpaths=""
 		for item in ${dir_list}; do
 
-			item_dirpaths=$(find_header_dirs ${item})
+			item_dirpaths=$(find_header_dirs "${item}")
 			dirpaths="${dirpaths} ${item_dirpaths}"
 		done
 		dirpaths=$(canonicalize_ws "${dirpaths}")
@@ -494,11 +494,11 @@ main()
 			echoninfo "scanning ${item}"
 
 			# Acquire a list of the directory's contents.
-			sub_items=$(ls ${item})
+			sub_items=$(ls "${item}")
 
 			# If there is at least one header present, add the current directory to
 			# the list header of directories.
-			result=$(echo ${sub_items} | grep "\.h")
+			result=$(echo "${sub_items}" | grep "\.h")
 			if [ -n "${result}" ]; then
 				dirpaths="${dirpaths} ${item}"
 				echon2info " ...found headers."
@@ -516,8 +516,8 @@ main()
 	echoinfo "preparing to monolithify '${inputfile}'."
 
 	# Make a copy of the inputfile.
-	cp ${inputfile} ${outputfile}
-	
+	cp "${inputfile}" "${outputfile}"
+
 	echoinfo "new header will be saved to '${outputfile}'."
 
 	done_flag="0"
@@ -527,7 +527,7 @@ main()
 
 		# Perform a replacement pass. The return string is non-null if
 		# additional passes are necessary and null otherwise.
-		result=$(replace_pass ${outputfile} "${dirpaths}")
+		result=$(replace_pass "${outputfile}" "${dirpaths}")
 
 		if [ -n "${result}" ]; then
 
@@ -552,4 +552,3 @@ main()
 
 # The script's main entry point, passing all parameters given.
 main "$@"
-

--- a/build/recu-sed.sh
+++ b/build/recu-sed.sh
@@ -10,12 +10,12 @@ print_usage()
 {
 	# Echo usage info
 	echo " "
-	echo " "$script_name
+	echo " $script_name"
 	echo " "
 	echo " Field G. Van Zee"
 	echo " "
 	echo " Recusively descend a directory tree and perform sed commands, either on"
-	echo " the filename or the file contents, or both." 
+	echo " the filename or the file contents, or both."
 	echo " "
 	echo " Usage:"
 	echo "   ${script_name} [options]"
@@ -64,7 +64,7 @@ print_usage()
 	echo " "
 	echo " Note: -c and -s options are mutually exclusive."
 	echo " "
-	
+
 	# Exit with non-zero exit status
 	exit 1
 }
@@ -76,7 +76,7 @@ perform_sed()
 {
 	# Variables set by getopts.
 	local exist_dir="$1"
-	
+
 	#echo "exist_dir: $exist_dir"
 
 	# The suffix used to create temporary files
@@ -87,35 +87,34 @@ perform_sed()
 		echo "${script_name}: ${exist_dir} does not seem to be a valid directory."
 		exit 1
 	fi
-	
+
 	# Check that the filename sed expression, if given, begins with an 's'.
 	if [ -n "$filename_sed_expr" ]; then
-		
+
 		# If it's a valid search-and-replace expression, this should return an 's'.
 		filename_sed_char=${filename_sed_expr%%/*}
-		
+
 		if [ "$filename_sed_char" != "s" ]; then
 			echo "${script_name}: sed expression given with -f must be search-and-replace."
 			exit 1
 		fi
 	fi
-	
+
 	# Check that the sed script, if given, exists.
 	if [ -n "$contents_sed_script" ]; then
-		
-		if [ ! -f ${contents_sed_script} ]; then
+		if [ ! -f "${contents_sed_script}" ]; then
 			echo "${script_name}: ${contents_sed_script} is not a regular file or does not exist."
 			exit 1
 		fi
 	fi
-	
+
 	# Assume that the sed expression is a search-and-replace. Extract the patterns
 	# to match on. (Arbitrary sed expressions should be applied through a sed script.)
 	if [ "$filename_sed_expr" != "" ]; then
 		filename_sed_match=${filename_sed_expr#s/}
 		filename_sed_match=${filename_sed_match%%/*}
 	fi
-	
+
 
 	# Get the list of source files in the directory given. Supress stderr if
 	# level 0 or 1 verbosity was requested.
@@ -124,10 +123,10 @@ perform_sed()
 	#else
 	#	old_filepaths="$(ls -d -b ${exist_dir}/${filename_pattern})"
 	#fi
-	
+
 	#echo $old_filepaths
 	#echo "$exist_dir/$filename_pattern"
-	
+
 	#for old_filepath in $old_filepaths; do
 	#echo "exist_dir:    $exist_dir"
 
@@ -140,23 +139,23 @@ perform_sed()
 		if [ "${old_filepath}" == "${exist_dir}" ]; then
 			continue
 		fi
-		
+
 		# Skip any non-regular files.
 		if [ ! -f "$old_filepath" ]; then
-			
+
 			# And say we are doing so if verboseness was requested.
 			if [ "$verbose_level" = "2" ]; then
 				echo "${script_name}: Ignoring $old_filepath"
 			fi
 			continue
 		fi
-		
+
 		# Strip exist_dir from filename.
 		old_filename=${old_filepath##*/}
 
 		# Strip the filename from old_filepath to leave the directory path.
 		old_dirpath=${old_filepath%/*}
-		
+
 		# Create a new filename from the old one. If a filename sed expression was given,
 		# it will be applied now.
 		if [ "$filename_sed_expr" != "" ]; then
@@ -166,20 +165,20 @@ perform_sed()
 		fi
 
 		#echo "new_filename: $new_filename"
-			
+
 		# Create the filepath to the new file location.
 		new_filepath="${old_dirpath}/${new_filename}"
 		#echo "new_filepath: $new_filepath"
-			
+
 		# Grep for the filename pattern within the filename of the current file.
 		if [ "$filename_sed_expr" != "" ]; then
 			grep_filename=$(echo "${old_filename}" | grep "${filename_sed_match}")
 		fi
-		
+
 
 		# If we are not performing a dry run, proceed.
 		if [ -z "$dry_run_flag" ]; then
-			
+
 			# Save the old file permissions so we can re-apply them to the
 			# new file if its contents change (ie: if it's not just a 'mv',
 			# which inherently preserves file permissions).
@@ -191,12 +190,12 @@ perform_sed()
 			# the user requested that we use svn mv, then do that, otherwise we
 			# use regular mv.
 			if [ "${old_filepath}" != "${new_filepath}" ]; then
-	
+
 				if [ -n "$use_svn_mv_flag" ]; then
-	
+
 					svn mv "${old_filepath}" "${new_filepath}"
 				else
-	
+
 					mv -f "${old_filepath}" "${new_filepath}"
 				fi
 			fi
@@ -204,7 +203,7 @@ perform_sed()
 
 			# A dry run still needs the act upon the "new" file, so if the
 			# filepaths are different, simply set the new filepath to the
-			# old one. (We won't need the previous value of new_filepath 
+			# old one. (We won't need the previous value of new_filepath
 			# anymore.)
 			#if [ "${old_filepath}" != "${new_filepath}" ]; then
 			#	new_filepath="${old_filepath}"
@@ -214,35 +213,35 @@ perform_sed()
 		# Handle the cases that might change the contents of the file.
 		if [ "$contents_sed_expr" != "" ] ||
 		   [ "$contents_sed_script" != "" ]; then
-			
+
 			# Execute the sed command based on whether the sed action was given
 			# as a command line expression or a script residing in a file.
 			if   [ "$contents_sed_script" != "" ]; then
-				
+
 				# Perform the action, saving the result to a temporary file.
-				cat "${new_filepath}" | sed -f ${contents_sed_script} \
-				                      > ${new_filepath}.${temp_file_suffix}
-			
+				< "${new_filepath}" sed -f "${contents_sed_script}" \
+				                      > "${new_filepath}.${temp_file_suffix}"
+
 			elif [ "$contents_sed_expr" != "" ]; then
-				
+
 				# Perform the action, saving the result to a temporary file.
-				cat "${new_filepath}" | sed -e "${contents_sed_expr}" \
-				                      > ${new_filepath}.${temp_file_suffix}
+				< "${new_filepath}" sed -e "${contents_sed_expr}" \
+				                      > "${new_filepath}.${temp_file_suffix}"
 			fi
-			
+
 			# Check the difference.
 			file_diff=$(diff "${new_filepath}" "${new_filepath}.${temp_file_suffix}")
-			
-			
+
+
 			# If we are not performing a dry run, proceed.
 			if [ -z "$dry_run_flag" ]; then
-			
+
 				# If the file contents change.
 				if [ -n "$file_diff" ]; then
-				
+
 					# Apply the old file permissions to the new file (before we
 					# potentially overwrite the old file with the new one).
-					chmod ${old_perms} "${new_filepath}.${temp_file_suffix}"
+					chmod "${old_perms}" "${new_filepath}.${temp_file_suffix}"
 
 					# Apply the file contents changes to the new filepath (which may
 					# or may not be the same as the old filepath).
@@ -259,7 +258,7 @@ perform_sed()
 			fi
 
 		fi
-		
+
 		# Check for dos2unix. If it's not here, we'll just substitute cat.
 		#type_dos2unix=$(type -path dos2unix)
 		#if [ -n "$type_dos2unix" ]; then
@@ -281,17 +280,17 @@ perform_sed()
 			which_matches=""
 			file_touched="no"
 		fi
-		
+
 		# Be verbose, if requested, about which file we're looking at.
 		if [ "$verbose_level" != "0" ]; then
-			
+
 			# But we only need to output a line if the file was touched.
 			if [ "$file_touched" != "no" ]; then
-				
+
 				# Construct a relative filepath by stripping the initial root
 				# directory so that the output does not span as many columns on
 				# the terminal.
-				rel_old_filepath=${old_filepath#${initial_root_dir}/}
+				rel_old_filepath=${old_filepath#"${initial_root_dir}"/}
 
 				# Add a "dry run" condition to the output if we're doing a dry-run
 				# so that the user knows we didn't really change anything.
@@ -302,9 +301,9 @@ perform_sed()
 				fi
 			fi
 		fi
-		
+
 	done
-	
+
 	# Exit peacefully.
 	return 0
 }
@@ -316,21 +315,21 @@ recursive_sed()
 {
 	# Local variable declarations
 	local item sub_items curr_dir this_dir
-	
-	
+
+
 	# Extract our argument
 	curr_dir="$1"
-	
+
 
 	# Call our function to perform the sed operations on the files in the
 	# directory given.
 	perform_sed "${curr_dir}"
-	
+
 
 	# If we were asked to act recursively, then continue processing
 	# curr_dir's contents.
 	if [ "$recursive_flag" = "1" ]; then
-		
+
 		# Get a listing of items in the directory according to the hidden
 		# files/directories flag.
 		if [ -n "$hidden_files_dirs_flag" ]; then
@@ -346,7 +345,7 @@ recursive_sed()
 		fi
 
 		#echo "sub_items: $sub_items"
-	
+
 		# Descend into the contents of curr_dir, calling recursive_sed on
 		# any items that are directories.
 		find "${curr_dir}" -maxdepth 1 -name "*" -print | while read item
@@ -361,7 +360,7 @@ recursive_sed()
 
 			# If item is a directory, descend into it.
 			if [ -d "$item" ]; then
-			
+
 				#echo "item is dir: $item"
 
 				recursive_sed "$item"
@@ -369,8 +368,8 @@ recursive_sed()
 		done
 
 	fi
-	
-	
+
+
 	# Return peacefully
 	return 0
 }
@@ -392,17 +391,17 @@ main()
 	contents_sed_expr=""
 	contents_sed_script=""
 
-	recursive_flag="1"	
+	recursive_flag="1"
 
-	
+
 	# Get the script name
 	script_name=${0##*/}
-	
-	
+
+
 	# Local variable declarations.
 	local item sub_items this_dir
-	
-	
+
+
 	# Process our command line options.
 	while getopts ":c:df:hp:r:s:nNv:" opt; do
 		case $opt in
@@ -420,23 +419,23 @@ main()
 		esac
 	done
 	shift $(($OPTIND - 1))
-	
-	
+
+
 	# Make sure we've parsed all command line arguments by now.
 	if [ $# != "0" ]; then
 		echo "${script_name}: Unparsed command line arguments! Try running with no arguments for help."
 		exit 1
 	fi
-	
-	
+
+
 	# Make sure we received at least one of the required options.
 	if [ -z "$filename_sed_expr" ] &&
 	   [ -z "$contents_sed_expr" ] &&
 	   [ -z "$contents_sed_script" ]; then
 		print_usage
 	fi
-	
-	
+
+
 	# Make sure that both a file contents sed expression and sed script were
 	# not given.
 	if [ "$contents_sed_expr"   != "" ] &&
@@ -447,12 +446,12 @@ main()
 
 
 	# Make sure that verboseness level is valid.
-	if [ "$verbose_level" != "0" ] && 
+	if [ "$verbose_level" != "0" ] &&
 	   [ "$verbose_level" != "1" ] &&
 	   [ "$verbose_level" != "2" ]; then
 		verbose_level="1"
 	fi
-	
+
 	# Prepare the filename pattern arguments to perform_sed().
 	if [ "$filename_pattern" = "" ] ; then
 		filename_pattern='*'
@@ -460,14 +459,14 @@ main()
 
 	# Prepare the directory arguments to perform_sed().
 	if [ "$root_dir" != "" ] ; then
-		
+
 		# Strip / from end of directory paths, if there is one.
 		root_dir=${root_dir%/}
 	else
 		root_dir=$PWD
 	fi
 	initial_root_dir=${root_dir}
-	
+
 
 	#echo "root_dir: $root_dir"
 
@@ -485,4 +484,3 @@ main()
 
 # The script's main entry point, passing all parameters given.
 main "$@"
-

--- a/ci/cxx/cxx-test.sh
+++ b/ci/cxx/cxx-test.sh
@@ -36,23 +36,23 @@
 SOURCE_DIR=$1
 CONFIG=$2
 
-if [ -z $SOURCE_DIR ] || [ -z $CONFIG ]; then
+if [ -z "$SOURCE_DIR" ] || [ -z "$CONFIG" ]; then
     echo "usage: cxx-test.sh <source dir> <config>"
     exit 1
 fi
 
 BUILD_DIR=$(pwd)
-INCLUDE_DIR=$BUILD_DIR/include/$CONFIG
-LIB_DIR=$BUILD_DIR/lib/$CONFIG
+INCLUDE_DIR=$BUILD_DIR/include/"$CONFIG"
+LIB_DIR=$BUILD_DIR/lib/"$CONFIG"
 
-if [ ! -e $INCLUDE_DIR/blis.h ]; then
+if [ ! -e "$INCLUDE_DIR"/blis.h ]; then
     echo "could not find blis.h"
     exit 1
 fi
 
-if [ ! -e $SOURCE_DIR/ci/cxx/Makefile ]; then
+if [ ! -e "$SOURCE_DIR"/ci/cxx/Makefile ]; then
     echo "could not find cxx-test Makefile"
     exit 1
 fi
 
-make -C $SOURCE_DIR/ci/cxx INCLUDE_DIR=$INCLUDE_DIR LIB_DIR=$LIB_DIR BUILD_DIR=$BUILD_DIR
+make -C "$SOURCE_DIR"/ci/cxx INCLUDE_DIR="$INCLUDE_DIR" LIB_DIR="$LIB_DIR" BUILD_DIR="$BUILD_DIR"

--- a/ci/do_level0.sh
+++ b/ci/do_level0.sh
@@ -3,11 +3,11 @@
 set -e
 set -x
 
-: ${SRCDIR:=../..}
+: "${SRCDIR:=../..}"
 
 if ! [ -d test/level0 ]; then
     mkdir -p test/level0
-    ln -s $SRCDIR/test/level0/* test/level0/
+    ln -s "$SRCDIR"/test/level0/* test/level0/
 fi
 
 cd test/level0

--- a/ci/do_riscv.sh
+++ b/ci/do_riscv.sh
@@ -25,15 +25,15 @@ esac
 TOOLCHAIN_PATH=$DIST_PATH/../toolchain
 TOOLCHAIN_URL=https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${TAG}/${TARBALL}
 
-mkdir -p $TOOLCHAIN_PATH
-cd $TOOLCHAIN_PATH
+mkdir -p "$TOOLCHAIN_PATH"
+cd "$TOOLCHAIN_PATH"
 
-wget $TOOLCHAIN_URL
-tar -xf $TARBALL
+wget "$TOOLCHAIN_URL"
+tar -xf "$TARBALL"
 
 # Once CI upgrades to jammy, the next three lines can be removed.
 # The qemu version installed via packages (qemu-user qemu-user-binfmt)
 # is sufficient.
 TARBALL_QEMU=qemu-riscv-2023.02.25-ubuntu-20.04.tar.gz
-wget https://github.com/flame/ci-utils/raw/master/riscv/${TARBALL_QEMU}
-tar -xf $TARBALL_QEMU
+wget https://github.com/flame/ci-utils/raw/master/riscv/"${TARBALL_QEMU}"
+tar -xf "$TARBALL_QEMU"

--- a/ci/do_sde.sh
+++ b/ci/do_sde.sh
@@ -65,7 +65,7 @@ for ARCH in penryn sandybridge haswell skx knl piledriver steamroller excavator 
 
     make TESTSUITE_WRAPPER="$TESTSUITE_WRAPPER" check
 
-    TMP=`grep "active sub-configuration" output.testsuite`
+    TMP=$(grep "active sub-configuration" output.testsuite)
     CONFIG=${TMP##* }
     if [ "$CONFIG" != "$ARCH" ]; then
         echo "Wrong configuration chosen:"

--- a/ci/do_testsuite.sh
+++ b/ci/do_testsuite.sh
@@ -9,41 +9,40 @@ export BLIS_JR_NT=1
 export BLIS_IR_NT=1
 export BLIS_THREAD_IMPL="single"
 
-if [ "$TEST" = "FAST" -o "$TEST" = "ALL" ]; then
+if [[ "$TEST" = "FAST" || "$TEST" = "ALL" ]]; then
 	make testblis-fast
 	cat ./output.testsuite
-	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	"$DIST_PATH"/testsuite/check-blistest.sh ./output.testsuite
 
-	for impl in $(echo $THR | sed 's/none//' | tr , ' '); do
+	for impl in $(echo "$THR" | sed 's/none//' | tr , ' '); do
 		export BLIS_THREAD_IMPL="$impl"
 		make testblis-fast
 		cat ./output.testsuite
-		$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+		"$DIST_PATH"/testsuite/check-blistest.sh ./output.testsuite
 	done
 fi
 
-if [ "$TEST" = "MD" -o "$TEST" = "ALL" ]; then
+if [[ "$TEST" = "MD" || "$TEST" = "ALL" ]]; then
 	make testblis-md
 	cat ./output.testsuite
-	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	"$DIST_PATH"/testsuite/check-blistest.sh ./output.testsuite
 fi
 
-if [ "$TEST" = "SALT" -o "$TEST" = "ALL" ]; then
+if [[ "$TEST" = "SALT" || "$TEST" = "ALL" ]]; then
 	# Disable multithreading within BLIS.
 	export BLIS_JC_NT=1 BLIS_IC_NT=1 BLIS_JR_NT=1 BLIS_IR_NT=1
 	make testblis-salt
 	cat ./output.testsuite
-	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	"$DIST_PATH"/testsuite/check-blistest.sh ./output.testsuite
 fi
 
-if [ "$TEST" = "1" -o "$TEST" = "ALL" ]; then
+if [[ "$TEST" = "1" || "$TEST" = "ALL" ]]; then
 	make testblis
 	cat ./output.testsuite
-	$DIST_PATH/testsuite/check-blistest.sh ./output.testsuite
+	"$DIST_PATH"/testsuite/check-blistest.sh ./output.testsuite
 fi
 
 export BLIS_THREAD_IMPL="single"
 make testblas
 cat ./output.testsuite
-$DIST_PATH/blastest/check-blastest.sh
-
+"$DIST_PATH"/blastest/check-blastest.sh

--- a/common.mk
+++ b/common.mk
@@ -330,7 +330,7 @@ CONFIG_MK_FILE     := config.mk
 # including common.mk, that path is used instead. This allows Makefiles for
 # example code and test drivers to reference an installed prefix directory
 # for situations when the build directory no longer exists.
-BASE_SHARE_PATH    := $(SHARE_PATH)
+BASE_SHARE_PATH    := $(shell echo $(SHARE_PATH) | sed 's/ /\\ /g')
 
 # Include the configuration file.
 -include $(BASE_SHARE_PATH)/$(CONFIG_MK_FILE)
@@ -369,6 +369,18 @@ DIST_PATH := .
 INSTALL_LIBDIR   := $(HOME)/blis/lib
 INSTALL_INCDIR   := $(HOME)/blis/include
 INSTALL_SHAREDIR := $(HOME)/blis/share
+
+else
+
+DIST_PATH_REAL := $(DIST_PATH)
+INSTALL_LIBDIR_REAL := $(INSTALL_LIBDIR)
+INSTALL_INCDIR_REAL := $(INSTALL_INCDIR)
+INSTALL_SHAREDIR_REAL := $(INSTALL_SHAREDIR)
+
+DIST_PATH := .dist_path
+INSTALL_LIBDIR := .install_libdir
+INSTALL_INCDIR := .install_incdir
+INSTALL_SHAREDIR := .install_sharedir
 
 endif
 
@@ -659,7 +671,7 @@ SOFLAGS    := -dynamiclib
 ifeq ($(MK_ENABLE_RPATH),yes)
 SOFLAGS    += -Wl,-install_name,@rpath/$(LIBBLIS_SONAME)
 else
-SOFLAGS    += -Wl,-install_name,$(libdir)/$(LIBBLIS_SONAME)
+SOFLAGS    += -Wl,-install_name,$(shell echo $(INSTALL_LIBDIR_REAL) | sed 's/ /\\ /g')/$(LIBBLIS_SONAME)
 endif
 else
 SOFLAGS    := -shared

--- a/config/altra/QuickStart/blis_build_altra.sh
+++ b/config/altra/QuickStart/blis_build_altra.sh
@@ -8,7 +8,7 @@ echo "Configuring BLIS for Altra using OpenMP for parallelism..."
 echo "##########################################################"
 . ./blis_configure_altra.sh quiet
 echo "Switching to directory $BLIS_HOME"
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make -j
 popd > /dev/null
 if [ "$1" != "notest" ]; then

--- a/config/altra/QuickStart/blis_build_altra_pthreads.sh
+++ b/config/altra/QuickStart/blis_build_altra_pthreads.sh
@@ -8,7 +8,7 @@ echo "Configuring BLIS for Altra using pThreads for parallelism..."
 echo "##########################################################"
 . ./blis_configure_altra_pthreads.sh quiet
 echo "Switching to directory $BLIS_HOME"
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make -j
 popd > /dev/null
 if [ "$1" != "notest" ]; then

--- a/config/altra/QuickStart/blis_build_both_libraries.sh
+++ b/config/altra/QuickStart/blis_build_both_libraries.sh
@@ -10,28 +10,27 @@ echo "##########################################################"
 echo "Saving the pThreads build..."
 echo "##########################################################"
 # Temporarily move the pthreads build
-mkdir $BLIS_HOME/.tempinc
-mkdir $BLIS_HOME/.templib
-mv $BLIS_INC/* $BLIS_HOME/.tempinc/
-mv $BLIS_LIB/* $BLIS_HOME/.templib/
+mkdir "$BLIS_HOME"/.tempinc
+mkdir "$BLIS_HOME"/.templib
+mv "$BLIS_INC"/* "$BLIS_HOME"/.tempinc/
+mv "$BLIS_LIB"/* "$BLIS_HOME"/.templib/
 # And rename the pthread versions of the include and library files
 #echo "##########################################################"
-pushd $BLIS_HOME/.tempinc/ > /dev/null
+pushd "$BLIS_HOME"/.tempinc/ > /dev/null
 echo "Renaming pThread-enabled blis.h -> blisP.h"
 mv blis.h blisP.h
 popd > /dev/null
-pushd $BLIS_HOME/.templib/ > /dev/null
-for f in $(ls -1); do
+pushd "$BLIS_HOME"/.templib/ > /dev/null
+for f in *; do
     destf=${f/blis/blisP}
     echo "Renaming pThread library $f -> $destf"
     mv "$f" "$destf"
 
     # Fix the symbolic links
     if [[ -L "$destf" ]]; then
-        target=$(readlink $destf)
+        target=$(readlink "$destf")
         target=${target/blis/blisP}
-        \rm "$destf"
-        ln -s "$target" "$destf"
+        ln -sf "$target" "$destf"
     fi
 done
 popd > /dev/null
@@ -46,10 +45,10 @@ echo "##########################################################"
 echo "Restoring the pThreads build..."
 echo "##########################################################"
 # And move the pthread versions back
-mv $BLIS_HOME/.tempinc/*  $BLIS_INC/
-mv $BLIS_HOME/.templib/* $BLIS_LIB/
-rmdir $BLIS_HOME/.tempinc
-rmdir $BLIS_HOME/.templib
+mv "$BLIS_HOME"/.tempinc/*  "$BLIS_INC"/
+mv "$BLIS_HOME"/.templib/* "$BLIS_LIB"/
+rmdir "$BLIS_HOME"/.tempinc
+rmdir "$BLIS_HOME"/.templib
 
 . ./blis_test.sh quiet
 . ./blis_setenv.sh

--- a/config/altra/QuickStart/blis_configure_altra.sh
+++ b/config/altra/QuickStart/blis_configure_altra.sh
@@ -13,7 +13,7 @@ if [ "$quiet_confopenmp" = "" ]; then
 fi
 
 . ./blis_setenv.sh $quiet_confopenmp
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make distclean
 ./configure -t openmp --disable-pba-pools altra
 popd > /dev/null

--- a/config/altra/QuickStart/blis_configure_altra_pthreads.sh
+++ b/config/altra/QuickStart/blis_configure_altra_pthreads.sh
@@ -13,7 +13,7 @@ if [ "$quiet_confpthreads" = "" ]; then
 fi
 
 . ./blis_setenv.sh $quiet_confpthreads
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make distclean
 ./configure -t pthreads --disable-pba-pools altra
 popd > /dev/null

--- a/config/altra/QuickStart/blis_quick_start_uninstall_altra.sh
+++ b/config/altra/QuickStart/blis_quick_start_uninstall_altra.sh
@@ -5,24 +5,24 @@
 #
 if [[ -n "$BLIS_HOME" ]]; then
   echo "REMOVING ALL ALTRA QUICKSTART FILES FROM $BLIS_HOME"
-    
-  rm $BLIS_HOME/blis_build_altra_pthreads.sh
-	rm $BLIS_HOME/blis_build_altra.sh
-	rm $BLIS_HOME/blis_build_both_libraries.sh
-	
-	rm $BLIS_HOME/blis_configure_altra_pthreads.sh
-	rm $BLIS_HOME/blis_configure_altra.sh
-	
-	rm $BLIS_HOME/blis_quick_start_altra.txt
-	rm $BLIS_HOME/blis_setenv.sh
-	
-  rm $BLIS_HOME/blis_unset_par.sh
-  rm $BLIS_HOME/blis_test.sh
 
-	rm $BLIS_HOME/TimeDGEMM.c
-	rm $BLIS_HOME/time_gemm.x
-	
-	rm $BLIS_HOME/blis_quick_start_uninstall_altra.sh
+  rm "$BLIS_HOME"/blis_build_altra_pthreads.sh
+	rm "$BLIS_HOME"/blis_build_altra.sh
+	rm "$BLIS_HOME"/blis_build_both_libraries.sh
+
+	rm "$BLIS_HOME"/blis_configure_altra_pthreads.sh
+	rm "$BLIS_HOME"/blis_configure_altra.sh
+
+	rm "$BLIS_HOME"/blis_quick_start_altra.txt
+	rm "$BLIS_HOME"/blis_setenv.sh
+
+  rm "$BLIS_HOME"/blis_unset_par.sh
+  rm "$BLIS_HOME"/blis_test.sh
+
+	rm "$BLIS_HOME"/TimeDGEMM.c
+	rm "$BLIS_HOME"/time_gemm.x
+
+	rm "$BLIS_HOME"/blis_quick_start_uninstall_altra.sh
 
 else
   echo "ONLY USE THIS SCRIPT FROM THE BLIS HOME DIRECTORY!"

--- a/config/altra/QuickStart/blis_setenv.sh
+++ b/config/altra/QuickStart/blis_setenv.sh
@@ -29,7 +29,7 @@ else
 fi
 
 if [ -f "$file_path_and_name" ] ; then
-	. $file_path_and_name quiet
+	. "$file_path_and_name" quiet
 else
   echo "ERROR - this file is not being executed from a blis home directory."
   echo "If you cannot use this script in a home directory, you can hardcode"
@@ -64,11 +64,11 @@ if [ "$quiet_setenv" = "" ]; then
   echo "BLIS_HOME set to $BLIS_HOME"
   echo "BLIS_INC set to $BLIS_INC"
   echo "================================================================="
-  ls -l $BLIS_INC
+  ls -l "$BLIS_INC"
   echo "-----------------------------------------------------------------"
   echo "BLIS_LIB set to $BLIS_LIB"
   echo "-----------------------------------------------------------------"
-  ls -l $BLIS_LIB
+  ls -l "$BLIS_LIB"
   echo "#################################################################"
 fi
 
@@ -116,7 +116,7 @@ elif (($firmware == 108)); then
 arrayCoreIDs=(28 29 38 39 2 3 12 13 6 7 16 17 0 1 10 11 68 69 78 79 42 43 52 53 46 47 56 57 40 41 50 51 24 25 34 35 20 21 30 31 26 27 36 37 22 23 32 33 64 65 74 75 60 61 70 71 66 67 76 77 62 63 72 73 8 9 18 19 4 5 14 15 48 49 58 59 44 45 54 55 108 109 118 119 82 83 92 93 86 87 96 97 80 81 90 91 148 149 158 159 122 123 132 133 126 127 136 137 120 121 130 131 104 105 114 115 100 101 110 111 106 107 116 117 102 103 112 113 144 145 154 155 140 141 150 151 146 147 156 157 142 143 152 153 88 89 98 99 84 85 94 95 128 129 138 139 124 125 134 135)
 else
   echo "ERROR - UNSUPPORTED FIRMWARE $firmware"
-  exit -1
+  exit 2
 fi
 
 # Brief check: @ = list all numbers, loop for i in ${}; do ... done
@@ -183,8 +183,8 @@ blis_set_cores_and_sockets() {
 	}
 	
 # Convenience functions:
-blis_set_cores_1S() { blis_set_cores_and_sockets $1 1 ; }
-blis_set_cores_2S() { blis_set_cores_and_sockets $1 2 ; }
+blis_set_cores_1S() { blis_set_cores_and_sockets "$1" 1 ; }
+blis_set_cores_2S() { blis_set_cores_and_sockets "$1" 2 ; }
 
 # For safety:
 . ./blis_unset_par.sh

--- a/config/altra/QuickStart/blis_test.sh
+++ b/config/altra/QuickStart/blis_test.sh
@@ -16,7 +16,7 @@ echo "#################################################################"
 # running the test code!
 . ./blis_unset_par.sh quiet
 echo "Switching to directory $BLIS_HOME"
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make check -j
 popd > /dev/null
 

--- a/config/altra/QuickStart/blis_unset_par.sh
+++ b/config/altra/QuickStart/blis_unset_par.sh
@@ -1,4 +1,4 @@
-#!/bin/blis
+#!/bin/sh
 
 if [ "$1" = "quiet" ]; then
     quiet_unsetpar="quiet"

--- a/config/altramax/QuickStart/blis_build_altramax.sh
+++ b/config/altramax/QuickStart/blis_build_altramax.sh
@@ -8,7 +8,7 @@ echo "Configuring BLIS for Altramax using OpenMP for parallelism..."
 echo "#############################################################"
 . ./blis_configure_altramax.sh quiet
 echo "Switching to directory $BLIS_HOME"
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make -j
 popd > /dev/null
 if [ "$1" != "notest" ]; then

--- a/config/altramax/QuickStart/blis_build_altramax_pthreads.sh
+++ b/config/altramax/QuickStart/blis_build_altramax_pthreads.sh
@@ -8,7 +8,7 @@ echo "Configuring BLIS for Altramax using pThreads for parallelism..."
 echo "###############################################################"
 . ./blis_configure_altramax_pthreads.sh quiet
 echo "Switching to directory $BLIS_HOME"
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make -j
 popd > /dev/null
 if [ "$1" != "notest" ]; then

--- a/config/altramax/QuickStart/blis_build_both_libraries.sh
+++ b/config/altramax/QuickStart/blis_build_both_libraries.sh
@@ -10,25 +10,25 @@ echo "##########################################################"
 echo "Saving the pThreads build..."
 echo "##########################################################"
 # Temporarily move the pthreads build
-mkdir $BLIS_HOME/.tempinc
-mkdir $BLIS_HOME/.templib
-mv $BLIS_INC/* $BLIS_HOME/.tempinc/
-mv $BLIS_LIB/* $BLIS_HOME/.templib/
+mkdir "$BLIS_HOME"/.tempinc
+mkdir "$BLIS_HOME"/.templib
+mv "$BLIS_INC"/* "$BLIS_HOME"/.tempinc/
+mv "$BLIS_LIB"/* "$BLIS_HOME"/.templib/
 # And rename the pthread versions of the include and library files
 #echo "##########################################################"
-pushd $BLIS_HOME/.tempinc/ > /dev/null
+pushd "$BLIS_HOME"/.tempinc/ > /dev/null
 echo "Renaming pThread-enabled blis.h -> blisP.h"
 mv blis.h blisP.h
 popd > /dev/null
-pushd $BLIS_HOME/.templib/ > /dev/null
-for f in $(ls -1); do
+pushd "$BLIS_HOME"/.templib/ > /dev/null
+for f in *; do
     destf=${f/blis/blisP}
     echo "Renaming pThread library $f -> $destf"
     mv "$f" "$destf"
 
     # Fix the symbolic links
     if [[ -L "$destf" ]]; then
-        target=$(readlink $destf)
+        target=$(readlink "$destf")
         target=${target/blis/blisP}
         \rm "$destf"
         ln -s "$target" "$destf"
@@ -46,10 +46,10 @@ echo "##########################################################"
 echo "Restoring the pThreads build..."
 echo "##########################################################"
 # And move the pthread versions back
-mv $BLIS_HOME/.tempinc/*  $BLIS_INC/
-mv $BLIS_HOME/.templib/* $BLIS_LIB/
-rmdir $BLIS_HOME/.tempinc
-rmdir $BLIS_HOME/.templib
+mv "$BLIS_HOME"/.tempinc/*  "$BLIS_INC"/
+mv "$BLIS_HOME"/.templib/* "$BLIS_LIB"/
+rmdir "$BLIS_HOME"/.tempinc
+rmdir "$BLIS_HOME"/.templib
 
 . ./blis_test.sh quiet
 . ./blis_setenv.sh

--- a/config/altramax/QuickStart/blis_configure_altramax.sh
+++ b/config/altramax/QuickStart/blis_configure_altramax.sh
@@ -13,7 +13,7 @@ if [ "$quiet_confopenmp" = "" ]; then
 fi
 
 . ./blis_setenv.sh $quiet_confopenmp
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make distclean
 ./configure -t openmp --disable-pba-pools altramax
 popd > /dev/null

--- a/config/altramax/QuickStart/blis_configure_altramax_pthreads.sh
+++ b/config/altramax/QuickStart/blis_configure_altramax_pthreads.sh
@@ -13,7 +13,7 @@ if [ "$quiet_confpthreads" = "" ]; then
 fi
 
 . ./blis_setenv.sh $quiet_confpthreads
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make distclean
 ./configure -t pthreads --disable-pba-pools altramax
 popd > /dev/null

--- a/config/altramax/QuickStart/blis_quick_start_uninstall_altramax.sh
+++ b/config/altramax/QuickStart/blis_quick_start_uninstall_altramax.sh
@@ -5,24 +5,24 @@
 #
 if [[ -n "$BLIS_HOME" ]]; then
   echo "REMOVING ALL ALTRAMAX QUICKSTART FILES FROM $BLIS_HOME"
-    
-  rm $BLIS_HOME/blis_build_altramax_pthreads.sh
-	rm $BLIS_HOME/blis_build_altramax.sh
-	rm $BLIS_HOME/blis_build_both_libraries.sh
-	
-	rm $BLIS_HOME/blis_configure_altramax_pthreads.sh
-	rm $BLIS_HOME/blis_configure_altramax.sh
-	
-	rm $BLIS_HOME/blis_quick_start_altramax.txt
-	rm $BLIS_HOME/blis_setenv.sh
-	
-  rm $BLIS_HOME/blis_unset_par.sh
-  rm $BLIS_HOME/blis_test.sh
 
-	rm $BLIS_HOME/TimeDGEMM.c
-	rm $BLIS_HOME/time_gemm.x
-	
-	rm $BLIS_HOME/blis_quick_start_uninstall_altramax.sh
+  rm "$BLIS_HOME"/blis_build_altramax_pthreads.sh
+	rm "$BLIS_HOME"/blis_build_altramax.sh
+	rm "$BLIS_HOME"/blis_build_both_libraries.sh
+
+	rm "$BLIS_HOME"/blis_configure_altramax_pthreads.sh
+	rm "$BLIS_HOME"/blis_configure_altramax.sh
+
+	rm "$BLIS_HOME"/blis_quick_start_altramax.txt
+	rm "$BLIS_HOME"/blis_setenv.sh
+
+  rm "$BLIS_HOME"/blis_unset_par.sh
+  rm "$BLIS_HOME"/blis_test.sh
+
+	rm "$BLIS_HOME"/TimeDGEMM.c
+	rm "$BLIS_HOME"/time_gemm.x
+
+	rm "$BLIS_HOME"/blis_quick_start_uninstall_altramax.sh
 
 else
   echo "ONLY USE THIS SCRIPT FROM THE BLIS HOME DIRECTORY!"

--- a/config/altramax/QuickStart/blis_setenv.sh
+++ b/config/altramax/QuickStart/blis_setenv.sh
@@ -29,7 +29,7 @@ else
 fi
 
 if [ -f "$file_path_and_name" ] ; then
-	. $file_path_and_name quiet
+	.  "$file_path_and_name" quiet
 else
   echo "ERROR - this file is not being executed from a blis home directory."
   echo "If you cannot use this script in a home directory, you can hardcode"
@@ -55,11 +55,11 @@ if [ "$quiet_setenv" = "" ]; then
   echo "BLIS_HOME set to $BLIS_HOME"
   echo "BLIS_INC set to $BLIS_INC"
   echo "-----------------------------------------------------------------"
-  ls -l $BLIS_INC
+  ls -l "$BLIS_INC"
   echo "-----------------------------------------------------------------"
   echo "BLIS_LIB set to $BLIS_LIB"
   echo "-----------------------------------------------------------------"
-  ls -l $BLIS_LIB
+  ls -l "$BLIS_LIB"
   echo "-----------------------------------------------------------------"
 fi
 
@@ -108,7 +108,7 @@ elif (($firmware == 205)); then
     arrayCoreIDs=(0 1 64 65 8 9 72 73 2 3 66 67 10 11 74 75 4 5 68 69 12 13 76 77 6 7 70 71 14 15 78 79 16 17 80 81 24 25 88 89 18 19 82 83 26 27 90 91 20 21 84 85 28 29 92 93 22 23 86 87 30 31 94 95 32 33 96 97 40 41 104 105 34 35 98 99 42 43 106 107 36 37 100 101 44 45 108 109 38 39 102 103 46 47 110 111 48 49 112 113 52 53 116 117 50 51 114 115 54 55 118 119 56 57 120 121 60 61 124 125 58 59 122 123 62 63 126 127 128 129 192 193 136 137 200 201 130 131 194 195 138 139 202 203 132 133 196 197 140 141 204 205 134 135 198 199 142 143 206 207 144 145 208 209 152 153 216 217 146 147 210 211 154 155 218 219 148 149 212 213 156 157 220 221 150 151 214 215 158 159 222 223 160 161 224 225 168 169 232 233 162 163 226 227 170 171 234 235 164 165 228 229 172 173 236 237 166 167 230 231 174 175 238 239 176 177 240 241 180 181 244 245 178 179 242 243 182 183 246 247 184 185 248 249 188 189 252 253 186 187 250 251 190 191 254 255)
 else
   echo "ERROR - UNSUPPORTED FIRMWARE $firmware"
-  exit -1
+  exit 2
 fi
 
 # Brief check: @ = list all numbers, loop for i in ${}; do ... done
@@ -173,11 +173,10 @@ blis_set_cores_and_sockets() {
   echo "GOMP_CPU_AFFINITY set to $GOMP_CPU_AFFINITY"
   echo "JC/IC/JR = $BLIS_JC_NT/$BLIS_IC_NT/$BLIS_JR_NT"
 	}
-	
+
 # Convenience functions:
-blis_set_cores_1S() { blis_set_cores_and_sockets $1 1 ; }
-blis_set_cores_2S() { blis_set_cores_and_sockets $1 2 ; }
+blis_set_cores_1S() { blis_set_cores_and_sockets "$1" 1 ; }
+blis_set_cores_2S() { blis_set_cores_and_sockets "$1" 2 ; }
 
 # For safety:
 . ./blis_unset_par.sh
-

--- a/config/altramax/QuickStart/blis_test.sh
+++ b/config/altramax/QuickStart/blis_test.sh
@@ -16,7 +16,7 @@ echo "#################################################################"
 # running the test code!
 . ./blis_unset_par.sh quiet
 echo "Switching to directory $BLIS_HOME"
-pushd $BLIS_HOME > /dev/null
+pushd "$BLIS_HOME" > /dev/null
 make check -j
 popd > /dev/null
 

--- a/config/altramax/QuickStart/blis_unset_par.sh
+++ b/config/altramax/QuickStart/blis_unset_par.sh
@@ -1,4 +1,4 @@
-#!/bin/blis
+#!/bin/sh
 
 if [ "$1" = "quiet" ]; then
     quiet_unsetpar="quiet"

--- a/configure
+++ b/configure
@@ -31,8 +31,8 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#
-# shellcheck disable=2001,2249,2034,2154,2181,2312,2250,2292
+# shellcheck enable=all
+# shellcheck disable=2001,2249,2034,2154,2181,2312,2250,2292,2248
 
 #
 # -- Helper functions ----------------------------------------------------------
@@ -1818,7 +1818,7 @@ check_compiler()
     if [[ ${cc_vendor} = NVIDIA ]]; then
         blacklistcc_add "knl"
     fi
-    
+
     # gcc
     if [[ ${cc_vendor} = gcc ]]; then
 
@@ -2448,7 +2448,7 @@ check_tool()
 		for opt in ${the_flags}; do
 
 			# See if the tool responds to the current flag.
-			${tool} ${opt} > /dev/null 2>&1
+			"${tool}" "${opt}" > /dev/null 2>&1
 
 			# If the tool responded to the flag with a nominal error code of
 			# 0, we found one that works and set rval accoringly.
@@ -2847,7 +2847,7 @@ create_makefile_fragment()
 	fi
 	echo "${script_name}: creating makefile fragments in $3"
 	"${gen_make_frags_sh}"                       \
-		-h ${recursive} -v0                      \
+		-h "${recursive}" -v0                    \
 		-o "${script_name}"                      \
 		-p "$1" "$2" "$3"                        \
 		"${gen_make_frags_dirpath}/fragment.mk"  \
@@ -3575,7 +3575,7 @@ blis_main()
 
 	fi
 
-	build_and_check_configurations
+	build_and_check_configurations "${config_name}"
 
 	# In order to determine the default behavior of the --with[out]-memkind
 	# option, we try to detect whether libmemkind is available. If it is,
@@ -4707,7 +4707,7 @@ blis_main()
 
     rm -f .dist_path; ln -s "${dist_path}" .dist_path
     rm -f .install_libdir; ln -s "${libdir}" .install_libdir
-    rm -f .install_incdir; ln -s "${includedir}" .install_libdir
+    rm -f .install_incdir; ln -s "${includedir}" .install_incdir
     rm -f .install_sharedir; ln -s "${sharedir}" .install_sharedir
 
 	# -- Handle out-of-tree builds ---------------------------------------------
@@ -4738,17 +4738,18 @@ blis_main()
 		echo "${script_name}: configured to build within top-level directory of source distribution."
 	fi
 
-	if [ "${warn_user_generic}" = "1" ]; then
-
-		echo "${script_name}: "
-		echo "${script_name}: *** Unable to automatically detect hardware type! ***"
-		echo "${script_name}: "
-		echo "${script_name}: NOTE: configure was unable to identify a subconfiguration"
-		echo "${script_name}: optimized for your hardware. As a result, the 'generic'"
-		echo "${script_name}: subconfiguration (with low-performance reference kernels)"
-		echo "${script_name}: will be used. For support, please open an issue on GitHub"
-		echo "${script_name}: at https://github.com/flame/blis/issues."
-		echo "${script_name}: "
+	if [[ ${warn_user_generic} = 1 ]]; then
+        cat <<EOF
+${script_name}:
+${script_name}: *** Unable to automatically detect hardware type! ***
+${script_name}:
+${script_name}: NOTE: configure was unable to identify a subconfiguration
+${script_name}: optimized for your hardware. As a result, the 'generic'
+${script_name}: subconfiguration (with low-performance reference kernels)
+${script_name}: will be used. For support, please open an issue on GitHub
+${script_name}: at https://github.com/flame/blis/issues.
+${script_name}:
+EOF
 	fi
 
 	# Exit peacefully.
@@ -4922,7 +4923,7 @@ EOF
 
 get_config_var()
 {
-	echo "$(grep "^ *$1 *:=" ${sharedir}/blis/config.mk | sed 's/'$1' *:= *//')"
+    grep "^ *$1 *:=" "${sharedir}"/blis/config.mk | sed 's/'"$1"' *:= *//'
 }
 
 maybe_echo()
@@ -5262,11 +5263,11 @@ plugin_main()
 	if [ $# -gt "1" ]; then   # more than one configuration argument given.
 		print_usage_plugin
 	elif [ $# == "0" ]; then   # try to guess the plugin name.
-		plugin_h=$(ls ${plugin_dir}/bli_plugin_*.h 2>/dev/null)
-		if [ -z ${plugin_h} ]; then
+		plugin_h=$(ls "${plugin_dir}"/bli_plugin_*.h 2>/dev/null)
+		if [ -z "${plugin_h}" ]; then
 			print_usage_plugin
 		else
-			plugin_name=$(echo ${plugin_h} | sed -e 's/.*bli_plugin_//' -e 's/\.h//')
+			plugin_name=$(echo "${plugin_h}" | sed -e 's/.*bli_plugin_//' -e 's/\.h//')
 		fi
 	else
 		plugin_name="${1}"
@@ -5396,7 +5397,7 @@ plugin_main()
 		if [ -e config_registry ] && [ ${force_flag} == '0' ]; then
 			maybe_echo "already done"
 		else
-			cp ${sharedir}/blis/config_registry config_registry
+			cp "${sharedir}"/blis/config_registry config_registry
 			maybe_echo "done"
 		fi
 
@@ -5408,9 +5409,9 @@ plugin_main()
 			maybe_echo "already done"
 		else
 			if [ ${examples_flag} == '1' ]; then
-				cp ${sharedir}/blis/plugin/bli_plugin_register.c bli_plugin_register.c
+				cp "${sharedir}"/blis/plugin/bli_plugin_register.c bli_plugin_register.c
 			else
-				strip_examples ${sharedir}/blis/plugin/bli_plugin_register.c bli_plugin_register.c
+				strip_examples "${sharedir}/blis/plugin/bli_plugin_register.c" bli_plugin_register.c
 			fi
 			perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" bli_plugin_register.c
 			maybe_echo "done"
@@ -5418,15 +5419,15 @@ plugin_main()
 
 		# -- bli_plugin_<name>.h --
 
-		if [ -e bli_plugin_${plugin_name}.h ] && [ ${force_flag} == '0' ]; then
+		if [ -e "bli_plugin_${plugin_name}.h" ] && [ ${force_flag} == '0' ]; then
 			maybe_echo "${script_name}: creating bli_plugin_${plugin_name}.h from ${sharedir}/blis/plugin/bli_plugin.h.in...already done"
 		else
 			if [ ${examples_flag} == '1' ]; then
-				generate_config_file ${sharedir}/blis/plugin/bli_plugin.h.in bli_plugin_${plugin_name}.h
+				generate_config_file "${sharedir}/blis/plugin/bli_plugin.h.in" "bli_plugin_${plugin_name}.h"
 			else
-				generate_config_file ${sharedir}/blis/plugin/bli_plugin.h.in bli_plugin_${plugin_name}_.h
-				strip_examples bli_plugin_${plugin_name}_.h bli_plugin_${plugin_name}.h
-				rm bli_plugin_${plugin_name}_.h
+				generate_config_file "${sharedir}/blis/plugin/bli_plugin.h.in" "bli_plugin_${plugin_name}_.h"
+				strip_examples "bli_plugin_${plugin_name}_.h" "bli_plugin_${plugin_name}.h"
+				rm "bli_plugin_${plugin_name}_.h"
 			fi
 		fi
 
@@ -5441,14 +5442,14 @@ plugin_main()
 			files="bli_plugin_init_ref.c"
 		fi
 		for file in ${files}; do
-			if [ ! -e ref_kernels/${file} ] || [ ${force_flag} == '1' ]; then
+			if [ ! -e "ref_kernels/${file}" ] || [ ${force_flag} == '1' ]; then
 				mkdir -p ref_kernels
 				if [ ${examples_flag} == '1' ]; then
-					cp ${sharedir}/blis/plugin/${file} ref_kernels/${file}
+					cp "${sharedir}/blis/plugin/${file}" "ref_kernels/${file}"
 				else
-					strip_examples ${sharedir}/blis/plugin/${file} ref_kernels/${file}
+					strip_examples "${sharedir}/blis/plugin/${file}" "ref_kernels/${file}"
 				fi
-				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" ref_kernels/${file}
+				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" "ref_kernels/${file}"
 				done="false"
 			fi
 		done
@@ -5466,28 +5467,28 @@ plugin_main()
 		for config in ${full_config_list}; do
 			maybe_echo -n "${script_name}:   config/${config}..."
 
-			if [ -e config/${config}/make_defs.mk ] && [ ${force_flag} == '0' ]; then
+			if [ -e "config/${config}/make_defs.mk" ] && [ ${force_flag} == '0' ]; then
 				maybe_echo "already done"
 			else
-				mkdir -p config/${config}
-				cp ${sharedir}/blis/config/${config}/make_defs.mk config/${config}
+				mkdir -p "config/${config}"
+				cp "${sharedir}/blis/config/${config}/make_defs.mk" "config/${config}"
 				maybe_echo "done"
 			fi
 		done
 
 		for config in ${full_subconfig_list}; do
-			if [ ! -e config/${config}/bli_plugin_init_${config}.c ] || [ ${force_flag} == '1' ]; then
-				if [ ${config} != zen3 ] || [ ${examples_flag} == '0' ]; then
-					strip_examples ${sharedir}/blis/plugin/bli_plugin_init_zen3.c config/${config}/bli_plugin_init_${config}.c
-					perl -pi -e "s/zen3/${config}/g" config/${config}/bli_plugin_init_${config}.c
+			if [ ! -e "config/${config}/bli_plugin_init_${config}.c" ] || [ ${force_flag} == '1' ]; then
+				if [ "${config}" != zen3 ] || [ ${examples_flag} == '0' ]; then
+					strip_examples "${sharedir}/blis/plugin/bli_plugin_init_zen3.c" "config/${config}/bli_plugin_init_${config}.c"
+					perl -pi -e "s/zen3/${config}/g" "config/${config}/bli_plugin_init_${config}.c"
 				else
-					cp ${sharedir}/blis/plugin/bli_plugin_init_zen3.c config/${config}/bli_plugin_init_${config}.c
+					cp "${sharedir}/blis/plugin/bli_plugin_init_zen3.c" "config/${config}/bli_plugin_init_${config}.c"
 				fi
-				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" config/${config}/bli_plugin_init_${config}.c
+				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" "config/${config}/bli_plugin_init_${config}.c"
 			fi
 
-			if [ ! -e config/${config}/bli_kernel_defs_${config}.h ] || [ ${force_flag} == '1' ]; then
-				cp ${sharedir}/blis/config/${config}/bli_kernel_defs_${config}.h config/${config}/bli_kernel_defs_${config}.h
+			if [ ! -e "config/${config}/bli_kernel_defs_${config}.h" ] || [ ${force_flag} == '1' ]; then
+				cp "${sharedir}/blis/config/${config}/bli_kernel_defs_${config}.h" "config/${config}/bli_kernel_defs_${config}.h"
 			fi
 		done
 
@@ -5498,17 +5499,17 @@ plugin_main()
 		for kernels in ${full_kernel_list}; do
 			maybe_echo -n "${script_name}:   kernels/${kernels}..."
 
-			if [ -e kernels/${kernels} ] && [ ${force_flag} == '0' ]; then
+			if [ -e kernels/"${kernels}" ] && [ ${force_flag} == '0' ]; then
 				maybe_echo "already done"
 			else
-				mkdir -p kernels/${kernels}
+				mkdir -p kernels/"${kernels}"
 				maybe_echo "done"
 			fi
 		done
 
 		if [ ${examples_flag} == '1' ]; then
 			if [ ! -e kernels/zen3/my_kernel_1_zen3.c ] || [ ${force_flag} == '1' ]; then
-				cp ${sharedir}/blis/plugin/my_kernel_1_zen3.c kernels/zen3
+				cp "${sharedir}"/blis/plugin/my_kernel_1_zen3.c kernels/zen3
 				perl -pi -e "s|\@PLUGIN_HEADER\@|${plugin_h}|;" -e "s|\@plugin_name\@|${plugin_name}|;" kernels/zen3/my_kernel_1_zen3.c
 			fi
 		fi
@@ -5530,7 +5531,7 @@ plugin_main()
 		if [ -e Makefile ] && [ ${force_flag} == '0' ]; then
 			maybe_echo "already done"
 		else
-			cp ${sharedir}/blis/plugin/Makefile Makefile
+			cp "${sharedir}"/blis/plugin/Makefile Makefile
 			maybe_echo "done"
 		fi
 
@@ -5548,7 +5549,7 @@ plugin_main()
 
 		build_and_check_configurations
 
-		generate_config_file ${sharedir}/blis/plugin/config.mk.in config.mk
+		generate_config_file "${sharedir}/blis/plugin/config.mk.in" config.mk
 
 		# -- Makefile fragments --
 

--- a/configure
+++ b/configure
@@ -4703,6 +4703,13 @@ blis_main()
 	fi
 
 
+    # -- Helper symlinks --
+
+    rm -f .dist_path; ln -s "${dist_path}" .dist_path
+    rm -f .install_libdir; ln -s "${libdir}" .install_libdir
+    rm -f .install_incdir; ln -s "${includedir}" .install_libdir
+    rm -f .install_sharedir; ln -s "${sharedir}" .install_sharedir
+
 	# -- Handle out-of-tree builds ---------------------------------------------
 
 	# Under some circumstances, we need to create some symbolic links to

--- a/configure
+++ b/configure
@@ -1279,7 +1279,7 @@ auto_detect()
 		rootdir=${pair%:*}
 
 		filepath=$(find "${dist_path}/${rootdir}" -name "${filename}")
-		c_src_filepaths="${c_src_filepaths} ${filepath}"
+		c_src_filepaths="${c_src_filepaths} \"${filepath}\""
 	done
 
 	# Accumulate a list of header files we'll need to locate along with
@@ -1306,7 +1306,7 @@ auto_detect()
 
 		filepath=$(find "${dist_path}/${rootdir}" -name "${filename}")
 		path=${filepath%/*}
-		c_hdr_paths="${c_hdr_paths} -I${path}"
+		c_hdr_paths="${c_hdr_paths} \"-I${path}\""
 	done
 
 	# Define the executable name.
@@ -1344,7 +1344,7 @@ auto_detect()
 	# Special case for RISC-V, whose architecture can be detected with
 	# preprocessor macros alone. This avoids having to run RISC-V binaries
 	# on a cross-compiler host. Returns "generic" if RISC-V not detected.
-	riscv_config=$(${cmd} -E "${dist_path}/build/detect/riscv/bli_riscv_cpuid.h" |
+	riscv_config=$(eval "${cmd} -E \"${dist_path}/build/detect/riscv/bli_riscv_cpuid.h\"" |
 	               grep '^[^#]')
 	if [[ $riscv_config != *generic* ]]; then
 		echo "${riscv_config}"
@@ -4614,7 +4614,7 @@ blis_main()
 		#if [ -d "${kernels_dirpath}/${conf}" ]; then
 
 		echo "${script_name}: mirroring ${kernels_dirpath}/${kern} to ${obj_kernels_dirpath}/${kern}"
-		${mirror_tree_sh} "${kernels_dirpath}/${kern}" "${obj_kernels_dirpath}/${kern}"
+		"${mirror_tree_sh}" "${kernels_dirpath}/${kern}" "${obj_kernels_dirpath}/${kern}"
 		#else
 		#	echo "${script_name}: mirroring ${kernels_dirpath}/${conf} skipped... directory does not exist"
 		#fi
@@ -5547,10 +5547,10 @@ plugin_main()
 
 		# The extra '/.' on the FRAME call is necessary to trick create_makefile_fragments
 		# into not taking the last entry in ${plugin_dir} as the 'current directory name'.
-		create_makefile_fragment FRAME ${plugin_dir}/. obj/${config_name} false
-		create_makefile_fragment CONFIG ${config_dirpath} obj/${config_name}/config
-		create_makefile_fragment KERNELS ${kernels_dirpath} obj/${config_name}/kernels
-		create_makefile_fragment REFKERN ${refkern_dirpath} obj/${config_name}/ref_kernels
+		create_makefile_fragment FRAME "${plugin_dir}/." "obj/${config_name} false"
+		create_makefile_fragment CONFIG "${config_dirpath}" "obj/${config_name}/config"
+		create_makefile_fragment KERNELS "${kernels_dirpath}" "obj/${config_name}/kernels"
+		create_makefile_fragment REFKERN "${refkern_dirpath}" "obj/${config_name}/ref_kernels"
 
 	fi
 

--- a/frame/compat/cblas/integrate-cblas-tarball.sh
+++ b/frame/compat/cblas/integrate-cblas-tarball.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -48,7 +48,7 @@ print_usage()
 	
 	# Echo usage info
 	echo " "
-	echo " "$script_name
+	echo " $script_name"
 	echo " "
 	echo " Field G. Van Zee"
 	echo " "
@@ -126,7 +126,7 @@ main()
 	# Un-tar and un-gzip the tarball.
 	echo "${script_name}: extracting '${tarball_path}'."
 	echo "${script_name}: expecting unpacked directory to be named '${cblas_dir}'."
-	tar xzf ${tarball_path}
+	tar xzf "${tarball_path}"
 
 	# Create the directory into which we will copy the source code for the
 	# CBLAS wrappers.
@@ -154,7 +154,7 @@ main()
 	# Process each CBLAS source file.
 	echo "${script_name}: copying source from '${cblas_dir}/src' to '${src_dir}' with"
 	echo "${script_name}: '#ifdef BLIS_ENABLE_CBLAS' guard:"
-	for cbl_src_filepath in ${cblas_dir}/src/cblas_*.c; do
+	for cbl_src_filepath in "${cblas_dir}"/src/cblas_*.c; do
 
 		# Strip the path to obtain just the filename.
 		cbl_src_file=${cbl_src_filepath##*/}
@@ -167,8 +167,8 @@ main()
 		    include_bli_type_defs.h \
 		    include_bli_cblas.h \
 		    ifdef_cblas.h \
-		    ${cbl_src_filepath} \
-		    endif_cblas.h > ${src_dir}/${cbl_src_file}
+		    "${cbl_src_filepath}" \
+		    endif_cblas.h > "${src_dir}"/"${cbl_src_file}"
 	done
 
 	# Remove the temporary files.
@@ -250,8 +250,7 @@ fix_file()
 
 	echo "${script_name}: ...fixing ${filename} with 'sed -e ${sedstring}'"
 
-	cat ${filepath} | sed -e "${sedstring}" > ${filepath}.new
-	mv ${filepath}.new ${filepath}
+	sed -ie "${sedstring}" "${filepath}"
 }
 
 

--- a/test/1m4m/runme.sh
+++ b/test/1m4m/runme.sh
@@ -33,9 +33,9 @@ elif [ ${sys} = "stampede2" ]; then
 	echo "Need to set GOMP_CPU_AFFINITY."
 	exit 1
 
-	threads="jc1ic1jr1_2400
-	         jc4ic6jr1_6000
-	         jc4ic12jr1_8000"
+#	threads="jc1ic1jr1_2400
+#	         jc4ic6jr1_6000
+#	         jc4ic12jr1_8000"
 
 elif [ ${sys} = "lonestar5" ]; then
 
@@ -103,7 +103,7 @@ for th in ${threads}; do
 	psize=${th##*_}; thinfo=${th%%_*}
 
 	# Identify each threading parameter and insert a space before it.
-	thsep=$(echo -e ${thinfo} | sed -e "s/\([jip][cr]\)/ \1/g" )
+	thsep=$(echo -e "${thinfo}" | sed -e "s/\([jip][cr]\)/ \1/g" )
 
 	nt=1
 
@@ -112,18 +112,18 @@ for th in ${threads}; do
 		# Given the current string, which identifies a loop and the
 		# number of ways of parallelism for that loop, strip out
 		# the ways and loop separately to identify each.
-		loop=$(echo -e ${loopnum} | sed -e "s/[0-9]//g" )
-		num=$(echo -e ${loopnum} | sed -e "s/[a-z]//g" )
+		loop=$(echo -e "${loopnum}" | sed -e "s/[0-9]//g" )
+		num=$(echo -e "${loopnum}" | sed -e "s/[a-z]//g" )
 
 		# Construct a string that we can evaluate to set the number
 		# of ways of parallelism for the current loop.
 		loop_nt_eq_num="${loop}_nt=${num}"
 
 		# Update the total number of threads.
-		nt=$(expr ${nt} \* ${num})
+		nt=$((nt * num))
 
 		# Evaluate the string to assign the ways to the variable.
-		eval ${loop_nt_eq_num}
+		eval "${loop_nt_eq_num}"
 
 	done
 
@@ -134,8 +134,7 @@ for th in ${threads}; do
 
 		for im in ${test_impls}; do
 
-			if [ "${dt}" = "s"       -o "${dt}" = "d"         ] && \
-			   [ "${im}" = "1m_blis" ]; then
+			if [[ ${dt} = s || ${dt} = d ]] && [[ ${im} = 1m_blis ]]; then
 				continue
 			fi
 
@@ -151,7 +150,7 @@ for th in ${threads}; do
 				fi
 
 				# Find the threading suffix by probing the executable.
-				binname=$(ls ${exec_root}_${dt}${op}_${psize}_${im}_*.x)
+				binname=$(ls "${exec_root}"_"${dt}""${op}"_"${psize}"_"${im}"_*.x)
 				suf_ext=${binname##*_}
 				suf=${suf_ext%%.*}
 
@@ -185,7 +184,7 @@ for th in ${threads}; do
 					# properly if GOMP_CPU_AFFINITY is set. So we temporarily
 					# unset it here if we are about to execute OpenBLAS, but
 					# otherwise restore it.
-					if [ ${im} = "openblas" ]; then
+					if [ "${im}" = "openblas" ]; then
 						unset GOMP_CPU_AFFINITY
 					else
 						export GOMP_CPU_AFFINITY="${GOMP_CPU_AFFINITYsave}"
@@ -223,4 +222,3 @@ for th in ${threads}; do
 		done
 	done
 done
-

--- a/test/3/old/runme.sh
+++ b/test/3/old/runme.sh
@@ -17,7 +17,7 @@ sys="blis"
 #export GOMP_CPU_AFFINITY="0 2 4 6 8 10 12 14 16 18 20 22 1 3 5 7 9 11 13 15 17 19 21 23"
 #export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103"
 
-if [ ${sys} = "blis" ]; then
+if [ "${sys}" = "blis" ]; then
 
 	export GOMP_CPU_AFFINITY="0-3"
 
@@ -26,7 +26,7 @@ if [ ${sys} = "blis" ]; then
 	         jc2ic1jr1_1s
 	         jc2ic2jr1_2s"
 
-elif [ ${sys} = "stampede2" ]; then
+elif [ "${sys}" = "stampede2" ]; then
 
 	echo "Need to set GOMP_CPU_AFFINITY."
 	exit 1
@@ -36,7 +36,7 @@ elif [ ${sys} = "stampede2" ]; then
 	         jc4ic6jr1_1s
 	         jc4ic12jr1_2s"
 
-elif [ ${sys} = "lonestar5" ]; then
+elif [ "${sys}" = "lonestar5" ]; then
 
 	export GOMP_CPU_AFFINITY="0-23"
 
@@ -48,7 +48,7 @@ elif [ ${sys} = "lonestar5" ]; then
 	         jc2ic3jr2_1s
 	         jc4ic3jr2_2s"
 
-elif [ ${sys} = "ul252" ]; then
+elif [ "${sys}" = "ul252" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/field/intel/mkl/lib/intel64"
 	export GOMP_CPU_AFFINITY="0-51"
@@ -58,7 +58,7 @@ elif [ ${sys} = "ul252" ]; then
 	         jc2ic13jr1_1s
 	         jc4ic13jr1_2s"
 
-elif [ ${sys} = "ul264" ]; then
+elif [ "${sys}" = "ul264" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/field/intel/mkl/lib/intel64"
 	export GOMP_CPU_AFFINITY="0-63"
@@ -68,7 +68,7 @@ elif [ ${sys} = "ul264" ]; then
 	         jc1ic8jr4_1s
 	         jc2ic8jr4_2s"
 
-elif [ ${sys} = "ul2128" ]; then
+elif [ "${sys}" = "ul2128" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/field/intel/mkl/lib/intel64"
 	export GOMP_CPU_AFFINITY="0-127"
@@ -143,7 +143,7 @@ for th in ${threads}; do
 	tsuf=${th##*_}; thinfo=${th%%_*}
 
 	# Identify each threading parameter and insert a space before it.
-	thsep=$(echo -e ${thinfo} | sed -e "s/\([jip][cr]\)/ \1/g" )
+	thsep=$(echo -e "${thinfo}" | sed -e "s/\([jip][cr]\)/ \1/g" )
 
 	nt=1
 
@@ -152,26 +152,26 @@ for th in ${threads}; do
 		# Given the current string, which identifies a loop and the
 		# number of ways of parallelism for that loop, strip out
 		# the ways and loop separately to identify each.
-		loop=$(echo -e ${loopnum} | sed -e "s/[0-9]//g" )
-		num=$(echo -e ${loopnum} | sed -e "s/[a-z]//g" )
+		loop=$(echo -e "${loopnum}" | sed -e "s/[0-9]//g" )
+		num=$(echo -e "${loopnum}" | sed -e "s/[a-z]//g" )
 
 		# Construct a string that we can evaluate to set the number
 		# of ways of parallelism for the current loop.
 		loop_nt_eq_num="${loop}_nt=${num}"
 
 		# Update the total number of threads.
-		nt=$(expr ${nt} \* ${num})
+		nt=$((nt * num))
 
 		# Evaluate the string to assign the ways to the variable.
-		eval ${loop_nt_eq_num}
+		eval "${loop_nt_eq_num}"
 
 	done
 
 	# Find a binary using the test driver prefix and the threading suffix.
 	# Then strip everything before and after the max problem size that's
 	# encoded into the name of the binary.
-	binname=$(ls -1 ${exec_root}_*_${tsuf}.x | head -n1)
-	temp1=${binname#${exec_root}_*_}
+	binname=$(ls -1 "${exec_root}"_*_"${tsuf}".x | head -n1)
+	temp1=${binname#"${exec_root}"_*_}
 	psize=${temp1%%_*}
 
 	# Sanity check: If 'ls' couldn't find any binaries, then the user
@@ -205,7 +205,7 @@ for th in ${threads}; do
 				fi
 
 				# Find the threading suffix by probing the executable.
-				binname=$(ls ${exec_root}_${dt}${op}_*_${im}_${tsuf}.x)
+				binname=$(ls "${exec_root}"_"${dt}""${op}"_*_"${im}"_"${tsuf}".x)
 
 				#echo "found file: ${binname} with suffix ${suf}"
 
@@ -236,7 +236,7 @@ for th in ${threads}; do
 					# properly if GOMP_CPU_AFFINITY is set. So we temporarily
 					# unset it here if we are about to execute OpenBLAS, but
 					# otherwise restore it.
-					if [ ${im} = "openblas" ]; then
+					if [ "${im}" = "openblas" ]; then
 						unset GOMP_CPU_AFFINITY
 					else
 						export GOMP_CPU_AFFINITY="${GOMP_CPU_AFFINITYsave}"
@@ -265,13 +265,12 @@ for th in ${threads}; do
 
 				# Run executable with or without numactl, depending on how
 				# the numactl variable was set.
-				${numactl} ./${exec_name} > ${out_file}
+				"${numactl}" ./"${exec_name}" > "${out_file}"
 
 				# Bedtime!
-				sleep ${delay}
+				sleep "${delay}"
 
 			done
 		done
 	done
 done
-

--- a/test/3/runme.sh
+++ b/test/3/runme.sh
@@ -150,7 +150,7 @@ for th in ${threads}; do
 	thinfo=${th%%_*}
 
 	# Identify each threading parameter and insert a space before it.
-	thinfo_sep=$(echo -e ${thinfo} | sed -e "s/\([jip][cr]\)/ \1/g" )
+	thinfo_sep=$(echo -e "${thinfo}" | sed -e "s/\([jip][cr]\)/ \1/g" )
 
 	nt=1
 
@@ -159,25 +159,25 @@ for th in ${threads}; do
 		# Given the current string, which identifies a loop and the number of
 		# ways of parallelism to be obtained from that loop, strip out the ways
 		# and loop separately to identify each.
-		loop=$(echo -e ${loopnum} | sed -e "s/[0-9]//g" )
-		nways=$(echo -e ${loopnum} | sed -e "s/[a-z]//g" )
+		loop=$(echo -e "${loopnum}" | sed -e "s/[0-9]//g" )
+		nways=$(echo -e "${loopnum}" | sed -e "s/[a-z]//g" )
 
 		# Construct a string that we can evaluate to set the number of ways of
 		# parallelism for the current loop (e.g. jc_nt, ic_nt, jr_nt).
 		loop_nt_eq_num="${loop}_nt=${nways}"
 
 		# Update the total number of threads.
-		nt=$(expr ${nt} \* ${nways})
+		nt=$((nt * nways))
 
 		# Evaluate the string to assign the ways to the variable.
-		eval ${loop_nt_eq_num}
+		eval "${loop_nt_eq_num}"
 
 	done
 
 	# Find a binary using the test driver prefix and the threading suffix.
 	# Then strip everything before and after the max problem size that's
 	# encoded into the name of the binary.
-	binname=$(ls -1 ${exec_root}_*_${tsuf}.x | head -n1)
+	binname=$(ls -1 "${exec_root}"_*_"${tsuf}".x | head -n1)
 
 	# Sanity check: If 'ls' couldn't find any binaries, then the user
 	# probably didn't build them. Inform the user and proceed to the next
@@ -244,7 +244,7 @@ for th in ${threads}; do
 					# properly if GOMP_CPU_AFFINITY is set. So we temporarily
 					# unset it here if we are about to execute OpenBLAS, but
 					# otherwise restore it.
-					if [ ${im} = "openblas" ]; then
+					if [ "${im}" = "openblas" ]; then
 						unset GOMP_CPU_AFFINITY
 					else
 						export GOMP_CPU_AFFINITY="${GOMP_CPU_AFFINITYsave}"
@@ -296,14 +296,13 @@ for th in ${threads}; do
 				# Run executable with or without numactl, depending on how
 				# the numactl variable was set.
 				if [ "${dryrun}" != "yes" ]; then
-					${numactl} ./${exec_name} -d ${dt} -c ${oppars} -i ${ind} -p "${psr}" -r ${nrepeats} ${qv} > ${out_file}
+					"${numactl}" ./"${exec_name}" -d "${dt}" -c "${oppars}" -i "${ind}" -p "${psr}" -r "${nrepeats}" "${qv}" > "${out_file}"
 				fi
 
 				# Bedtime!
-				sleep ${delay}
+				sleep "${delay}"
 
 			done
 		done
 	done
 done
-

--- a/test/exec_sizes/grab_top_outputs.sh
+++ b/test/exec_sizes/grab_top_outputs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -52,7 +52,7 @@ for e in ${execs}; do
 
 	echo "Capturing ${exec_name}..."
 
-	./${exec_name} &
+	./"${exec_name}" &
 
 	sleep 1
 
@@ -60,4 +60,3 @@ for e in ${execs}; do
 
 	pkill "${exec_name}" > /dev/null
 done
-

--- a/test/mixeddt/runme.sh
+++ b/test/mixeddt/runme.sh
@@ -23,7 +23,7 @@ sys="tx2"
 export GOMP_CPU_AFFINITY="0 1 2 3"
 
 # Modify LD_LIBRARY_PATH.
-if [ ${sys} = "blis" ]; then
+if [ "${sys}" = "blis" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 
@@ -35,7 +35,7 @@ if [ ${sys} = "blis" ]; then
 	ir_nt=1 # 1st loop
 	nt=4
 
-elif [ ${sys} = "stampede2" ]; then
+elif [ "${sys}" = "stampede2" ]; then
 
 	echo "Need to set GOMP_CPU_AFFINITY."
 	exit 1
@@ -46,7 +46,7 @@ elif [ ${sys} = "stampede2" ]; then
 	ir_nt=1 # 1st loop
 	nt=48
 
-elif [ ${sys} = "lonestar5" ]; then
+elif [ "${sys}" = "lonestar5" ]; then
 
 	echo "Need to set GOMP_CPU_AFFINITY."
 	exit 1
@@ -60,7 +60,7 @@ elif [ ${sys} = "lonestar5" ]; then
 	ir_nt=1 # 1st loop
 	nt=24
 
-elif [ ${sys} = "ul252" ]; then
+elif [ "${sys}" = "ul252" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/field/intel/mkl/lib/intel64"
 	#export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103"
@@ -73,7 +73,7 @@ elif [ ${sys} = "ul252" ]; then
 	ir_nt=1 # 1st loop
 	#nt=52
 	nt=26
-elif [ ${sys} = "tx2" ]; then
+elif [ "${sys}" = "tx2" ]; then
 
 	export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55"
 
@@ -134,7 +134,7 @@ for th in ${threads}; do
 			for op in ${test_ops}; do
 
 				# Set the number of threads according to th.
-				if [ ${th} = "mt" ]; then
+				if [ "${th}" = "mt" ]; then
 
 					export BLIS_JC_NT=${jc_nt}
 					export BLIS_IC_NT=${ic_nt}
@@ -144,7 +144,7 @@ for th in ${threads}; do
 					export OPENBLAS_NUM_THREADS=${nt}
 
 					# Unset GOMP_CPU_AFFINITY for OpenBLAS.
-					if [ ${im} = "openblas" ]; then
+					if [ "${im}" = "openblas" ]; then
 						unset GOMP_CPU_AFFINITY
 					else
 						export GOMP_CPU_AFFINITY=${GOMP_CPU_AFFINITYsave}
@@ -168,7 +168,7 @@ for th in ${threads}; do
 				echo "Running (nt = ${OMP_NUM_THREADS}) ./${exec_name} > ${out_file}"
 
 				# Run executable.
-				./${exec_name} > ${out_file}
+				./"${exec_name}" > "${out_file}"
 
 				#sleep 1
 

--- a/test/runme.sh
+++ b/test/runme.sh
@@ -26,7 +26,7 @@ for im in ${test_impls}; do
 		echo "Running ${exec_name} > ${out_file}"
 
 		# Run executable.
-		./${exec_name} > ${out_file}
+		./"${exec_name}" > "${out_file}"
 
 		sleep 1
 

--- a/test/studies/skx/runme.sh
+++ b/test/studies/skx/runme.sh
@@ -5,7 +5,7 @@ exec_root="test"
 out_root="output"
 
 out_rootdir=$(date +%Y%m%d)
-mkdir -p $out_rootdir
+mkdir -p "$out_rootdir"
 
 #sys="blis"
 #sys="stampede"
@@ -27,32 +27,32 @@ sys="skx"
 export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39"
 
 # Modify LD_LIBRARY_PATH.
-if [ ${sys} = "blis" ]; then
+if [ "${sys}" = "blis" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 
-elif [ ${sys} = "stampede" ]; then
+elif [ "${sys}" = "stampede" ]; then
 
 	# A hack to use libiomp5 with gcc.
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/apps/intel/13/composer_xe_2013.2.146/compiler/lib/intel64"
 
-elif [ ${sys} = "stampede2" ]; then
+elif [ "${sys}" = "stampede2" ]; then
 
 	:
 
-elif [ ${sys} = "lonestar" ]; then
+elif [ "${sys}" = "lonestar" ]; then
 
 	# A hack to use libiomp5 with gcc.
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/apps/intel/16.0.1.150/compilers_and_libraries_2016.1.150/linux/compiler/lib/intel64"
 
-elif [ ${sys} = "wahlberg" ]; then
+elif [ "${sys}" = "wahlberg" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/flame/lib/acml/5.3.1/gfortran64_int64/lib"
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/flame/lib/acml/5.3.1/gfortran64_mp_int64/lib"
 fi
 
 # Threading scheme to use when multithreading
-if [ ${sys} = "blis" ]; then
+if [ "${sys}" = "blis" ]; then
 
 	jc_nt=1 # 5th loop
 	ic_nt=4 # 3rd loop
@@ -60,7 +60,7 @@ if [ ${sys} = "blis" ]; then
 	ir_nt=1 # 1st loop
 	nt=4
 
-elif [ ${sys} = "stampede" ]; then
+elif [ "${sys}" = "stampede" ]; then
 
 	jc_nt=2 # 5th loop
 	ic_nt=8 # 3rd loop
@@ -68,7 +68,7 @@ elif [ ${sys} = "stampede" ]; then
 	ir_nt=1 # 1st loop
 	nt=16
 
-elif [ ${sys} = "lonestar" ]; then
+elif [ "${sys}" = "lonestar" ]; then
 
 	jc_nt=2 # 5th loop
 	ic_nt=12 # 3rd loop
@@ -76,7 +76,7 @@ elif [ ${sys} = "lonestar" ]; then
 	ir_nt=1 # 1st loop
 	nt=24
 
-elif [ ${sys} = "wahlberg" ]; then
+elif [ "${sys}" = "wahlberg" ]; then
 
 	jc_nt=1 # 5th loop
 	ic_nt=2 # 3rd loop
@@ -84,7 +84,7 @@ elif [ ${sys} = "wahlberg" ]; then
 	ir_nt=1 # 1st loop
 	nt=4
 
-elif [ ${sys} = "arm-softiron" ]; then
+elif [ "${sys}" = "arm-softiron" ]; then
 
 	#jc_nt=1 # 5th loop
 	#ic_nt=2 # 3rd loop
@@ -92,7 +92,7 @@ elif [ ${sys} = "arm-softiron" ]; then
 	#ir_nt=1 # 1st loop
 	nt=4
 
-elif [ ${sys} = "stampede2" ]; then
+elif [ "${sys}" = "stampede2" ]; then
 
 	jc_nt=2 # 5th loop
 	ic_nt=1 # 3rd loop
@@ -100,7 +100,7 @@ elif [ ${sys} = "stampede2" ]; then
 	ir_nt=1 # 1st loop
 	nt=20
 
-elif [ ${sys} = "skx" ]; then
+elif [ "${sys}" = "skx" ]; then
 
         jc_1_nt=1 # 5th loop
         ic_1_nt=20 # 3rd loop
@@ -134,22 +134,22 @@ test_ops="${l3_ops}"
 test_ops_r="${l3_ops}"
 
 # Complex domain implementations to test.
-if [ ${sys} = "blis" ]; then
+if [ "${sys}" = "blis" ]; then
 
 	#test_impls="openblas mkl 3mhw_blis 3m3_blis 3m2_blis 3m1_blis 4mhw_blis 4m1b_blis 4m1a_blis"
 	test_impls="openblas 3mhw_blis 3m3_blis 3m2_blis 3m1_blis 4mhw_blis 4m1b_blis 4m1a_blis 1m_blis"
 
-elif [ ${sys} = "stampede" ]; then
+elif [ "${sys}" = "stampede" ]; then
 
 	test_impls="openblas mkl asm_blis 3mhw_blis 3m3_blis 3m2_blis 3m1_blis 4mhw_blis 4m1b_blis 4m1a_blis 1m_blis"
 	#test_impls="openblas mkl asm_blis"
 
-elif [ ${sys} = "stampede2" ]; then
+elif [ "${sys}" = "stampede2" ]; then
 
 	test_impls="openblas mkl 1m_blis"
 	#test_impls="1m_blis"
 
-elif [ ${sys} = "lonestar" ]; then
+elif [ "${sys}" = "lonestar" ]; then
 
 	test_impls="asm_blis 4mhw_blis 4m1a_blis 1m_blis 3m1_blis"
 	#test_impls="1m_blis 3m1_blis"
@@ -157,16 +157,16 @@ elif [ ${sys} = "lonestar" ]; then
 	#test_impls="mkl"
 	#test_impls="openblas mkl asm_blis"
 
-elif [ ${sys} = "wahlberg" ]; then
+elif [ "${sys}" = "wahlberg" ]; then
 
 	test_impls="openblas acml asm_blis 3mhw_blis 3m3_blis 3m2_blis 3m1_blis 4mhw_blis 4m1b_blis 4m1a_blis 1m_blis"
 	test_impls="openblas acml asm_blis"
 
-elif [ ${sys} = "arm-softiron" ]; then
+elif [ "${sys}" = "arm-softiron" ]; then
 
 	test_impls="openblas 1m_blis mkl"
 
-elif [ ${sys} = "skx" ]; then
+elif [ "${sys}" = "skx" ]; then
 
 	test_impls="openblas 1m_blis mkl"
 fi
@@ -186,15 +186,15 @@ for nc in ${cores_r}; do
 
 			for op in ${test_ops_r}; do
 
-				if [ ${nc} -gt 1 ]; then
+				if [ "${nc}" -gt 1 ]; then
                                         # Unset GOMP_CPU_AFFINITY for MKL when using mkl_intel_thread.
-                                        if [ ${im} = "openblas" ]; then
+                                        if [ "${im}" = "openblas" ]; then
                                                 unset GOMP_CPU_AFFINITY
                                         else
                                                 export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39"
 
                                         fi
-                                        if [ ${nc} -eq 20 ]; then
+                                        if [ "${nc}" -eq 20 ]; then
 
                                                 export BLIS_JC_NT=${jc_1_nt}
                                                 export BLIS_IC_NT=${ic_1_nt}
@@ -202,15 +202,15 @@ for nc in ${cores_r}; do
                                                 export BLIS_IR_NT=${ir_1_nt}
                                                 export OMP_NUM_THREADS=${nt_1}
                                                 out_dir="${out_rootdir}/1socket"
-                                                mkdir -p $out_rootdir/1socket
-                                        elif [ ${nc} -eq 40 ]; then
+                                                mkdir -p "$out_rootdir"/1socket
+                                        elif [ "${nc}" -eq 40 ]; then
                                                 export BLIS_JC_NT=${jc_2_nt}
                                                 export BLIS_IC_NT=${ic_2_nt}
                                                 export BLIS_JR_NT=${jr_2_nt}
                                                 export BLIS_IR_NT=${ir_2_nt}
                                                 export OMP_NUM_THREADS=${nt_2}
                                                 out_dir="${out_rootdir}/2sockets"
-                                                mkdir -p $out_rootdir/2sockets
+                                                mkdir -p "$out_rootdir"/2sockets
                                         fi
                                         th="mt"
                                 else
@@ -218,7 +218,7 @@ for nc in ${cores_r}; do
                                         export BLIS_NUM_THREADS=1
                                         export OMP_NUM_THREADS=1
                                         out_dir="${out_rootdir}/st"
-                                        mkdir -p $out_rootdir/st
+                                        mkdir -p "$out_rootdir"/st
                                         th="st"
                                 fi
 
@@ -231,7 +231,7 @@ for nc in ${cores_r}; do
 				echo "Running (nt = ${OMP_NUM_THREADS}) ./${exec_name} > ${out_file}"
 
 				# Run executable.
-				./${exec_name} > ${out_file}
+				./"${exec_name}" > "${out_file}"
 
 				sleep 1
 
@@ -248,16 +248,16 @@ for nc in ${cores_r}; do
 		for im in ${test_impls}; do
 
 			for op in ${test_ops}; do
-				
-				if [ ${nc} -gt 1 ]; then
+
+				if [ "${nc}" -gt 1 ]; then
                                         # Unset GOMP_CPU_AFFINITY for MKL when using mkl_intel_thread.
-                                        if [ ${im} = "openblas" ]; then
+                                        if [ "${im}" = "openblas" ]; then
                                                 unset GOMP_CPU_AFFINITY
                                         else
                                                 export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39"
 
                                         fi
-                                        if [ ${nc} -eq 20 ]; then
+                                        if [ "${nc}" -eq 20 ]; then
 
                                                 export BLIS_JC_NT=${jc_1_nt}
                                                 export BLIS_IC_NT=${ic_1_nt}
@@ -265,7 +265,7 @@ for nc in ${cores_r}; do
                                                 export BLIS_IR_NT=${ir_1_nt}
                                                 export OMP_NUM_THREADS=${nt_1}
                                                 out_dir="${out_rootdir}/1socket"
-                                        elif [ ${nc} -eq 40 ]; then
+                                        elif [ "${nc}" -eq 40 ]; then
                                                 export BLIS_JC_NT=${jc_2_nt}
                                                 export BLIS_IC_NT=${ic_2_nt}
                                                 export BLIS_JR_NT=${jr_2_nt}
@@ -290,7 +290,7 @@ for nc in ${cores_r}; do
 
 				echo "Running (nt = ${OMP_NUM_THREADS}) ./${exec_name} > ${out_file}"
 				# Run executable.
-				./${exec_name} > ${out_file}
+				./"${exec_name}" > "${out_file}"
 
 				sleep 1
 

--- a/test/studies/thunderx2/runme.sh
+++ b/test/studies/thunderx2/runme.sh
@@ -6,7 +6,7 @@ out_root="output"
 
 out_rootdir=$(date +%Y%m%d)
 #out_rootdir=20180830
-mkdir -p $out_rootdir
+mkdir -p "$out_rootdir"
 
 sys="thunderx2"
 
@@ -86,17 +86,17 @@ for nc in ${cores_r}; do
 
 			for op in ${test_ops_r}; do
 				# Set the number of threads according to th.
-				if [ ${nc} -gt 1 ]; then
+				if [ "${nc}" -gt 1 ]; then
 					# Unset GOMP_CPU_AFFINITY for MKL when using mkl_intel_thread.
-					if [ ${im} = "openblas" ]; then
+					if [ "${im}" = "openblas" ]; then
 						unset GOMP_CPU_AFFINITY
-					elif [ ${im} = "armpl" ]; then
+					elif [ "${im}" = "armpl" ]; then
 						unset GOMP_CPU_AFFINITY
 					else
 						export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55"
 
 					fi
-					if [ ${nc} -eq 28 ]; then
+					if [ "${nc}" -eq 28 ]; then
 
 						export BLIS_JC_NT=${jc_1_nt}
 						export BLIS_IC_NT=${ic_1_nt}
@@ -104,15 +104,15 @@ for nc in ${cores_r}; do
 						export BLIS_IR_NT=${ir_1_nt}
 						export OMP_NUM_THREADS=${nt_1}
 						out_dir="${out_rootdir}/1socket"
-						mkdir -p $out_rootdir/1socket
-					elif [ ${nc} -eq 56 ]; then
+						mkdir -p "$out_rootdir/1socket"
+					elif [ "${nc}" -eq 56 ]; then
                                         	export BLIS_JC_NT=${jc_2_nt}
                                         	export BLIS_IC_NT=${ic_2_nt}
                                         	export BLIS_JR_NT=${jr_2_nt}
                                         	export BLIS_IR_NT=${ir_2_nt}
                                         	export OMP_NUM_THREADS=${nt_2}
 						out_dir="${out_rootdir}/2sockets"
-						mkdir -p $out_rootdir/2sockets
+						mkdir -p "$out_rootdir/2sockets"
 					fi
 					th="mt"
 				else
@@ -123,7 +123,7 @@ for nc in ${cores_r}; do
 					export BLIS_IR_NT=1
 					export OMP_NUM_THREADS=1
 					out_dir="${out_rootdir}/st"
-					mkdir -p $out_rootdir/st
+					mkdir -p "$out_rootdir/st"
 					th="st"
 				fi
 
@@ -136,7 +136,7 @@ for nc in ${cores_r}; do
 				echo "Running (nt = ${OMP_NUM_THREADS}) ./${exec_name} > ${out_file}"
 
 				# Run executable.
-				./${exec_name} > ${out_file}
+				./"${exec_name}" > "${out_file}"
 
 				sleep 1
 
@@ -155,17 +155,17 @@ for nc in ${cores}; do
 			for op in ${test_ops}; do
 
 				# Set the number of threads according to th.
-				if [ ${nc} -gt 1 ]; then
+				if [ "${nc}" -gt 1 ]; then
 					# Unset GOMP_CPU_AFFINITY for MKL when using mkl_intel_thread.
-					if [ ${im} = "openblas" ]; then
+					if [ "${im}" = "openblas" ]; then
 						unset GOMP_CPU_AFFINITY
-					elif [ ${im} = "armpl" ]; then
+					elif [ "${im}" = "armpl" ]; then
 						unset GOMP_CPU_AFFINITY
 					else
 						export GOMP_CPU_AFFINITY="0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55"
 
 					fi
-					if [ ${nc} -eq 28 ]; then
+					if [ "${nc}" -eq 28 ]; then
 
 						export BLIS_JC_NT=${jc_1_nt}
 						export BLIS_IC_NT=${ic_1_nt}
@@ -173,7 +173,7 @@ for nc in ${cores}; do
 						export BLIS_IR_NT=${ir_1_nt}
 						export OMP_NUM_THREADS=${nt_1}
 						out_dir="${out_rootdir}/1socket"
-					elif [ ${nc} -eq 56 ]; then
+					elif [ "${nc}" -eq 56 ]; then
                                         	export BLIS_JC_NT=${jc_2_nt}
                                         	export BLIS_IC_NT=${ic_2_nt}
                                         	export BLIS_JR_NT=${jr_2_nt}
@@ -201,7 +201,7 @@ for nc in ${cores}; do
 
 				echo "Running (nt = ${OMP_NUM_THREADS}) ./${exec_name} > ${out_file}"
 				# Run executable.
-				./${exec_name} > ${out_file}
+				./"${exec_name}" > "${out_file}"
 
 				sleep 1
 

--- a/test/sup/old/supmt/runme.sh
+++ b/test/sup/old/supmt/runme.sh
@@ -9,23 +9,23 @@ sys="blis"
 #sys="ul252"
 #sys="ul264"
 
-if [ ${sys} = "blis" ]; then
+if [ "${sys}" = "blis" ]; then
 
 	export GOMP_CPU_AFFINITY="0-3"
 	nt=4
 
-elif [ ${sys} = "lonestar5" ]; then
+elif [ "${sys}" = "lonestar5" ]; then
 
 	export GOMP_CPU_AFFINITY="0-23"
 	nt=12
 
-elif [ ${sys} = "ul252" ]; then
+elif [ "${sys}" = "ul252" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/field/intel/mkl/lib/intel64"
 	export GOMP_CPU_AFFINITY="0-51"
 	nt=26
 
-elif [ ${sys} = "ul264" ]; then
+elif [ "${sys}" = "ul264" ]; then
 
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/field/intel/mkl/lib/intel64"
 	export GOMP_CPU_AFFINITY="0-63"
@@ -129,7 +129,7 @@ for th in ${threads}; do
 										# running properly if GOMP_CPU_AFFINITY is set.
 										# So we temporarily unset it here if we are about
 										# to execute OpenBLAS, but otherwise restore it.
-										if [ ${im} = "openblas" ]; then
+										if [ "${im}" = "openblas" ]; then
 											unset GOMP_CPU_AFFINITY
 										else
 											export GOMP_CPU_AFFINITY="${GOMP_CPU_AFFINITYsave}"
@@ -158,19 +158,19 @@ for th in ${threads}; do
 										# Construct the shape substring (e.g. m6npkp)
 										shstr=""
 
-										if [ ${chm} = "s" ]; then
+										if [ "${chm}" = "s" ]; then
 											shstr="${shstr}m${sm}"
 										else
 											shstr="${shstr}mp"
 										fi
 
-										if [ ${chn} = "s" ]; then
+										if [ "${chn}" = "s" ]; then
 											shstr="${shstr}n${sn}"
 										else
 											shstr="${shstr}np"
 										fi
 
-										if [ ${chk} = "s" ]; then
+										if [ "${chk}" = "s" ]; then
 											shstr="${shstr}k${sk}"
 										else
 											shstr="${shstr}kp"
@@ -187,9 +187,9 @@ for th in ${threads}; do
 										echo "Running (nt = ${nt_use}) ./${exec_name} > ${out_file}"
 
 										# Run executable.
-										./${exec_name} > ${out_file}
+										./"${exec_name}" > "${out_file}"
 
-										sleep ${delay}
+										sleep "${delay}"
 
 									done
 								done
@@ -201,4 +201,3 @@ for th in ${threads}; do
 		done
 	done
 done
-

--- a/test/sup/old/supst/runme.sh
+++ b/test/sup/old/supst/runme.sh
@@ -91,19 +91,19 @@ for th in ${threads}; do
 										# Construct the shape substring (e.g. m6npkp)
 										shstr=""
 
-										if [ ${chm} = "s" ]; then
+										if [ "${chm}" = "s" ]; then
 											shstr="${shstr}m${sm}"
 										else
 											shstr="${shstr}mp"
 										fi
 
-										if [ ${chn} = "s" ]; then
+										if [ "${chn}" = "s" ]; then
 											shstr="${shstr}n${sn}"
 										else
 											shstr="${shstr}np"
 										fi
 
-										if [ ${chk} = "s" ]; then
+										if [ "${chk}" = "s" ]; then
 											shstr="${shstr}k${sk}"
 										else
 											shstr="${shstr}kp"
@@ -120,9 +120,9 @@ for th in ${threads}; do
 										echo "Running (nt = ${nt}) ./${exec_name} > ${out_file}"
 
 										# Run executable.
-										./${exec_name} > ${out_file}
+										"./${exec_name}" > "${out_file}"
 
-										sleep ${delay}
+										sleep "${delay}"
 
 									done
 								done
@@ -134,4 +134,3 @@ for th in ${threads}; do
 		done
 	done
 done
-

--- a/test/sup/runme.sh
+++ b/test/sup/runme.sh
@@ -129,24 +129,24 @@ for th in ${threads}; do
 
 		# Choose the small m, n, and k values based on the threadedness and
 		# datatype currently being executed.
-		if   [ ${th} = "st" ]; then
-			if   [ ${dt} = "s" ]; then
+		if   [ "${th}" = "st" ]; then
+			if   [ "${dt}" = "s" ]; then
 				sms=${sms_st_s}
 				sns=${sns_st_s}
 				sks=${sks_st_s}
-			elif [ ${dt} = "d" ]; then
+			elif [ "${dt}" = "d" ]; then
 				sms=${sms_st_d}
 				sns=${sns_st_d}
 				sks=${sks_st_d}
 			else
 				exit 1
 			fi
-		elif [ ${th} = "mt" ]; then
-			if   [ ${dt} = "s" ]; then
+		elif [ "${th}" = "mt" ]; then
+			if   [ "${dt}" = "s" ]; then
 				sms=${sms_mt_s}
 				sns=${sns_mt_s}
 				sks=${sks_mt_s}
-			elif [ ${dt} = "d" ]; then
+			elif [ "${dt}" = "d" ]; then
 				sms=${sms_mt_d}
 				sns=${sns_mt_d}
 				sks=${sks_mt_d}
@@ -222,7 +222,7 @@ for th in ${threads}; do
 
 													# Set BLIS_PACK_A if the pcombo char is 'p'; otherwise
 													# unset the variable altogether.
-													if [ ${packa} = "p" ]; then
+													if [ "${packa}" = "p" ]; then
 														export BLIS_PACK_A=1
 													else
 														unset BLIS_PACK_A
@@ -230,7 +230,7 @@ for th in ${threads}; do
 
 													# Set BLIS_PACK_B if the pcombo char is 'p'; otherwise
 													# unset the variable altogether.
-													if [ ${packb} = "p" ]; then
+													if [ "${packb}" = "p" ]; then
 														export BLIS_PACK_B=1
 													else
 														unset BLIS_PACK_B
@@ -265,7 +265,7 @@ for th in ${threads}; do
 												# running properly if GOMP_CPU_AFFINITY is set.
 												# So we temporarily unset it here if we are about
 												# to execute OpenBLAS, but otherwise restore it.
-												if [ ${im} = "openblas" ]; then
+												if [ "${im}" = "openblas" ]; then
 													unset GOMP_CPU_AFFINITY
 												else
 													export GOMP_CPU_AFFINITY="${GOMP_CPU_AFFINITYsave}"
@@ -294,19 +294,19 @@ for th in ${threads}; do
 												# Construct the shape substring (e.g. m6npkp)
 												shstr=""
 
-												if [ ${chm} = "s" ]; then
+												if [ "${chm}" = "s" ]; then
 													shstr="${shstr}m${sm}"
 												else
 													shstr="${shstr}mp"
 												fi
 
-												if [ ${chn} = "s" ]; then
+												if [ "${chn}" = "s" ]; then
 													shstr="${shstr}n${sn}"
 												else
 													shstr="${shstr}np"
 												fi
 
-												if [ ${chk} = "s" ]; then
+												if [ "${chk}" = "s" ]; then
 													shstr="${shstr}k${sk}"
 												else
 													shstr="${shstr}kp"
@@ -330,9 +330,9 @@ for th in ${threads}; do
 												echo "Running (nt = ${nt_use}) ${numactl} ./${exec_name} > ${out_file}"
 
 												# Run executable.
-												${numactl} ./${exec_name} > ${out_file}
+												"${numactl}" ./"${exec_name}" > "${out_file}"
 
-												sleep ${delay}
+												sleep "${delay}"
 
 											done
 										done
@@ -346,4 +346,3 @@ for th in ${threads}; do
 		done
 	done
 done
-

--- a/testsuite/check-blistest.sh
+++ b/testsuite/check-blistest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  BLIS    
+#  BLIS
 #  An object-based framework for developing high-performance BLAS-like
 #  libraries.
 #
@@ -45,7 +45,7 @@ failmsg1="Please see output.testsuite for details."
 
 # First make sure that the testsuite completed normally (e.g. did not abort()
 # or segfault).
-grep -q 'Exiting normally' $1
+grep -q 'Exiting normally' "$1"
 
 # The testsuite did not complete if the error code from grep was *not* 0.
 if [ $? -ne 0 ]; then
@@ -54,7 +54,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # If the testsuite completed normally, check for numerical failures.
-grep -q 'FAILURE' $1
+grep -q 'FAILURE' "$1"
 
 # A numerical failure was detected if the error code from grep was 0.
 if [ $? -eq 0 ]; then
@@ -65,5 +65,3 @@ else
     printf "${ansi_green}""${script_name}: ${passmsg}""${ansi_normal}\n"
     exit 0
 fi
-
-


### PR DESCRIPTION
Details:
- Having a space in the source directory, build directory, or install directory leads to major problems, both due to insufficient quoting in several bash scripts, but also due to fundamental limitations in GNU make.
- Quoting problems in scripts have been fixed.
- For the Makefile, no true solution is possible. Instead, symlink the source directory (DIST_PATH) as .dist_path and install directories (e.q. INSTALL_LIBDIR as .install_libdir). New helper rules ensure these symlinks as well as the underlying directories exist when needed.