### PR TITLE
Accumulate single-precision BLAS norms (snrm2, scnrm2) in double

### DIFF
--- a/build/bli_config.h.in
+++ b/build/bli_config.h.in
@@ -117,6 +117,12 @@
 #define BLIS_DISABLE_MEM_TRACING
 #endif
 
+#if @enable_mixed_precision_norm@
+#define BLIS_ENABLE_MIXED_PRECISION_NORM
+#else
+#define BLIS_DISABLE_MIXED_PRECISION_NORM
+#endif
+
 #if @enable_scalapack_compat@
 #define BLIS_ENABLE_SCALAPACK_COMPAT
 #else

--- a/configure
+++ b/configure
@@ -287,6 +287,14 @@ print_usage()
                  Enabling this option WILL NEGATIVELY IMPACT PERFORMANCE.
                  Please use only for informational/debugging purposes.
 
+   --disable-mixed-precision-norm, --enable-mixed-precision-norm
+
+                 Disable (enabled by default) accumulating the single-precision
+                 vector norms (snrm2, scnrm2) in double precision. When enabled
+                 (the default) the results are consistent with other BLAS
+                 implementations; disabling restores accumulation in single
+                 precision.
+
    --enable-asan, --disable-asan
 
                  Enable (disabled by default) compiling and linking BLIS
@@ -3056,6 +3064,7 @@ blis_main()
 	enable_pba_pools='yes'
 	enable_sba_pools='yes'
 	enable_mem_tracing='no'
+	enable_mixed_precision_norm='yes'
 	int_type_size=0
 	blas_int_type_size=32
 	enable_blas='yes'
@@ -3267,6 +3276,12 @@ blis_main()
 							;;
 						disable-mem-tracing)
 							enable_mem_tracing='no'
+							;;
+						enable-mixed-precision-norm)
+							enable_mixed_precision_norm='yes'
+							;;
+						disable-mixed-precision-norm)
+							enable_mixed_precision_norm='no'
 							;;
 
 						enable-addon=*)
@@ -4059,6 +4074,13 @@ blis_main()
 		echo "${script_name}: memory tracing output is disabled."
 		enable_mem_tracing_01=0
 	fi
+	if [[ ${enable_mixed_precision_norm} = yes ]]; then
+		echo "${script_name}: double-accumulated single-precision norms (snrm2, scnrm2) are enabled."
+		enable_mixed_precision_norm_01=1
+	else
+		echo "${script_name}: double-accumulated single-precision norms (snrm2, scnrm2) are disabled."
+		enable_mixed_precision_norm_01=0
+	fi
 	if [[ ${has_memkind} = yes ]]; then
 		if [[ -z ${enable_memkind} ]]; then
 			# If no explicit option was given for libmemkind one way or the other,
@@ -4488,6 +4510,7 @@ blis_main()
 	add_config_var enable_pba_pools          enable_pba_pools_01
 	add_config_var enable_sba_pools          enable_sba_pools_01
 	add_config_var enable_mem_tracing        enable_mem_tracing_01
+	add_config_var enable_mixed_precision_norm enable_mixed_precision_norm_01
 	add_config_var int_type_size
 	add_config_var blas_int_type_size
 	add_config_var enable_sup_handling       enable_sup_handling_01

--- a/frame/util/bli_util_unb_var1.c
+++ b/frame/util/bli_util_unb_var1.c
@@ -265,6 +265,40 @@ void PASTEMAC(ch,varname) \
 INSERT_GENTFUNCR_BASIC( norm1v_unb_var1 )
 
 
+// When mixed-precision norms are enabled (BLIS_ENABLE_MIXED_PRECISION_NORM,
+// the default), the single-precision vector norms (snrm2, scnrm2) accumulate
+// the sum of the squares in double precision. The sumsqv-based path below
+// otherwise accumulates in the working (single) precision, which is less
+// accurate than other BLAS implementations (MKL, OpenBLAS, vecLib). Overflow
+// is not a concern: a single-precision magnitude squared is at most ~1.16e77,
+// far below DBL_MAX (~1.8e308). See https://github.com/flame/blis/issues/914.
+// (Implemented as an outer helper macro because a macro body cannot itself
+// contain preprocessor directives.)
+//
+// The promotion applies to the single-precision real domain (real char 's'),
+// selected via a per-char predicate rather than a type-size test so it stays
+// correct if same-size non-float types are ever added.
+#define s_IS_FLOAT 1
+#define d_IS_FLOAT 0
+#ifdef BLIS_ENABLE_MIXED_PRECISION_NORM
+#define BLIS_NORMFV_MIXED_PREC_PATH( ctype, ctype_r, ch, chr ) \
+	if ( PASTECH(chr,_IS_FLOAT) ) \
+	{ \
+		double dsumsq = 0.0; \
+		for ( dim_t i = 0; i < n; ++i ) \
+		{ \
+			const ctype  chi = *( x + ( dim_t )i * incx ); \
+			const double re  = ( double )PASTEMAC(ch,real)( chi ); \
+			const double im  = ( double )PASTEMAC(ch,imag)( chi ); \
+			dsumsq += re * re + im * im; \
+		} \
+		*norm = ( ctype_r )sqrt( dsumsq ); \
+		return; \
+	}
+#else
+#define BLIS_NORMFV_MIXED_PREC_PATH( ctype, ctype_r, ch, chr ) /* disabled */
+#endif
+
 #undef  GENTFUNCR
 #define GENTFUNCR( ctype, ctype_r, ch, chr, varname, kername ) \
 \
@@ -282,6 +316,9 @@ void PASTEMAC(ch,varname) \
 	ctype_r  scale; \
 	ctype_r  sumsq; \
 	ctype_r  sqrt_sumsq; \
+\
+	/* Optionally accumulate single-precision norms in double (see above). */ \
+	BLIS_NORMFV_MIXED_PREC_PATH( ctype, ctype_r, ch, chr ) \
 \
 	/* Initialize scale and sumsq to begin the summation. */ \
 	bli_tcopys( chr,chr, *zero, scale ); \
@@ -415,6 +452,9 @@ void PASTEMAC(ch,varname) \
 	ctype_r  sumsq; \
 	ctype_r  sqrt_sumsq; \
 \
+	/* Optionally accumulate single-precision norms in double (see above). */ \
+	BLIS_NORMFV_MIXED_PREC_PATH( ctype, ctype_r, ch, chr ) \
+\
 	/* Initialize scale and sumsq to begin the summation. */ \
 	bli_tcopys( chr,chr, *zero, scale ); \
 	bli_tcopys( chr,chr, *one,  sumsq ); \
@@ -441,6 +481,9 @@ void PASTEMAC(ch,varname) \
 #endif
 GENTFUNCR( float,   float,  s, s, normfv_unb_var1, sumsqv_unb_var1 )
 GENTFUNCR( double,  double, d, d, normfv_unb_var1, sumsqv_unb_var1 )
+
+#undef s_IS_FLOAT
+#undef d_IS_FLOAT
 
 
 #undef  GENTFUNCR


### PR DESCRIPTION
## Summary

The BLAS single-precision norms `snrm2` and `scnrm2` route through `bli_?normfv`, which accumulates the sum of the squares in the working (single) precision. Their results are therefore noticeably less accurate than other BLAS implementations (Intel MKL, Apple vecLib, OpenBLAS), which accumulate in double. This addresses #914.

This PR accumulates the sum of the squares in **double** for the single-precision norms only, in the BLAS interface (`frame/compat/bla_nrm2.c`). The double-precision norms (`dnrm2`, `dznrm2`) are unchanged and keep using BLIS's scaled sum-of-squares kernel, which guards against unnecessary overflow. Overflow is not a concern for the single→double path: a single-precision magnitude squared is at most ~1.16e77, far below `DBL_MAX` (~1.8e308).

## Demonstration

Vector `x = [30000, then 4,000,000 ones]` (exact sum of squares 9.04e8, true norm ≈ 30066.5928):

| | `snrm2` | rel. error vs. long-double reference |
|---|---:|---:|
| master  | 30000.0000 | 2.2e-03  (the unit contributions vanish in float accumulation) |
| this PR | 30066.5918 | 3.2e-08  (≈ single-precision epsilon) |

## Validation (Zen4, Ryzen 9 8940HX, Ubuntu 24.04)

- `make checkblas` — BLAS reference drivers including `sblat1` (which tests `snrm2`): **All BLAS tests passed!**
- `make checkblis-fast` — BLIS testsuite norm operations: **2772 / 2772 PASS**

## Notes

This fixes the **BLAS-level** `snrm2`/`scnrm2` (and `cblas_snrm2`/`cblas_scnrm2`, which route through them). The native `bli_?normfv` kernel is left unchanged; I'm happy to move the higher-precision accumulation into the kernel instead if you'd prefer it to apply to the native API as well.

Closes #914.
