### PR TITLE
Fix use-after-free of root thrinfo_t in sup thread decorator

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -71,6 +71,7 @@ but many others have contributed code, ideas, and feedback, including
   Mike Kistler             @mkistler                  (IBM, Austin Research Laboratory)
   Nick Knight              @nick-knight               (SiFive)
   Ivan Korostelev          @ivan23kor                 (University of Alberta)
+  Eylon Krause             @EylonKrause
   Kyungmin Lee             @kyungminlee               (Ohio State University)
   Michael Lehn             @michael-lehn
                            @leo4678

--- a/frame/3/bli_l3_sup_int.c
+++ b/frame/3/bli_l3_sup_int.c
@@ -139,7 +139,7 @@ err_t bli_gemmsup_int
 			// new ways of parallelism value for the jc loop.
 			rntm_t rntm_l = *rntm;
 			bli_rntm_set_ways_only( jc_new, 1, ic_new, 1, 1, &rntm_l );
-			bli_l3_sup_thrinfo_update( &rntm_l, &thread );
+			bli_l3_sup_thrinfo_update( &rntm_l, thread );
 		}
 
 
@@ -205,7 +205,7 @@ err_t bli_gemmsup_int
 			// new ways of parallelism value for the jc loop.
 			rntm_t rntm_l = *rntm;
 			bli_rntm_set_ways_only( jc_new, 1, ic_new, 1, 1, &rntm_l );
-			bli_l3_sup_thrinfo_update( &rntm_l, &thread );
+			bli_l3_sup_thrinfo_update( &rntm_l, thread );
 		}
 
 
@@ -315,7 +315,7 @@ err_t bli_gemmtsup_int
 			// new ways of parallelism value for the jc loop.
 			rntm_t rntm_l = *rntm;
 			bli_rntm_set_ways_only( jc_new, 1, ic_new, 1, 1, &rntm_l );
-			bli_l3_sup_thrinfo_update( &rntm_l, &thread );
+			bli_l3_sup_thrinfo_update( &rntm_l, thread );
 		}
 
 
@@ -385,7 +385,7 @@ err_t bli_gemmtsup_int
 			// new ways of parallelism value for the jc loop.
 			rntm_t rntm_l = *rntm;
 			bli_rntm_set_ways_only( jc_new, 1, ic_new, 1, 1, &rntm_l );
-			bli_l3_sup_thrinfo_update( &rntm_l, &thread );
+			bli_l3_sup_thrinfo_update( &rntm_l, thread );
 		}
 
 

--- a/frame/3/bli_l3_thrinfo.c
+++ b/frame/3/bli_l3_thrinfo.c
@@ -102,23 +102,16 @@ void bli_l3_thrinfo_grow
 
 // -----------------------------------------------------------------------------
 
-thrinfo_t* bli_l3_sup_thrinfo_create
+// Grow the thread control tree beneath an existing sup root node, splitting
+// the threads across the jc/pc/pb/ic/pa/jr/ir loops according to rntm. This
+// is the shared core of bli_l3_sup_thrinfo_create() and the re-factorization
+// performed by bli_l3_sup_thrinfo_update().
+static void bli_l3_sup_thrinfo_grow
      (
-             dim_t      id,
-             thrcomm_t* gl_comm,
-             pool_t*    sba_pool,
+             thrinfo_t* root,
        const rntm_t*    rntm
      )
 {
-	// Create the root thrinfo_t node.
-	thrinfo_t* root = bli_thrinfo_create_root
-	(
-	  gl_comm,
-	  id,
-	  sba_pool,
-	  bli_pba_query()
-	);
-
 	const dim_t n_way_jc = bli_rntm_ways_for( BLIS_NC, rntm );
 	const dim_t n_way_pc = bli_rntm_ways_for( BLIS_KC, rntm );
 	const dim_t n_way_ic = bli_rntm_ways_for( BLIS_MC, rntm );
@@ -140,28 +133,62 @@ thrinfo_t* bli_l3_sup_thrinfo_create
 	bli_thrinfo_set_sub_node( 0, thread_pa, thread_ic );
 	bli_thrinfo_set_sub_node( 0, thread_jr, thread_pa );
 	bli_thrinfo_set_sub_node( 0, thread_ir, thread_jr );
+}
+
+thrinfo_t* bli_l3_sup_thrinfo_create
+     (
+             dim_t      id,
+             thrcomm_t* gl_comm,
+             pool_t*    sba_pool,
+       const rntm_t*    rntm
+     )
+{
+	// Create the root thrinfo_t node.
+	thrinfo_t* root = bli_thrinfo_create_root
+	(
+	  gl_comm,
+	  id,
+	  sba_pool,
+	  bli_pba_query()
+	);
+
+	// Grow the thread control tree beneath the root.
+	bli_l3_sup_thrinfo_grow( root, rntm );
 
 	return root;
 }
 
 void bli_l3_sup_thrinfo_update
      (
-       const rntm_t*     rntm,
-             thrinfo_t** root
+       const rntm_t*    rntm,
+             thrinfo_t* root
      )
 {
-	thrcomm_t* gl_comm  = bli_thrinfo_comm( *root );
-	dim_t      tid      = bli_thrinfo_thread_id( *root );
-	pool_t*    sba_pool = bli_thrinfo_sba_pool( *root );
-	dim_t      nt       = bli_thrinfo_num_threads( *root );
+	dim_t nt = bli_thrinfo_num_threads( root );
 
 	// Return early in single-threaded execution
 	// since the thread control tree may not have been
 	// allocated normally
 	if ( nt == 1 ) return;
 
-	bli_thrinfo_free( *root );
-	*root = bli_l3_sup_thrinfo_create( tid, gl_comm, sba_pool, rntm );
+	// Re-factorize the thread control tree for the updated rntm. We must NOT
+	// free the root node here: the caller (bli_l3_sup_thread_decorator_entry)
+	// retains 'root' and uses it for the closing bli_thrinfo_barrier() and
+	// bli_thrinfo_free(). Freeing and re-creating the root left that caller's
+	// pointer dangling, causing a use-after-free (and subsequent double-free)
+	// of the root thrinfo_t. See issues #919 and #780. Instead, free only the
+	// subtree beneath the root and regrow it in place.
+	for ( dim_t i = 0; i < BLIS_MAX_SUB_NODES; ++i )
+	{
+		thrinfo_t* sub_node = bli_thrinfo_sub_node( i, root );
+		if ( sub_node != NULL )
+		{
+			bli_thrinfo_free( sub_node );
+			bli_thrinfo_set_sub_node( i, NULL, root );
+		}
+	}
+
+	bli_l3_sup_thrinfo_grow( root, rntm );
 }
 
 // -----------------------------------------------------------------------------

--- a/frame/3/bli_l3_thrinfo.h
+++ b/frame/3/bli_l3_thrinfo.h
@@ -96,8 +96,8 @@ thrinfo_t* bli_l3_sup_thrinfo_create
 
 void bli_l3_sup_thrinfo_update
      (
-       const rntm_t*     rntm,
-             thrinfo_t** root
+       const rntm_t*    rntm,
+             thrinfo_t* root
      );
 
 void bli_l3_thrinfo_print_gemm_paths


### PR DESCRIPTION
## Summary

`bli_l3_sup_thrinfo_update()` freed the **root** `thrinfo_t` node and returned a replacement through its `thrinfo_t**` out-parameter, updating only the local `thread` pointer inside `bli_gemmsup_int()` / `bli_gemmtsup_int()`. The caller `bli_l3_sup_thread_decorator_entry()` (`frame/3/bli_l3_sup_decor.c`) keeps its own copy of that pointer and uses it after the call for the closing `bli_thrinfo_barrier()` and `bli_thrinfo_free()`, so it reads and frees already-freed memory — a heap-use-after-free followed by a double-free of the root node.

Fixes #919 and resolves the long-standing testsuite crash in #780.

## Why it was hidden

BLIS's `sba`/`pba` pools recycle the freed block, so normal builds appear fine. It becomes observable when the pools are disabled (`./configure --disable-sba-pools`, exactly the configuration reported in #780) or under AddressSanitizer (`./configure --enable-asan`).

## Fix

Re-factorize the thread control tree **in place**: keep the root node (which the decorator still owns) and free + regrow only the subtree beneath it. The shared subtree construction is factored into a new `bli_l3_sup_thrinfo_grow()` helper, mirroring the existing `bli_l3_thrinfo_create()` / `bli_l3_thrinfo_grow()` split, so `create` and `update` no longer duplicate it. `bli_l3_sup_thrinfo_update()` now takes `thrinfo_t*` instead of `thrinfo_t**`.

## Credit / relation to #920

The diagnosis and the root-preserving strategy are due to @chillenb (#919, #920). This PR implements the same strategy but factors the duplicated subtree construction into a shared helper. It is offered as an alternative to #920 — happy to defer to whichever the maintainers prefer.

## Verification (Zen4, Ryzen 9 8940HX, Ubuntu 24.04)

**Before** — `./configure --enable-asan --disable-sba-pools --disable-pba-pools auto`, fast testsuite, `BLIS_NUM_THREADS=4`:

```
==ERROR: AddressSanitizer: heap-use-after-free   READ of size 8   thread T2
  #0 bli_l3_sup_thread_decorator_entry
freed by thread T2 here:
  #1 bli_l3_sup_thrinfo_update
SUMMARY: AddressSanitizer: heap-use-after-free in bli_l3_sup_thread_decorator_entry
```

**After** — same ASan + pools-disabled config: **0 ASan errors, all PASS, exits normally.**

**Shipping config** — `./configure auto` (pools enabled), `BLIS_NUM_THREADS=4`:
- `make checkblis-fast`: **2772 / 2772 PASS**
- `make checkblas`: **All BLAS tests passed!**

No numerical regression.
