### PR TITLE
Prototype: weighted-static partitioning for heterogeneous cores

### DIFF
--- a/frame/thread/bli_thread_range.c
+++ b/frame/thread/bli_thread_range.c
@@ -763,6 +763,118 @@ siz_t bli_thread_range_ndim
 
 // -----------------------------------------------------------------------------
 
+#ifdef BLIS_ENABLE_HETERO_SCHED
+
+#include <string.h>   // strcmp()
+
+// Heterogeneous (weighted-static) work partitioning. On GB10 the 10 Cortex-X925
+// performance cores are ~3.6x faster than the 10 Cortex-A725 efficiency cores;
+// an equal static split makes the fast cores idle at every barrier waiting for
+// the slow ones. Instead we hand each thread a share of the loop proportional
+// to its core's throughput, so all threads finish each phase together.
+//
+// PROTOTYPE scope: assumes the group's BLIS work_id equals the logical CPU it
+// runs on -- true for the pinned all-20 case (taskset -c 0-19, OMP_PROC_BIND=
+// close, 1D IC parallelism). Activated only when BLIS_HETERO_WEIGHT (> 1) is
+// set. A production version would derive per-work_id weights from sched_getcpu()
+// gathered through the thread communicator, so it holds for any factorization.
+
+// GB10 Cortex-X925 logical CPUs (== work_id under the pinned all-20 layout).
+static bool bli_hetero_is_x925( dim_t id )
+{
+	return ( id >= 5 && id <= 9 ) || ( id >= 15 && id <= 19 );
+}
+
+// The X925:A725 work weight. This path is used only by level-3 ops (GEMM and
+// friends), which have data reuse, and there the perf-optimal weight is
+// ~constant across shapes -- NOT the arithmetic-intensity-scaled value one
+// might expect. Although the *solo* per-cluster throughput ratio falls from
+// ~3.6 (compute-bound) toward ~2.7 for memory-bound rank-k, the optimal weight
+// for CONCURRENT execution stays ~3.6 at every shape measured (a flat 3.6 beats
+// an AI-scaled weight even at m=n=8192, k=4). The reason: X925's larger caches
+// and 6 FP pipes convert the *shared* memory bandwidth into useful work more
+// efficiently, so loading it heavily wins even when the shape looks memory-
+// bound. Reuse -- not single-pass AI -- is what matters.
+//
+// Streaming level-1/2 ops (gemv, axpy, dot, ...) are the opposite case: no
+// reuse, pure DRAM bandwidth, X925:A725 per-core ratio ~1.0-1.1 (measured). For
+// them the correct weight is ~1, i.e. plain equal partitioning -- which is
+// exactly what they already use (their OpenMP splits don't call this function).
+//
+// The weight is per datatype: the X925:A725 compute-throughput ratio is ~4.0
+// (the FMA-peak ratio: 6 pipes x 3.9 GHz vs 2 pipes x 2.8 GHz), but the
+// perf-optimal weight is adjusted by each datatype's achieved efficiency and
+// was measured on GB10 (all-20 GEMM, weight sweep):
+//   s 4.2   d 3.6   c 4.0   z 4.4   (c/z use reference micro-kernels here)
+//
+// Control via the env var BLIS_HETERO_WEIGHT (also the enable switch):
+//   unset or <= 1  -> disabled (equal static split);
+//   "auto"         -> the per-datatype weights above;
+//   a number > 1   -> that fixed weight for all datatypes (for experiments).
+static double bli_hetero_weight( num_t dt )
+{
+	static double mode = -3.0;   // -3 uninit, -1 disabled, -2 auto, >1 fixed
+	if ( mode < -2.5 )
+	{
+		const char* e = getenv( "BLIS_HETERO_WEIGHT" );
+		if      ( e == NULL )                mode = -1.0;
+		else if ( strcmp( e, "auto" ) == 0 ) mode = -2.0;
+		else { const double v = atof( e ); mode = ( v > 1.0 ) ? v : -1.0; }
+	}
+	if ( mode == -1.0 ) return 1.0;    // disabled -> equal split
+	if ( mode  >  1.0 ) return mode;   // fixed override for all datatypes
+
+	switch ( dt )                      // mode == -2.0: per-datatype defaults
+	{
+		case BLIS_FLOAT:    return 4.2;
+		case BLIS_DOUBLE:   return 3.6;
+		case BLIS_SCOMPLEX: return 4.0;
+		case BLIS_DCOMPLEX: return 4.4;
+		default:            return 3.6;
+	}
+}
+
+// Weighted analogue of bli_thread_range_sub for the forward, dense case: split
+// [0,n) into n_way bf-aligned partitions with widths proportional to each
+// work_id's core weight. Exact tiling: partition k's end = round(cumw(k)/total
+// * n_bf)*bf, so partitions abut and the last one absorbs the bf remainder.
+static void bli_thread_range_hetero_sub
+     (
+       dim_t  work_id,
+       dim_t  n_way,
+       dim_t  n,
+       dim_t  bf,
+       double xw,
+       dim_t* start,
+       dim_t* end
+     )
+{
+	const dim_t n_bf = n / bf;
+	const dim_t rem  = n % bf;
+
+	double total = 0.0;
+	for ( dim_t j = 0; j < n_way; ++j )
+		total += bli_hetero_is_x925( j ) ? xw : 1.0;
+
+	// Cumulative weight up to (but not including) partition k.
+	double cum = 0.0;
+	dim_t  s_bf = 0;
+	for ( dim_t k = 0; k <= work_id; ++k )
+	{
+		if ( k == work_id ) s_bf = ( dim_t )( cum / total * n_bf + 0.5 );
+		cum += bli_hetero_is_x925( k ) ? xw : 1.0;
+	}
+	const dim_t e_bf = ( dim_t )( cum / total * n_bf + 0.5 );
+
+	*start = s_bf * bf;
+	*end   = e_bf * bf;
+
+	// The highest-indexed partition absorbs the sub-bf edge remainder.
+	if ( work_id == n_way - 1 ) *end = n; ( void )rem;
+}
+
+#endif // BLIS_ENABLE_HETERO_SCHED
+
 siz_t bli_thread_range
      (
        const thrinfo_t* thr,
@@ -808,10 +920,24 @@ siz_t bli_thread_range
 	}
 	else // if unweighted, dense, or zeros
 	{
+		const dim_t work_id = bli_thrinfo_work_id( thr );
+		const dim_t n_way   = bli_thrinfo_n_way( thr );
+
+#ifdef BLIS_ENABLE_HETERO_SCHED
+		// Weighted-static split across heterogeneous cores (forward only), when
+		// enabled and the loop is actually parallel. Weight is per datatype.
+		const double xw = bli_hetero_weight( bli_obj_dt( a ) );
+		if ( xw > 1.0 && n_way > 1 && !handle_edge_low )
+		{
+			bli_thread_range_hetero_sub( work_id, n_way, n, bf, xw, start, end );
+			return m * ( *end - *start );
+		}
+#endif
+
 		bli_thread_range_sub
 		(
-		  bli_thrinfo_work_id( thr ),
-		  bli_thrinfo_n_way( thr ),
+		  work_id,
+		  n_way,
 		  n,
 		  bf,
 		  handle_edge_low,


### PR DESCRIPTION
On a heterogeneous machine (e.g. NVIDIA GB10's Cortex-X925 + Cortex-A725 clusters) a single level-3 op loses much of its throughput to barrier sync: the equal static loop split gives every thread the same work, so the fast cores idle at each pack/compute barrier waiting for the slow ones (all-20 DGEMM: ~380 vs ~890 GFLOP/s). This partitions the dense forward loop range in proportion to each thread's core throughput instead of equally, so all threads finish each phase together.

Hooked into the unweighted branch of bli_thread_range() (where trsm/syrk's triangular weighting already lives). The weight is per datatype (measured X925:A725 GEMM optima: s 4.2 d 3.6 c 4.0 z 4.4). Compile-gated by BLIS_ENABLE_HETERO_SCHED; runtime-gated by env BLIS_HETERO_WEIGHT ("auto" = per-datatype table, a number = fixed weight, unset = disabled), so default builds are unchanged. Measured ~2.2-2.5x over the equal split across s/d/c/z; GEMM stays bit-correct (the split only chooses which rows a thread owns).

PROTOTYPE limitations: assumes the loop work_id equals the logical CPU it runs on (holds for a pinned 1D-IC layout) and hardcodes the GB10 X925 CPU set. A production version should derive per-work_id core identity from sched_getcpu() gathered through the thread communicator, so it holds for any factorization and pinning.