### PR TITLE
fix(dgemm-sup-haswell kernels): correct offset calculation on void po…

### DIFF
--- a/kernels/haswell/3/sup/bli_gemmsup_rd_haswell_asm_d6x8m.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rd_haswell_asm_d6x8m.c
@@ -74,14 +74,18 @@ void bli_dgemmsup_rd_haswell_asm_6x8m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t n_left = n0 % 8;
 
 	// First check whether this is a edge case in the n dimension. If so,
@@ -731,10 +735,10 @@ void bli_dgemmsup_rd_haswell_asm_6x4m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -744,6 +748,10 @@ void bli_dgemmsup_rd_haswell_asm_6x4m
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter16 = k0 / 16;
 	uint64_t k_left16 = k0 % 16;
 	uint64_t k_iter4  = k_left16 / 4;
@@ -1303,10 +1311,10 @@ void bli_dgemmsup_rd_haswell_asm_6x2m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -1316,6 +1324,10 @@ void bli_dgemmsup_rd_haswell_asm_6x2m
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter16 = k0 / 16;
 	uint64_t k_left16 = k0 % 16;
 	uint64_t k_iter4  = k_left16 / 4;

--- a/kernels/haswell/3/sup/bli_gemmsup_rd_haswell_asm_d6x8n.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rd_haswell_asm_d6x8n.c
@@ -74,14 +74,18 @@ void bli_dgemmsup_rd_haswell_asm_6x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t m_left = m0 % 6;
 
 	// First check whether this is a edge case in the n dimension. If so,
@@ -800,10 +804,10 @@ void bli_dgemmsup_rd_haswell_asm_3x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -813,6 +817,10 @@ void bli_dgemmsup_rd_haswell_asm_3x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter16 = k0 / 16;
 	uint64_t k_left16 = k0 % 16;
 	uint64_t k_iter4  = k_left16 / 4;
@@ -1387,10 +1395,10 @@ void bli_dgemmsup_rd_haswell_asm_2x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -1400,6 +1408,10 @@ void bli_dgemmsup_rd_haswell_asm_2x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter16 = k0 / 16;
 	uint64_t k_left16 = k0 % 16;
 	uint64_t k_iter4  = k_left16 / 4;
@@ -1917,10 +1929,10 @@ void bli_dgemmsup_rd_haswell_asm_1x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -1930,6 +1942,10 @@ void bli_dgemmsup_rd_haswell_asm_1x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter16 = k0 / 16;
 	uint64_t k_left16 = k0 % 16;
 	uint64_t k_iter4  = k_left16 / 4;

--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8m.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8m.c
@@ -55,10 +55,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x7m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      );
@@ -71,10 +71,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x5m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
@@ -88,10 +88,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x3m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
@@ -105,10 +105,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x1m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
@@ -497,14 +497,18 @@ void bli_dgemmsup_rv_haswell_asm_6x8m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t n_left = n0 % 8;
 
 	// First check whether this is a edge case in the n dimension. If so,
@@ -1874,14 +1878,17 @@ void bli_dgemmsup_rv_haswell_asm_6x6m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
 	//void*    a_next = bli_auxinfo_next_a( data );
 	//void*    b_next = bli_auxinfo_next_b( data );
 
@@ -2992,14 +2999,17 @@ void bli_dgemmsup_rv_haswell_asm_6x4m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
 	//void*    a_next = bli_auxinfo_next_a( data );
 	//void*    b_next = bli_auxinfo_next_b( data );
 
@@ -3903,14 +3913,17 @@ void bli_dgemmsup_rv_haswell_asm_6x2m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
 	//void*    a_next = bli_auxinfo_next_a( data );
 	//void*    b_next = bli_auxinfo_next_b( data );
 
@@ -4790,16 +4803,15 @@ static void bli_dgemmsup_rv_haswell_asm_6x7m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
      )
 {
-
 // Sets up the mask for loading relevant remainder elements in load direction
 // int64_t array of size 4 represents the mask for 4 elements of AVX2 vector register.
 //
@@ -4829,6 +4841,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x7m
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 8;
 	uint64_t k_left = k0 % 8;
 
@@ -5833,16 +5849,15 @@ static void bli_dgemmsup_rv_haswell_asm_6x5m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
      )
 {
-
 // Sets up the mask for loading relevant remainder elements in load direction
 // int64_t array of size 4 represents the mask for 4 elements of AVX2 vector register.
 //
@@ -5872,6 +5887,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x5m
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 8;
 	uint64_t k_left = k0 % 8;
 
@@ -6871,10 +6890,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x3m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
@@ -6906,6 +6925,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x3m
 //
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 8;
 	uint64_t k_left = k0 % 8;
 
@@ -7628,10 +7651,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x1m
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
 
@@ -7663,6 +7686,10 @@ static void bli_dgemmsup_rv_haswell_asm_6x1m
 //
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 8;
 	uint64_t k_left = k0 % 8;
 

--- a/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8n.c
+++ b/kernels/haswell/3/sup/bli_gemmsup_rv_haswell_asm_d6x8n.c
@@ -95,14 +95,18 @@ void bli_dgemmsup_rv_haswell_asm_6x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
 {
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t m_left = m0 % 6;
 
 	// First check whether this is a edge case in the m dimension. If so,
@@ -961,10 +965,10 @@ void bli_dgemmsup_rv_haswell_asm_5x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -974,6 +978,10 @@ void bli_dgemmsup_rv_haswell_asm_5x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 4;
 	uint64_t k_left = k0 % 4;
 
@@ -1709,10 +1717,10 @@ void bli_dgemmsup_rv_haswell_asm_4x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -1722,6 +1730,9 @@ void bli_dgemmsup_rv_haswell_asm_4x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
 	uint64_t k_iter = k0 / 4;
 	uint64_t k_left = k0 % 4;
 
@@ -2357,10 +2368,10 @@ void bli_dgemmsup_rv_haswell_asm_3x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -2370,6 +2381,10 @@ void bli_dgemmsup_rv_haswell_asm_3x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 4;
 	uint64_t k_left = k0 % 4;
 
@@ -3035,10 +3050,10 @@ void bli_dgemmsup_rv_haswell_asm_2x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -3048,6 +3063,10 @@ void bli_dgemmsup_rv_haswell_asm_2x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 4;
 	uint64_t k_left = k0 % 4;
 
@@ -3594,10 +3613,10 @@ void bli_dgemmsup_rv_haswell_asm_1x8n
              dim_t      n0,
              dim_t      k0,
        const void*      alpha,
-       const void*      a, inc_t rs_a0, inc_t cs_a0,
-       const void*      b, inc_t rs_b0, inc_t cs_b0,
+       const void*      a0, inc_t rs_a0, inc_t cs_a0,
+       const void*      b0, inc_t rs_b0, inc_t cs_b0,
        const void*      beta,
-             void*      c, inc_t rs_c0, inc_t cs_c0,
+             void*      c0, inc_t rs_c0, inc_t cs_c0,
        const auxinfo_t* data,
        const cntx_t*    cntx
      )
@@ -3607,6 +3626,10 @@ void bli_dgemmsup_rv_haswell_asm_1x8n
 
 	// Typecast local copies of integers in case dim_t and inc_t are a
 	// different size than is expected by load instructions.
+	double *a = (double *)a0;
+	double *b = (double *)b0;
+	double *c = (double *)c0;
+
 	uint64_t k_iter = k0 / 4;
 	uint64_t k_left = k0 % 4;
 


### PR DESCRIPTION
…inters

- The DGEMM sup haswell kernel was failing because the pointer offset was computed on a `void *`.
- The offset must be calculated in units of `double`, so we now cast to `double *` before applying the offset. This ensures correct indexing in the matrix and resolves the kernel failure.

  Fixes #899