### PR TITLE
Add optional all-dims-small (AND) rule for SUP threshold

### DIFF
--- a/frame/base/bli_cntx.h
+++ b/frame/base/bli_cntx.h
@@ -185,11 +185,23 @@ BLIS_INLINE bool bli_cntx_get_ukr_prefs_dt( num_t dt, kerid_t ukr_id, const cntx
 
 BLIS_INLINE bool bli_cntx_l3_sup_thresh_is_met( num_t dt, dim_t m, dim_t n, dim_t k, const cntx_t* cntx )
 {
+#ifdef BLIS_SUP_THRESH_ALL
+	// Take the SUP (skinny/unpacked) path only when *every* dimension is below
+	// its threshold, i.e. the matrix is small in all three dims. Shapes that
+	// are skinny in one dimension but large in another (rank-k updates, tall
+	// panels) are then handled by the packed native path, which is markedly
+	// faster for them on GB10 (measured: 4000x4000x64 native 677 vs SUP 474
+	// GFLOP/s). The default OR-semantics below would misroute those to SUP.
+	return ( m < bli_cntx_get_blksz_def_dt( dt, BLIS_MT, cntx ) &&
+	         n < bli_cntx_get_blksz_def_dt( dt, BLIS_NT, cntx ) &&
+	         k < bli_cntx_get_blksz_def_dt( dt, BLIS_KT, cntx ) );
+#else
 	if ( m < bli_cntx_get_blksz_def_dt( dt, BLIS_MT, cntx ) ) return TRUE;
 	if ( n < bli_cntx_get_blksz_def_dt( dt, BLIS_NT, cntx ) ) return TRUE;
 	if ( k < bli_cntx_get_blksz_def_dt( dt, BLIS_KT, cntx ) ) return TRUE;
 
 	return FALSE;
+#endif
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
BLIS's default SUP threshold rule routes to the skinny/unpacked path when ANY dimension is below its threshold (m<MT || n<NT || k<KT). That sends rank-k updates and tall/wide panels -- skinny in one dimension but large in another -- to SUP, where they run far slower than the packed native path (e.g. 4000x4000x64: SUP 474 vs native 683 GFLOP/s on GB10).

Add a config-gated ALL-dims variant (BLIS_SUP_THRESH_ALL) of bli_cntx_l3_sup_thresh_is_met: take SUP only when m, n AND k are all below threshold, i.e. genuinely small matrices. A lone small dimension no longer forces SUP; small squares (which do want SUP) are unaffected. Opt-in; default OR behavior preserved when the macro is undefined.