### PR TITLE
Strongly type ?setijv/?getijv/?setijm/?getijm (void* -> typed)

### DIFF
--- a/frame/base/bli_setgetijm.c
+++ b/frame/base/bli_setgetijm.c
@@ -42,7 +42,13 @@ typedef void (*setijm_fp)
        dim_t  j,
        void*  b, inc_t rs, inc_t cs
      );
-static setijm_fp GENARRAY(ftypes_setijm,setijm);
+static setijm_fp ftypes_setijm[BLIS_NUM_FP_TYPES] =
+{
+	( setijm_fp )bli_ssetijm,
+	( setijm_fp )bli_csetijm,
+	( setijm_fp )bli_dsetijm,
+	( setijm_fp )bli_zsetijm
+};
 
 err_t bli_setijm
      (
@@ -94,12 +100,10 @@ void PASTEMAC(ch,opname) \
        double ai, \
        dim_t  i, \
        dim_t  j, \
-       void*  b, inc_t rs, inc_t cs  \
+       ctype* b, inc_t rs, inc_t cs  \
      ) \
 { \
-	ctype* b_cast = ( ctype* )b; \
-\
-	ctype* b_ij = b_cast + (i  )*rs + (j  )*cs; \
+	ctype* b_ij = b + (i  )*rs + (j  )*cs; \
 \
 	bli_tsets( z,ch, ar, ai, *b_ij ); \
 }
@@ -116,7 +120,13 @@ typedef void (*getijm_fp)
              double* ar,
              double* ai
      );
-static getijm_fp GENARRAY(ftypes_getijm,getijm);
+static getijm_fp ftypes_getijm[BLIS_NUM_FP_TYPES] =
+{
+	( getijm_fp )bli_sgetijm,
+	( getijm_fp )bli_cgetijm,
+	( getijm_fp )bli_dgetijm,
+	( getijm_fp )bli_zgetijm
+};
 
 err_t bli_getijm
       (
@@ -166,14 +176,12 @@ void PASTEMAC(ch,opname) \
      ( \
              dim_t   i, \
              dim_t   j, \
-       const void*   b, inc_t rs, inc_t cs, \
+       const ctype*  b, inc_t rs, inc_t cs, \
              double* ar, \
              double* ai  \
      ) \
 { \
-	const ctype* b_cast = ( const ctype* )b; \
-\
-	const ctype* b_ij = b_cast + (i  )*rs + (j  )*cs; \
+	const ctype* b_ij = b + (i  )*rs + (j  )*cs; \
 \
 	bli_tgets( ch,z, *b_ij, *ar, *ai ); \
 }

--- a/frame/base/bli_setgetijm.h
+++ b/frame/base/bli_setgetijm.h
@@ -50,7 +50,7 @@ BLIS_EXPORT_BLIS void PASTEMAC(ch,opname) \
        double ai, \
        dim_t  i, \
        dim_t  j, \
-       void*  b, inc_t rs, inc_t cs  \
+       ctype* b, inc_t rs, inc_t cs  \
      );
 
 INSERT_GENTPROT_BASIC( setijm )
@@ -73,7 +73,7 @@ BLIS_EXPORT_BLIS void PASTEMAC(ch,opname) \
      ( \
              dim_t   i, \
              dim_t   j, \
-       const void*   b, inc_t rs, inc_t cs, \
+       const ctype*  b, inc_t rs, inc_t cs, \
              double* ar, \
              double* ai  \
      );

--- a/frame/base/bli_setgetijv.c
+++ b/frame/base/bli_setgetijv.c
@@ -41,7 +41,13 @@ typedef void (*setijv_fp)
        dim_t  i,
        void*  x, inc_t incx
      );
-static setijv_fp GENARRAY(ftypes_setijv,setijv);
+static setijv_fp ftypes_setijv[BLIS_NUM_FP_TYPES] =
+{
+	( setijv_fp )bli_ssetijv,
+	( setijv_fp )bli_csetijv,
+	( setijv_fp )bli_dsetijv,
+	( setijv_fp )bli_zsetijv
+};
 
 err_t bli_setijv
      (
@@ -87,12 +93,10 @@ void PASTEMAC(ch,opname) \
        double ar, \
        double ai, \
        dim_t  i, \
-       void*  x, inc_t incx  \
+       ctype* x, inc_t incx  \
      ) \
 { \
-	ctype* restrict x_cast = ( ctype* )x; \
-\
-	ctype* restrict x_i = x_cast + (i  )*incx; \
+	ctype* restrict x_i = x + (i  )*incx; \
 \
 	bli_tsets( z,ch, ar, ai, *x_i ); \
 }
@@ -108,7 +112,13 @@ typedef void (*getijv_fp)
              double* ar,
              double* ai
      );
-static getijv_fp GENARRAY(ftypes_getijv,getijv);
+static getijv_fp ftypes_getijv[BLIS_NUM_FP_TYPES] =
+{
+	( getijv_fp )bli_sgetijv,
+	( getijv_fp )bli_cgetijv,
+	( getijv_fp )bli_dgetijv,
+	( getijv_fp )bli_zgetijv
+};
 
 err_t bli_getijv
       (
@@ -152,14 +162,12 @@ err_t bli_getijv
 void PASTEMAC(ch,opname) \
      ( \
              dim_t   i, \
-       const void*   x, inc_t incx, \
+       const ctype*  x, inc_t incx, \
              double* ar, \
              double* ai  \
      ) \
 { \
-	const ctype* restrict x_cast = ( const ctype* )x; \
-\
-	const ctype* restrict x_i = x_cast + (i  )*incx; \
+	const ctype* restrict x_i = x + (i  )*incx; \
 \
 	bli_tgets( ch,z, *x_i, *ar, *ai ); \
 }

--- a/frame/base/bli_setgetijv.h
+++ b/frame/base/bli_setgetijv.h
@@ -48,7 +48,7 @@ BLIS_EXPORT_BLIS void PASTEMAC(ch,opname) \
        double ar, \
        double ai, \
        dim_t  i, \
-       void*  x, inc_t incx  \
+       ctype* x, inc_t incx  \
      );
 
 INSERT_GENTPROT_BASIC( setijv )
@@ -69,7 +69,7 @@ BLIS_EXPORT_BLIS err_t bli_getijv
 BLIS_EXPORT_BLIS void PASTEMAC(ch,opname) \
      ( \
              dim_t   i, \
-       const void*   b, inc_t incx, \
+       const ctype*  b, inc_t incx, \
              double* ar, \
              double* ai  \
      );


### PR DESCRIPTION
## Summary

`bli_?setijv` / `bli_?getijv` and the matrix variants `bli_?setijm` / `bli_?getijm` declared their element pointer as `void*`. As noted in #831, that's unhelpful for users generating typed bindings (e.g. the Fortran/C++ interfaces in the issue) from the public prototypes, and inconsistent with the rest of BLIS's typed API.

This changes the public element pointer from `void*` to the strongly typed `ctype*` (`float*` / `double*` / `scomplex*` / `dcomplex*`) in both the prototypes (`frame/base/bli_setgetij{v,m}.h`) and the definitions (`.c`). For example:

```c
// before
void bli_ssetijv( double ar, double ai, dim_t i, void*  x, inc_t incx );
// after
void bli_ssetijv( double ar, double ai, dim_t i, float* x, inc_t incx );
```

The object-API entry points (`bli_setijv`, `bli_getijv`, `bli_setijm`, `bli_getijm`) still erase the type to dispatch through their function-pointer arrays. Those arrays previously used `GENARRAY`; they now list the typed functions with an explicit cast to the array's (`void*`-buffer) dispatch signature. Behavior is unchanged.

## Scope / open question

This covers the `?setijv`/`?getijv`/`?setijm`/`?getijm` family from the issue. @ivan-pi also listed `void*` in `??copysc`, `??cast[m|v]`, `??castnzm`, `?fprint[m|v]`, `?print[m|v]` — happy to follow up on those in a separate PR.

One design point for your call: the dispatch arrays cast typed function pointers to the common `void*`-buffer signature (the buffer is passed as a `void*` of identical representation). If you'd rather avoid the function-pointer cast, I can instead keep internal `void*` shims and add typed public wrappers — let me know which you prefer.

## Validation (Zen4, Ubuntu 24.04)

- Builds clean — **0 new warnings**.
- Public prototypes now typed (via `gcc -E`): `void bli_ssetijv ( double ar, double ai, dim_t i, float* x, inc_t incx )`, `void bli_dsetijm ( ..., double* b, ... )`.
- Functional test (typed `bli_ssetijv`/`bli_sgetijv`, typed `bli_dsetijm`/`bli_dgetijm`, and the object-API `bli_setijv`/`bli_getijv`) — all correct.
- `make checkblis-fast`: **2772 / 2772 PASS**.

Fixes (partially) #831 (for the setget-ij family).
